### PR TITLE
Generate and embed static map of mountain targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Determine if Mount Rainier is "out" (visible) using real-time image classificati
 ## Overview
 This system performs online learning using Parameter-Efficient Fine-Tuning (PEFT) with LoRA on a `convnext_tiny` vision backbone. It integrates METAR weather data as a secondary input to the classification head, improving the model's accuracy by incorporating real-world visibility and ceiling data.
 
+![Mount Rainier Topo Map](assets/map.png)
+*Map showing Mount Rainier (M), UW ATG Webcam (C), and KSEA METAR Station (W).*
+
 ## Features
 - **Hardware-Accelerated Training:** Fully optimized for Mac M1/M2/M3 using Metal Performance Shaders (MPS).
 - **Online Learning:** Iterative LoRA training using live webcam captures converted directly to PyTorch tensors with **zero disk usage** for training data.

--- a/tools/generate_map.py
+++ b/tools/generate_map.py
@@ -1,0 +1,47 @@
+import requests
+import tomllib
+from pathlib import Path
+
+def generate_map():
+    # Load config
+    with open("mountain.toml", "rb") as f:
+        config = tomllib.load(f)
+    
+    # Load key
+    with open("mapbox.key", "r") as f:
+        token = f.read().strip()
+    
+    # Coordinates
+    mtn = config['mountain']
+    cam = config['webcam']
+    weather = config['weather']
+    
+    # Marker colors: Rainier (Red), Webcam (Blue), Weather (Green)
+    # Format: pin-s-{label}+{color}({lon},{lat})
+    markers = [
+        f"pin-s-m+f44336({mtn['longitude']},{mtn['latitude']})",
+        f"pin-s-c+2196f3({cam['longitude']},{cam['latitude']})",
+        f"pin-s-w+4caf50({weather['longitude']},{weather['latitude']})"
+    ]
+    
+    overlay = ",".join(markers)
+    style = "mapbox/outdoors-v12"
+    width, height = 800, 600
+    
+    url = f"https://api.mapbox.com/styles/v1/{style}/static/{overlay}/auto/{width}x{height}@2x?access_token={token}"
+    
+    print(f"Requesting map from Mapbox...")
+    headers = {"Referer": "https://tommyroar.github.io"}
+    response = requests.get(url, headers=headers)
+    
+    if response.status_code == 200:
+        Path("assets").mkdir(exist_ok=True)
+        with open("assets/map.png", "wb") as f:
+            f.write(response.content)
+        print("Map successfully saved to assets/map.png")
+    else:
+        print(f"Error: {response.status_code}")
+        print(response.text)
+
+if __name__ == "__main__":
+    generate_map()


### PR DESCRIPTION
This PR resolves #18 by implementing a static map generation tool and embedding the result in the README.

### 🗺️ Changes
- **Map Generation Tool:** Added `tools/generate_map.py` which uses the Mapbox Static Images API.
- **Authorized Requests:** Configured the script to use the `https://tommyroar.github.io` Referer header to authorize requests from the restricted token.
- **Geographic Context:** Embedded the generated `assets/map.png` in the README to visualize the relative positions of:
  - **Mount Rainier (M)**
  - **UW ATG Webcam (C)**
  - **KSEA METAR Station (W)**

### 🛠️ Usage
To regenerate the map after configuration changes:
```bash
python3 tools/generate_map.py
```

Resolves #18.