### PR TITLE
Refine CLI interface to use 'uv run training'

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,27 @@ All commands should be run from the `/train` directory:
 # Start a continuous live training loop with gradient accumulation
 uv run python scheduler.py live
 
+# Single training cycle from live cameras (captures all webcams and trains once)
+uv run python scheduler.py once
+
 # Single capture of all webcams and METAR data to /data (git-ignored)
 uv run python collector.py collect
 
 # Batch train on a local folder with /images and /metar subfolders
 uv run python scheduler.py batch --folder /path/to/data
 
-# Manage background training service via launchctl
+# Manage background training service via launchctl (periodic execution of 'once')
 uv run python scheduler.py schedule   # Install and load
 uv run python scheduler.py unschedule # Unload and remove
 ```
+
+### Command Details
+- **live**: Runs a continuous loop. It uses **gradient accumulation** in-memory to perform a training step after a configurable number of captures.
+- **once**: Performs a single capture of configured webcams and METAR data, runs a single training step on that batch, and then exits.
+- **batch**: Accepts a folder with `/images` and `/metar` subfolders and trains on all valid pairs.
+- **collect**: Performs a single capture of all configured webcams and fetches METAR, saving them to a datestamped folder in `/data`.
+- **schedule**: Installs and loads a `launchctl` service that wakes up the system periodically (configured via `schedule_seconds`) to run the `once` command.
+- **unschedule**: Unloads and removes the `launchctl` service.
 
 ## Technical Strategy
 - **Backbone:** `convnext_tiny` via `timm`.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,56 @@
 # is-the-mountain-out
-Determine if "the mountain" (Mount Rainier) is "out" using iterative LoRA training on live webcam streams, optimized for Apple Silicon.
+Determine if Mount Rainier is "out" (visible) using real-time image classification with iterative LoRA training on live webcam streams, optimized for Apple Silicon (MPS).
 
-## Design
-This project implements a real-time image classification system that fine-tunes a `convnext_tiny` model using Parameter-Efficient Fine-Tuning (PEFT) with LoRA. The training occurs iteratively as frames are captured from webcams, with a strict constraint of zero disk usage for image data.
+## Overview
+This system performs online learning using Parameter-Efficient Fine-Tuning (PEFT) with LoRA on a `convnext_tiny` vision backbone. It integrates METAR weather data as a secondary input to the classification head, improving the model's accuracy by incorporating real-world visibility and ceiling data.
 
-### Technical Strategy
-- **Hardware Acceleration:** Fully optimized for Mac M1/M2/M3 using Metal Performance Shaders (MPS).
-- **Online Learning:** Iterative LoRA training using live webcam captures converted directly to PyTorch tensors.
-- **Data Pipeline:** `OpenCV` for stream capture, `torchvision` for on-device transformations.
-- **Model:** `timm` provided `convnext_tiny` wrapped with `peft` LoRA.
-- **Scheduling:** `APScheduler` with crontab-style triggers defined in `config.toml`.
-- **Optimizations:** Incorporation of time-of-day and METAR weather data to refine predictions (e.g., visibility thresholds).
+## Features
+- **Hardware-Accelerated Training:** Fully optimized for Mac M1/M2/M3 using Metal Performance Shaders (MPS).
+- **Online Learning:** Iterative LoRA training using live webcam captures converted directly to PyTorch tensors with **zero disk usage** for training data.
+- **Dual-Input Architecture:** Classification head accepts both image features (768) and a 2D METAR weather vector (visibility, ceiling).
+- **Flexible Data Collection:** `collect` command for capturing datestamped datasets for offline batch training.
+- **Periodic Training:** `launchctl` service management for continuous background training.
+- **Batch Processing:** Support for training on local datasets with `/images` and `/metar` subfolders.
 
 ## Usage
-To start the iterative training loop on Apple Silicon:
-1. Ensure `uv` is installed.
-2. Configure `mountain.toml` in the root directory.
-3. Configure `train/config.toml` with your schedule and model settings.
-4. Run the training command:
-   ```bash
-   # Single cycle from live cameras
-   cd train && uv run python scheduler.py live
+### Prerequisites
+- [uv](https://github.com/astral-sh/uv) installed.
+- Mac with Apple Silicon (for MPS acceleration).
 
-   # Batch train on local folder with /images and /metar
-   cd train && uv run python scheduler.py batch --folder /path/to/data
-
-   # Continuous training via launchctl
-   cd train && uv run python scheduler.py schedule
-
-   # Single collection of all sources to /data
-   cd train && uv run collect
-   ```
+### Setup
+1. Configure `mountain.toml` in the root directory for target mountain details and webcams.
+2. Configure `train/config.toml` for model settings, schedule, and collection intervals.
 
 ### Commands
-- **live**: Runs a continuous loop capturing webcam images and METAR data. It uses **gradient accumulation** to perform a training step after a configurable number of captures (defaulting to 5 minutes between captures).
-- **batch**: Accepts a folder with `/images` and `/metar` subfolders and trains on all valid pairs.
-- **collect**: Performs a single capture of all configured webcams and fetches METAR, saving them to a datestamped folder in `/data`.
-- **schedule**: Installs and loads a `launchctl` service to run the `live` command periodically.
-- **unschedule**: Unloads and removes the `launchctl` service.
+All commands should be run from the `/train` directory:
+```bash
+# Start a continuous live training loop with gradient accumulation
+uv run python scheduler.py live
 
-## Design
-This project implements a real-time image classification system that fine-tunes a `convnext_tiny` model using Parameter-Efficient Fine-Tuning (PEFT) with LoRA. The training occurs iteratively as frames are captured from multiple webcams and processed in small batches.
+# Single capture of all webcams and METAR data to /data (git-ignored)
+uv run python collector.py collect
 
-### Technical Strategy
-- **Hardware Acceleration:** Fully optimized for Mac M1/M2/M3 using Metal Performance Shaders (MPS).
-- **Online Learning:** Iterative LoRA training using live webcam captures converted directly to PyTorch tensors.
-- **Batch Processing:** Captures are collected from all sources and trained in small batches for improved efficiency.
-- **Dual-Input Head:** The classification head accepts both image features and a 2D METAR weather vector (visibility and ceiling) to refine predictions.
-- **Data Pipeline:** `OpenCV` for stream capture, `torchvision` for on-device transformations.
-- **Scheduling:** `APScheduler` with crontab-style triggers defined in `config.toml`.
+# Batch train on a local folder with /images and /metar subfolders
+uv run python scheduler.py batch --folder /path/to/data
+
+# Manage background training service via launchctl
+uv run python scheduler.py schedule   # Install and load
+uv run python scheduler.py unschedule # Unload and remove
+```
+
+## Technical Strategy
+- **Backbone:** `convnext_tiny` via `timm`.
+- **PEFT:** LoRA layers targeting the `fc1` and `fc2` Linear layers in the MLP blocks.
+- **Weather Input:** Real-time METAR data from NOAA (e.g., KSEA) normalized and concatenated with image features.
+- **Optimizer:** `Adam` with a single-batch or accumulated-batch training cycle.
+- **Zero-Disk Training:** Live frames from `OpenCV` are moved directly to MPS tensors, avoiding overhead and privacy concerns related to storing temporary image files during the live loop.
+
+## Project Structure
+- `mountain.toml`: Target-specific configuration (coordinates, height, webcam links).
+- `train/config.toml`: General training and scheduling configuration.
+- `train/scheduler.py`: Main CLI and training loop orchestration.
+- `train/collector.py`: Data collection utility.
+- `train/utils.py`: Shared hardware-accelerated capture and weather fetching logic.
+- `train/model.py`: Dual-input LoRA model implementation.
+- `train/config_loader.py`: Unified TOML configuration loader.
+- `data/`: Local storage for `collect` outputs (ignored by git).

--- a/README.md
+++ b/README.md
@@ -25,20 +25,20 @@ This system performs online learning using Parameter-Efficient Fine-Tuning (PEFT
 All commands should be run from the `/train` directory:
 ```bash
 # Start a continuous live training loop with gradient accumulation
-uv run python scheduler.py live
+uv run training live
 
 # Single training cycle from live cameras (captures all webcams and trains once)
-uv run python scheduler.py once
+uv run training once
 
 # Single capture of all webcams and METAR data to /data (git-ignored)
-uv run python collector.py collect
+uv run collect
 
 # Batch train on a local folder with /images and /metar subfolders
-uv run python scheduler.py batch --folder /path/to/data
+uv run training batch --folder /path/to/data
 
 # Manage background training service via launchctl (periodic execution of 'once')
-uv run python scheduler.py schedule   # Install and load
-uv run python scheduler.py unschedule # Unload and remove
+uv run training schedule   # Install and load
+uv run training unschedule # Unload and remove
 ```
 
 ### Command Details

--- a/train/pyproject.toml
+++ b/train/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 training = "scheduler:app"
 collect = "collector:app"
 
+[tool.setuptools]
+py-modules = ["config_loader", "collector", "model", "utils", "scheduler", "main"]
+
 [tool.pytest.ini_options]
 pythonpath = ["."]
 

--- a/train/pyproject.toml
+++ b/train/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 training = "scheduler:app"
 collect = "collector:app"
 
+[tool.pytest.ini_options]
+pythonpath = ["."]
+
 [dependency-groups]
 dev = [
     "tomli-w>=1.2.0",

--- a/train/scheduler.py
+++ b/train/scheduler.py
@@ -213,8 +213,7 @@ def schedule(config: str = "config.toml", mountain: str = "../mountain.toml"):
     <array>
         <string>{executable}</string>
         <string>run</string>
-        <string>python</string>
-        <string>{current_dir / "scheduler.py"}</string>
+        <string>training</string>
         <string>once</string>
         <string>--config</string>
         <string>{current_dir / config}</string>

--- a/train/scheduler.py
+++ b/train/scheduler.py
@@ -30,9 +30,45 @@ class Trainer:
         self.optimizer = optim.Adam(self.model_wrapper.model.parameters(), lr=0.001)
         self.weather_fetcher = WeatherFetcher(self.config_loader.metar_station)
 
+    def run_single_cycle(self, label: int = 1):
+        """
+        Performs a single capture cycle from all sources and a training step.
+        Used for single-shot execution (e.g., via launchctl StartInterval).
+        """
+        print(f"[{datetime.now()}] Starting single training cycle...")
+        weather_vector = self.weather_fetcher.get_weather_vector()
+        
+        image_list = []
+        weather_list = []
+        label_list = []
+        
+        for source in self.config_loader.webcam_sources:
+            stream = WebcamStream(source, device=self.device)
+            try:
+                tensor = stream.capture_to_tensor()
+                if tensor is not None:
+                    image_list.append(tensor.squeeze(0))
+                    weather_list.append(weather_vector)
+                    label_list.append(torch.tensor(label))
+                    print(f"  Source {source}: Captured.")
+                else:
+                    print(f"  Source {source}: Capture failed.")
+            finally:
+                stream.release()
+        
+        if image_list:
+            image_batch = torch.stack(image_list)
+            weather_batch = torch.stack(weather_list)
+            label_batch = torch.stack(label_list)
+            
+            loss = self.model_wrapper.train_step(image_batch, weather_batch, label_batch, self.optimizer)
+            print(f"[{datetime.now()}] Cycle Complete: Loss = {loss:.4f}")
+        else:
+            print(f"[{datetime.now()}] Cycle skipped: No frames captured.")
+
     def live_training_loop(self, label: int = 1):
         """
-        Continuously captures frames and performs batch training using gradient accumulation logic.
+        Continuously captures frames and performs batch training using gradient accumulation.
         """
         print(f"[{datetime.now()}] Starting continuous live training loop...")
         
@@ -42,7 +78,6 @@ class Trainer:
         
         try:
             while True:
-                print(f"[{datetime.now()}] Capture cycle started...")
                 weather_vector = self.weather_fetcher.get_weather_vector()
                 
                 cycle_captured = False
@@ -65,22 +100,24 @@ class Trainer:
                     print(f"  Accumulation step {current_accum}/{self.config_loader.gradient_accumulation_steps}")
                     
                     if current_accum >= self.config_loader.gradient_accumulation_steps:
-                        # Perform training step
                         image_batch = torch.stack(image_list)
                         weather_batch = torch.stack(weather_list)
                         label_batch = torch.stack(label_list)
                         
                         loss = self.model_wrapper.train_step(image_batch, weather_batch, label_batch, self.optimizer)
-                        print(f"[{datetime.now()}] Batch Training Step Complete: Loss = {loss:.4f}")
-                        
-                        # Reset accumulators
+                        print(f"[{datetime.now()}] Batch Training Complete: Loss = {loss:.4f}")
                         image_list, weather_list, label_list = [], [], []
                 
-                # Wait for next interval
                 time.sleep(self.config_loader.capture_interval_seconds)
                 
         except (KeyboardInterrupt, SystemExit):
             print("\nExiting live training loop.")
+
+@app.command()
+def once(config: str = "config.toml", mountain: str = "../mountain.toml"):
+    """Performs a single capture and training cycle and then exits."""
+    trainer = Trainer(config, mountain)
+    trainer.run_single_cycle()
 
 @app.command()
 def live(config: str = "config.toml", mountain: str = "../mountain.toml"):
@@ -90,7 +127,7 @@ def live(config: str = "config.toml", mountain: str = "../mountain.toml"):
 
 @app.command()
 def batch(folder: str, label: int = 1, config: str = "config.toml", mountain: str = "../mountain.toml"):
-    """Runs the training loop on all valid inputs in a folder with /images and /metar subfolders."""
+    """Runs training on a folder with /images and /metar subfolders."""
     trainer = Trainer(config, mountain)
     
     image_dir = Path(folder) / "images"
@@ -101,10 +138,7 @@ def batch(folder: str, label: int = 1, config: str = "config.toml", mountain: st
         raise typer.Exit(code=1)
         
     image_files = sorted(image_dir.glob("*.jpg"))
-    
-    image_list = []
-    weather_list = []
-    label_list = []
+    image_list, weather_list, label_list = [], [], []
     
     import cv2
     from torchvision import transforms
@@ -160,17 +194,15 @@ def batch(folder: str, label: int = 1, config: str = "config.toml", mountain: st
 
 @app.command()
 def schedule(config: str = "config.toml", mountain: str = "../mountain.toml"):
-    """Installs the launchctl service for continuous training."""
+    """Installs the launchctl service for periodic training."""
     trainer = Trainer(config, mountain)
     config_loader = trainer.config_loader
     
-    # Path setup
     current_dir = Path.cwd().absolute()
     executable = subprocess.check_output(["which", "uv"], text=True).strip()
     plist_name = "com.mountain.trainer.plist"
     plist_path = Path.home() / "Library" / "LaunchAgents" / plist_name
     
-    # Generate Plist content
     plist_content = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -183,7 +215,7 @@ def schedule(config: str = "config.toml", mountain: str = "../mountain.toml"):
         <string>run</string>
         <string>python</string>
         <string>{current_dir / "scheduler.py"}</string>
-        <string>live</string>
+        <string>once</string>
         <string>--config</string>
         <string>{current_dir / config}</string>
         <string>--mountain</string>
@@ -204,25 +236,22 @@ def schedule(config: str = "config.toml", mountain: str = "../mountain.toml"):
     with open(plist_path, "w") as f:
         f.write(plist_content)
         
-    # Load the service
     subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
     subprocess.run(["launchctl", "load", str(plist_path)])
     
     print(f"Service installed and loaded at {plist_path}")
-    print(f"Running every {config_loader.schedule_seconds} seconds.")
+    print(f"Running once every {config_loader.schedule_seconds} seconds.")
 
 @app.command()
 def unschedule():
     """Unloads and removes the launchctl service."""
-    plist_name = "com.mountain.trainer.plist"
-    plist_path = Path.home() / "Library" / "LaunchAgents" / plist_name
-    
+    plist_path = Path.home() / "Library" / "LaunchAgents" / "com.mountain.trainer.plist"
     if plist_path.exists():
         subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
         plist_path.unlink()
-        print(f"Service unloaded and removed from {plist_path}")
+        print(f"Service removed from {plist_path}")
     else:
-        print("Service plist not found. Nothing to remove.")
+        print("Service not found.")
 
 if __name__ == "__main__":
     app()

--- a/train/tests/test_scheduler.py
+++ b/train/tests/test_scheduler.py
@@ -3,7 +3,6 @@ import torch
 import torch.optim as optim
 from unittest.mock import MagicMock, patch
 from scheduler import Trainer
-from utils import WebcamStream, WeatherFetcher
 
 @patch('scheduler.ConfigLoader')
 @patch('scheduler.ConvNextLoRAModel')
@@ -15,7 +14,6 @@ def test_trainer_initialization(mock_weather, mock_model_cls, mock_config):
         'rank': 8, 'alpha': 16, 'target_modules': ['fc1']
     }
     
-    # Mock model parameters
     mock_model = MagicMock()
     mock_model.model.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
     mock_model_cls.return_value = mock_model
@@ -27,7 +25,46 @@ def test_trainer_initialization(mock_weather, mock_model_cls, mock_config):
 
 @patch('scheduler.WebcamStream')
 @patch('scheduler.WeatherFetcher')
-@patch('time.sleep', side_effect=InterruptedError) # To break the loop after one cycle
+def test_run_single_cycle_execution(mock_weather_cls, mock_webcam):
+    """Verify that run_single_cycle captures multiple frames and performs a training step."""
+    with patch('scheduler.ConfigLoader') as mock_config:
+        mock_config.return_value.webcam_sources = [0, 1]
+        mock_config.return_value.metar_station = 'KSEA'
+        mock_config.return_value.lora_settings = {
+            'rank': 8, 'alpha': 16, 'target_modules': ['fc1']
+        }
+        
+        with patch('scheduler.ConvNextLoRAModel') as mock_model_cls:
+            mock_model = MagicMock()
+            mock_model.model.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
+            mock_model.train_step.return_value = 0.5
+            mock_model_cls.return_value = mock_model
+            
+            mock_weather = MagicMock()
+            mock_weather_vector = torch.tensor([0.8, 0.9])
+            mock_weather.get_weather_vector.return_value = mock_weather_vector
+            mock_weather_cls.return_value = mock_weather
+            
+            trainer = Trainer('dummy_path.toml')
+            trainer.optimizer = MagicMock()
+            
+            mock_stream = MagicMock()
+            mock_tensor = torch.randn(1, 3, 224, 224)
+            mock_stream.capture_to_tensor.return_value = mock_tensor
+            mock_webcam.return_value = mock_stream
+            
+            trainer.run_single_cycle(label=1)
+            
+            assert mock_stream.capture_to_tensor.call_count == 2
+            args, _ = mock_model.train_step.call_args
+            image_batch, weather_batch, label_batch, _ = args
+            assert image_batch.shape == (2, 3, 224, 224)
+            assert weather_batch.shape == (2, 2)
+            assert label_batch.shape == (2,)
+
+@patch('scheduler.WebcamStream')
+@patch('scheduler.WeatherFetcher')
+@patch('time.sleep', side_effect=InterruptedError) 
 def test_live_training_loop_cycle(mock_sleep, mock_weather_cls, mock_webcam):
     """Verify that live_training_loop captures multiple frames and performs a batch training step."""
     with patch('scheduler.ConfigLoader') as mock_config:
@@ -53,21 +90,12 @@ def test_live_training_loop_cycle(mock_sleep, mock_weather_cls, mock_webcam):
             trainer = Trainer('dummy_path.toml')
             trainer.optimizer = MagicMock()
             
-            # Mock successful webcam captures
             mock_stream = MagicMock()
             mock_tensor = torch.randn(1, 3, 224, 224)
             mock_stream.capture_to_tensor.return_value = mock_tensor
             mock_webcam.return_value = mock_stream
             
-            # Run the training cycle (expect loop break via mock_sleep)
             with pytest.raises(InterruptedError):
                 trainer.live_training_loop(label=1)
             
-            # Verify interactions
             assert mock_stream.capture_to_tensor.call_count == 2
-            # Batch should contain 2 samples
-            args, _ = mock_model.train_step.call_args
-            image_batch, weather_batch, label_batch, _ = args
-            assert image_batch.shape == (2, 3, 224, 224)
-            assert weather_batch.shape == (2, 2)
-            assert label_batch.shape == (2,)


### PR DESCRIPTION
This PR updates the README and scheduler code to use the cleaner `uv run training` and `uv run collect` command interface as requested. It also includes the necessary `pyproject.toml` updates to support these entry points.