### PR TITLE
feat: add evaluation script and checkpoints history

### DIFF
--- a/CHECKPOINTS.md
+++ b/CHECKPOINTS.md
@@ -1,0 +1,45 @@
+# Model Checkpoints & History
+
+This document catalogs the major model checkpoints saved during the project's development and outlines expectations for future models.
+
+## Current Checkpoints
+
+### 1. `checkpoints_v1_binary`
+- **Date:** March 11, 2026
+- **Architecture:** 2-Class Binary (Not Out / Out)
+- **Dataset:** Phase 1 (1,260 images)
+- **Strategy:** Heavy oversampling of the "Out" class (1.4% representation).
+- **Status:** Retired. This model was highly accurate on unambiguous days but suffered from false positives during "Partial" visibility, leading to the 3-class redesign.
+
+### 2. `checkpoints_v2_pre_reclassify`
+- **Date:** March 14, 2026
+- **Architecture:** 2-Class Binary
+- **Status:** Archived. This was the final state of the binary model weights immediately prior to the dataset reclassification into 3 classes.
+
+### 3. `train/checkpoints` (Current Phase 2 Baseline)
+- **Date:** March 14, 2026
+- **Architecture:** 3-Class (Not Out, Full, Partial)
+- **Dataset:** 1,319 images (Phase 1 re-labeled)
+  - Not Out: 1,254 (95.1%)
+  - Full: 8 (0.6%)
+  - Partial: 57 (4.3%)
+- **Strategy:** Fresh ConvNeXt weights fine-tuned with 78x oversampling on "Full" and 11x on "Partial".
+- **Status:** Active Baseline.
+
+## Future Expectations
+
+### The April 14 Fine-Tuned Model (`v3_spring`)
+The current Phase 2 data collection run is scheduled to conclude on **April 14**. This 30-day "Diffuse Spring" solar plan captures 21 images a day with a focus on capturing rapid clearing events and diverse cloud layers.
+
+Once the new dataset is labeled and the model is fine-tuned, we will run the new `tools/evaluate.py` script. 
+
+**Expectations:**
+1. **Partial Class Separation:** A massive improvement in F1 and Precision for the "Partial" class. The model should better understand the boundary between a fully obscured mountain and one peeking through a marine layer.
+2. **False Positives:** A continued suppression of false positives (predicting Full/Partial when it is Not Out).
+3. **METAR Reliance:** The model should demonstrate an even stronger fusion of visual and high-frequency METAR data to handle late-spring volatile weather.
+
+## Evaluation
+To compare a checkpoint against a labeled dataset, use the evaluation script:
+```bash
+uv run python tools/evaluate.py --checkpoint path/to/checkpoint --labels path/to/labels.yaml
+```

--- a/tools/evaluate.py
+++ b/tools/evaluate.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import yaml
+import torch
+from pathlib import Path
+import cv2
+from torchvision import transforms
+from sklearn.metrics import classification_report, confusion_matrix
+from metar import Metar
+import argparse
+
+# Force non-interactive backends where necessary
+os.environ["TQDM_DISABLE"] = "1"
+os.environ["PYTHONUNBUFFERED"] = "1"
+
+# Add root to path for imports
+sys.path.append(str(Path.cwd()))
+from train.model import ConvNextLoRAModel
+
+def get_metar_vector(img_path):
+    search_paths = [
+        img_path.parent.parent / "metar" / "metar.txt",
+        img_path.parent / "metar.txt",
+        img_path.parent / f"{img_path.stem}.txt"
+    ]
+    metar_text = None
+    for p in search_paths:
+        if p.exists():
+            with open(p, 'r') as f:
+                metar_text = f.read().strip()
+            break
+    
+    vis, ceil = 0.0, 1.0 # Default bad
+    if metar_text:
+        try:
+            obs = Metar.Metar(metar_text)
+            if obs.vis: vis = min(obs.vis.value('SM'), 10.0) / 10.0
+            if obs.sky:
+                layers = [l for l in obs.sky if l[0] in ['BKN', 'OVC']]
+                ceil = min(layers[0][1].value('FT'), 10000.0) / 10000.0 if layers else 1.0
+        except: pass
+    return [vis, ceil]
+
+def evaluate(checkpoint_dir: str, labels_file: str):
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
+    print(f"Loading checkpoint from: {checkpoint_dir}")
+    print(f"Using device: {device}")
+    
+    model = ConvNextLoRAModel(
+        num_classes=3, 
+        checkpoint_dir=checkpoint_dir, 
+        device=device
+    )
+    model.model_dict.eval()
+
+    labels_path = Path(labels_file)
+    data_root = labels_path.parent
+    
+    with open(labels_path, "r") as f:
+        labels_map = yaml.safe_load(f) or {}
+
+    print(f"Found {len(labels_map)} labels in {labels_file}")
+    
+    transform = transforms.Compose([
+        transforms.ToPILImage(),
+        transforms.Resize(224),
+        transforms.CenterCrop(224),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+    ])
+
+    true_labels = []
+    pred_labels = []
+    
+    print("Running inference...")
+    with torch.no_grad():
+        for rel_path, label in labels_map.items():
+            img_p = data_root / rel_path
+            if not img_p.exists():
+                continue
+                
+            frame = cv2.imread(str(img_p))
+            if frame is None:
+                continue
+            
+            frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            img_tensor = transform(frame_rgb).unsqueeze(0).to(device)
+            
+            weather = get_metar_vector(img_p)
+            weather_tensor = torch.tensor([weather], dtype=torch.float32).to(device)
+            
+            output = model(img_tensor, weather_tensor)
+            pred = torch.argmax(output, dim=1).item()
+            
+            true_labels.append(label)
+            pred_labels.append(pred)
+
+    if not true_labels:
+        print("No valid images found for evaluation.")
+        return
+        
+    print("\n--- Evaluation Results ---")
+    target_names = ["Not Out (0)", "Full (1)", "Partial (2)"]
+    # Handle cases where some classes might not be present in the true labels
+    present_classes = sorted(list(set(true_labels) | set(pred_labels)))
+    present_target_names = [target_names[i] for i in present_classes]
+    
+    print(classification_report(true_labels, pred_labels, labels=present_classes, target_names=present_target_names, zero_division=0))
+    
+    print("\nConfusion Matrix:")
+    print(confusion_matrix(true_labels, pred_labels, labels=present_classes))
+    
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Evaluate a trained model checkpoint on a labeled dataset.")
+    parser.add_argument("--checkpoint", type=str, default="train/checkpoints", help="Path to checkpoint directory")
+    parser.add_argument("--labels", type=str, required=True, help="Path to labels.yaml file")
+    
+    args = parser.parse_args()
+    evaluate(args.checkpoint, args.labels)

--- a/train/scheduler.py
+++ b/train/scheduler.py
@@ -238,6 +238,11 @@ def batch(
         print(f"  Epoch {epoch+1} complete. Avg loss: {avg_loss:.4f} ({len(epoch_losses)} batches)")
     
     trainer.model_wrapper.save_checkpoint(trainer.config_loader.checkpoint_dir)
+    print("\nTraining complete. Running final evaluation on the dataset...")
+    import sys
+    sys.path.append(str(Path.cwd()))
+    from tools.evaluate import evaluate
+    evaluate(trainer.config_loader.checkpoint_dir, str(labels_file))
 
 @app.command()
 def schedule(config: str = "mountain.toml"):


### PR DESCRIPTION
This PR implements the necessary infrastructure to evaluate and compare models as we approach the conclusion of the new data collection phase on April 14.

**Changes:**
1. **`tools/evaluate.py`**: A new standalone evaluation script that calculates F1-Score, Precision, Recall, and outputs a Confusion Matrix against any supplied `--checkpoint` and `--labels` file.
2. **`CHECKPOINTS.md`**: Created a centralized document to track the state of current/archived checkpoints and expectations for the upcoming `v3_spring` model.
3. **`train/scheduler.py`**: Integrated the evaluation script to automatically execute at the end of the `training batch` command, providing immediate visibility into model performance.

The baseline training run is currently re-running to gather sufficient benchmark metrics, which will be logged to `training_metrics.log`.