### PR TITLE
feat: isolated multi-tray Nomad captures with ad-hoc support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,11 @@ uv run collect live         # continuous collection loop
 uv run classify start [data_folder]
 uv run classify stop
 
-# macOS scheduling (launchctl)
-uv run training schedule / unschedule
-uv run collect schedule / unschedule
+# Nomad job management
+nomad job run nomad/collect.hcl          # start collector tray
+nomad job status mountain-collector      # check status
+nomad alloc logs <alloc-id>              # view logs
+nomad alloc logs -stderr <alloc-id>      # view error logs
 ```
 
 ### Frontend (ui/)

--- a/collect/collector.py
+++ b/collect/collector.py
@@ -58,6 +58,7 @@ def _derive_initial_last_capture_at(
     plan_timestamps: List[str],
     data_root: str,
     now_utc,
+    session_id: str,
 ) -> Optional[str]:
     """Return best known last_capture_at on startup.
 
@@ -68,7 +69,7 @@ def _derive_initial_last_capture_at(
     past = [t for t in plan_timestamps if datetime.fromisoformat(t) <= now_utc]
     if past:
         return past[-1]
-    prev_state = read_state(data_root)
+    prev_state = read_state(data_root, session_id)
     if prev_state and prev_state.last_capture_at:
         try:
             prev_ts = datetime.fromisoformat(prev_state.last_capture_at)
@@ -149,7 +150,7 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
     if not session_id:
-        session_id = str(uuid.uuid4())[:8]
+        session_id = "persistent" if not is_once else f"manual-{int(time.time())}"
     config_loader = ConfigLoader(config_path)
     weather_fetcher = WeatherFetcher(config_loader.metar_station)
     fallback_interval = config_loader.collection_seconds
@@ -161,15 +162,15 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
     if all_plan_timestamps:
         logging.info(f"Loaded plan: {len(plan_timestamps)} captures remaining.")
     else:
-        logging.info(f"No plan file found. Using fixed interval ({fallback_interval}s.")
+        logging.info(f"No plan file found. Using fixed interval ({fallback_interval}s).")
 
-    plan_last_capture_at = _derive_initial_last_capture_at(all_plan_timestamps, data_root, now_utc)
+    plan_last_capture_at = _derive_initial_last_capture_at(all_plan_timestamps, data_root, now_utc, session_id)
     plan_final_capture_at = all_plan_timestamps[-1] if all_plan_timestamps else None
 
     plan_total = len(plan_timestamps) if plan_timestamps else 0
 
     # Seed count and index from previous state so restarts don't reset to zero.
-    _prev = read_state(data_root)
+    _prev = read_state(data_root, session_id)
     capture_count = _prev.capture_count if _prev else 0
     plan_index = min(capture_count, plan_total)  # best-effort resume position
 

--- a/collect/collector.py
+++ b/collect/collector.py
@@ -177,12 +177,13 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
     stop_event = threading.Event()
     last_capture_at = plan_last_capture_at  # tracked across all loop iterations
     session_labels_file = Path(data_root) / f"labels.{session_id}.yaml"
+    trigger_file = Path(data_root) / f"trigger_{session_id}"
 
-    def _append_session_label(image_path: Path) -> None:
+    def _append_session_label(image_path: Path, is_adhoc: bool = False) -> None:
         rel = str(image_path.relative_to(Path(data_root)))
         entry = {
             rel: {
-                "type": "manual" if is_once else "scheduled"
+                "type": "manual" if is_adhoc else "scheduled"
             }
         }
         with open(session_labels_file, "a") as f:
@@ -193,32 +194,37 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
             return plan_timestamps[plan_index]
         return None
 
-    def _sleep_until_next() -> None:
-        """Sleep until the next scheduled capture time, or fallback interval."""
+    def _sleep_until_next() -> bool:
+        """Sleep until the next scheduled capture time, or fallback interval.
+        Returns True if a trigger file was detected.
+        """
         next_iso = _next_capture_at()
         if next_iso:
             target = datetime.fromisoformat(next_iso)
             wait = max(0, (target - datetime.now(timezone.utc)).total_seconds())
         else:
             wait = fallback_interval
+        
         logging.info(f"Next capture in {int(wait)}s.")
         end = time.monotonic() + wait
         while time.monotonic() < end:
             if stop_event.is_set():
-                return
+                return False
+            # Check for ad-hoc trigger file
+            if trigger_file.exists():
+                logging.info("Ad-hoc trigger detected!")
+                try:
+                    trigger_file.unlink()
+                except Exception: pass
+                return True
             time.sleep(min(1, end - time.monotonic()))
+        return False
 
     def capture_loop():
         nonlocal capture_count, plan_index, last_capture_at
 
         while not stop_event.is_set():
-            # Synchronize count with any other concurrent jobs (ad-hoc)
-            current_state = read_state(data_root, session_id)
-            if current_state:
-                capture_count = current_state.capture_count
-                if not last_capture_at:
-                    last_capture_at = current_state.last_capture_at
-
+            # Scheduled capture start
             write_state(data_root, make_state(
                 session_id=session_id, status="Capturing...",
                 capture_count=capture_count,
@@ -235,7 +241,7 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
             if image_path:
                 capture_count += 1
                 last_capture_at = datetime.now(timezone.utc).isoformat()
-                _append_session_label(image_path)
+                _append_session_label(image_path, is_adhoc=False)
 
             if plan_timestamps:
                 plan_index += 1
@@ -264,15 +270,49 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
                 rumps.quit_application()
                 return
 
-            _sleep_until_next()
+            # Wait for next or trigger
+            while not stop_event.is_set():
+                is_adhoc = _sleep_until_next()
+                if not is_adhoc:
+                    # Normal scheduled wakeup
+                    break
+                
+                # Ad-hoc capture wakeup
+                write_state(data_root, make_state(
+                    session_id=session_id, status="Capturing (Ad-hoc)...",
+                    capture_count=capture_count,
+                    plan_total=plan_total,
+                    interval_seconds=fallback_interval,
+                    last_capture_at=last_capture_at,
+                    next_capture_at=_next_capture_at(),
+                    session_labels_file=str(session_labels_file),
+                    final_capture_at=plan_final_capture_at,
+                ))
+                
+                image_path = perform_capture(config_loader, weather_fetcher, data_root, session_uuid=session_id)
+                if image_path:
+                    capture_count += 1
+                    last_capture_at = datetime.now(timezone.utc).isoformat()
+                    _append_session_label(image_path, is_adhoc=True)
+                
+                write_state(data_root, make_state(
+                    session_id=session_id, status="Idle",
+                    capture_count=capture_count,
+                    plan_total=plan_total,
+                    interval_seconds=fallback_interval,
+                    last_capture_at=last_capture_at,
+                    next_capture_at=_next_capture_at(),
+                    session_labels_file=str(session_labels_file),
+                    final_capture_at=plan_final_capture_at,
+                ))
 
     # Write initial state before starting tray so first _refresh() has data.
     # last_capture_at is derived from the plan (most recent past timestamp).
     write_state(data_root, make_state(
         session_id=session_id, status="Starting...",
-        capture_count=0, plan_total=plan_total,
+        capture_count=capture_count, plan_total=plan_total,
         interval_seconds=fallback_interval,
-        last_capture_at=plan_last_capture_at,
+        last_capture_at=last_capture_at,
         next_capture_at=_next_capture_at(),
         session_labels_file=str(session_labels_file),
         final_capture_at=plan_final_capture_at,

--- a/collect/collector.py
+++ b/collect/collector.py
@@ -212,6 +212,13 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
         nonlocal capture_count, plan_index, last_capture_at
 
         while not stop_event.is_set():
+            # Synchronize count with any other concurrent jobs (ad-hoc)
+            current_state = read_state(data_root, session_id)
+            if current_state:
+                capture_count = current_state.capture_count
+                if not last_capture_at:
+                    last_capture_at = current_state.last_capture_at
+
             write_state(data_root, make_state(
                 session_id=session_id, status="Capturing...",
                 capture_count=capture_count,

--- a/collect/collector.py
+++ b/collect/collector.py
@@ -150,7 +150,7 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
     if not session_id:
-        session_id = "persistent" if not is_once else f"manual-{int(time.time())}"
+        session_id = str(uuid.uuid4())[:8]
     config_loader = ConfigLoader(config_path)
     weather_fetcher = WeatherFetcher(config_loader.metar_station)
     fallback_interval = config_loader.collection_seconds
@@ -180,8 +180,13 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
 
     def _append_session_label(image_path: Path) -> None:
         rel = str(image_path.relative_to(Path(data_root)))
+        entry = {
+            rel: {
+                "type": "manual" if is_once else "scheduled"
+            }
+        }
         with open(session_labels_file, "a") as f:
-            yaml.dump({rel: None}, f, default_flow_style=False)
+            yaml.dump(entry, f, default_flow_style=False)
 
     def _next_capture_at() -> Optional[str]:
         if plan_timestamps and plan_index < len(plan_timestamps):

--- a/collect/collector.py
+++ b/collect/collector.py
@@ -142,13 +142,14 @@ def cli(ctx, **kwargs):
     if ctx.invoked_subcommand is None:
         ctx.invoke(tray)
 
-def run_tray_loop(config_path: str, data_root: str, is_once: bool = False):
+def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, session_id: Optional[str] = None):
     """Internal implementation for running the tray icon loop."""
     from datetime import datetime, timezone, timedelta
 
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-    session_id = str(uuid.uuid4())[:8]
+    if not session_id:
+        session_id = str(uuid.uuid4())[:8]
     config_loader = ConfigLoader(config_path)
     weather_fetcher = WeatherFetcher(config_loader.metar_station)
     fallback_interval = config_loader.collection_seconds
@@ -267,8 +268,14 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False):
     t = threading.Thread(target=capture_loop, daemon=True)
     t.start()
 
-    tray_manager = MountainTray(data_root=data_root)
-    tray_manager.run()
+    if rumps:
+        tray_manager = MountainTray(data_root=data_root, session_id=session_id)
+        tray_manager.run()
+    else:
+        logging.info("Headless mode: Waiting for loop to complete...")
+        while not stop_event.is_set():
+            time.sleep(1)
+
 
 @cli.command()
 @click.option('--data-root', default='data', help='Root directory for data storage.')
@@ -306,16 +313,18 @@ def schedule(data_root: str, days: int, lat: float, lon: float):
 @cli.command()
 @click.option('--config', default='mountain.toml', help='Path to config file.')
 @click.option('--data-root', default='data', help='Root directory for data storage.')
-def tray(config: str, data_root: str):
+@click.option('--session-id', default=None, help='Unique ID for this session.')
+def tray(config: str, data_root: str, session_id: str):
     """Runs continuous collection with a system tray icon."""
-    run_tray_loop(config, data_root, is_once=False)
+    run_tray_loop(config, data_root, is_once=False, session_id=session_id)
 
 @cli.command()
 @click.option('--config', default='mountain.toml', help='Path to config file.')
 @click.option('--data-root', default='data', help='Root directory for data storage.')
-def once(config: str, data_root: str):
+@click.option('--session-id', default=None, help='Unique ID for this session.')
+def once(config: str, data_root: str, session_id: str):
     """Performs a single capture, showing a tray icon briefly."""
-    run_tray_loop(config, data_root, is_once=True)
+    run_tray_loop(config, data_root, is_once=True, session_id=session_id)
 
 @cli.command()
 @click.option('--config', default='mountain.toml', help='Path to config file.')

--- a/collect/state.py
+++ b/collect/state.py
@@ -14,6 +14,8 @@ from typing import Dict, Optional
 STATE_FILENAME = "collector_state.json"
 PLAN_FILENAME  = "capture_plan.json"
 
+def _get_state_path(data_root: str | Path, session_id: str) -> Path:
+    return Path(data_root) / f"collector_state_{session_id}.json"
 
 @dataclass
 class CollectorState:
@@ -41,14 +43,14 @@ def _now_iso() -> str:
 
 
 def write_state(data_root: str | Path, state: CollectorState) -> None:
-    path = Path(data_root) / STATE_FILENAME
+    path = _get_state_path(data_root, state.session_id)
     tmp = path.with_suffix(".tmp")
     tmp.write_text(json.dumps(asdict(state), indent=2))
     tmp.replace(path)  # atomic on POSIX
 
 
-def read_state(data_root: str | Path) -> Optional[CollectorState]:
-    path = Path(data_root) / STATE_FILENAME
+def read_state(data_root: str | Path, session_id: str) -> Optional[CollectorState]:
+    path = _get_state_path(data_root, session_id)
     try:
         data = json.loads(path.read_text())
         return CollectorState(**data)

--- a/collect/state.py
+++ b/collect/state.py
@@ -56,6 +56,19 @@ def read_state(data_root: str | Path) -> Optional[CollectorState]:
         return None
 
 
+def fetch_remote_state(url: str) -> Optional[CollectorState]:
+    """Fetch collector state from a remote Cloudflare Worker endpoint."""
+    import requests
+    try:
+        response = requests.get(url, timeout=5)
+        response.raise_for_status()
+        data = response.json()
+        return CollectorState(**data)
+    except Exception as e:
+        print(f"Error fetching remote state: {e}")
+        return None
+
+
 def write_plan(data_root: str | Path, timestamps: list[str]) -> Path:
     """Save a list of ISO-8601 UTC capture timestamps to capture_plan.json."""
     path = Path(data_root) / PLAN_FILENAME

--- a/collect/tests/conftest.py
+++ b/collect/tests/conftest.py
@@ -1,0 +1,36 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+def _make_rumps_stub():
+    rumps_mod = types.ModuleType("rumps")
+
+    class MenuItem:
+        def __init__(self, title, callback=None):
+            self.title = title
+            self.callback = callback
+
+    class Timer:
+        def __init__(self, callback, interval):
+            self.callback = callback
+            self.interval = interval
+        def start(self): pass
+        def stop(self): pass
+
+    class App:
+        def __init__(self, name, title="", quit_button=None):
+            self.name = name
+            self.title = title
+            self.menu = []
+        def run(self): pass
+
+    rumps_mod.App = App
+    rumps_mod.MenuItem = MenuItem
+    rumps_mod.Timer = Timer
+    rumps_mod.separator = "---"
+    rumps_mod.quit_application = MagicMock()
+    return rumps_mod
+
+# Apply mock globally for collect tests
+if "rumps" not in sys.modules:
+    sys.modules["rumps"] = _make_rumps_stub()

--- a/collect/tests/test_collector.py
+++ b/collect/tests/test_collector.py
@@ -1,18 +1,31 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from collect.collector import collect, live
+import sys
+from click.testing import CliRunner
+from collect.collector import once, live
 from pathlib import Path
 import os
 import shutil
 from datetime import datetime, UTC
+import threading
+
+def run_sync_thread(target, daemon=True):
+    """Mocks threading.Thread to run the target synchronously."""
+    mock_thread = MagicMock()
+    def start_mock():
+        target()
+    mock_thread.start = start_mock
+    return mock_thread
 
 @patch('collect.collector.ConfigLoader')
 @patch('collect.collector.WebcamStream')
 @patch('collect.collector.WeatherFetcher')
-def test_collect_execution_utc_structure(mock_weather_cls, mock_webcam, mock_config, tmp_path):
-    """Verify that collect function uses the new UTC-based directory structure."""
-    mock_config.return_value.webcam_url = 'http://cam.jpg'
+@patch('threading.Thread', side_effect=run_sync_thread)
+def test_once_execution_utc_structure(mock_thread, mock_weather_cls, mock_webcam, mock_config, tmp_path):
+    """Verify that once function uses the new UTC-based directory structure."""
+    mock_config.return_value.webcam_url = 'Cam_JPG'
     mock_config.return_value.metar_station = 'KSEA'
+    mock_config.return_value.collection_seconds = 600
     
     mock_weather = MagicMock()
     mock_weather.fetch_latest_metar.return_value = "METAR KSEA 211953Z CLR 10/05"
@@ -22,22 +35,30 @@ def test_collect_execution_utc_structure(mock_weather_cls, mock_webcam, mock_con
     mock_stream.capture_raw.return_value = MagicMock()
     mock_webcam.return_value = mock_stream
     
-    with patch('cv2.imwrite') as mock_imwrite:
-        collect(config='mountain.toml', data_root=str(tmp_path))
-        
-        # Structure: data/YYYYMMDD/HHMMSS_UTC/
-        now_utc = datetime.now(UTC)
-        date_str = now_utc.strftime("%Y%m%d")
-        
-        date_dir = tmp_path / date_str
-        assert date_dir.exists()
-        
-        time_dir = next(date_dir.iterdir())
-        assert time_dir.name.endswith("_UTC")
-        assert (time_dir / "images").exists()
-        assert (time_dir / "metar").exists()
-        assert (time_dir / "metar" / "metar.txt").exists()
-        assert mock_imwrite.called
+    runner = CliRunner()
+    # We also need to mock rumps.App.run to not block
+    with patch('rumps.App.run') as mock_run:
+        with patch('cv2.imwrite') as mock_imwrite:
+            # Use CliRunner to call the command with arguments
+            result = runner.invoke(once, ['--config', 'mountain.toml', '--data-root', str(tmp_path), '--session-id', 'test-once'])
+            
+            assert result.exit_code == 0
+            
+            # Structure: data/YYYYMMDD/HHMMSS_UTC/
+            now_utc = datetime.now(UTC)
+            date_str = now_utc.strftime("%Y%m%d")
+            
+            date_dir = tmp_path / date_str
+            assert date_dir.exists()
+            
+            time_dirs = list(date_dir.iterdir())
+            assert len(time_dirs) > 0
+            time_dir = time_dirs[0]
+            assert time_dir.name.endswith("_UTC")
+            assert (time_dir / "images").exists()
+            assert (time_dir / "metar").exists()
+            assert (time_dir / "metar" / "metar.txt").exists()
+            assert mock_imwrite.called
 
 @patch('collect.collector.ConfigLoader')
 @patch('collect.collector.WebcamStream')
@@ -45,7 +66,7 @@ def test_collect_execution_utc_structure(mock_weather_cls, mock_webcam, mock_con
 @patch('time.sleep', side_effect=KeyboardInterrupt)
 def test_live_collection_loop(mock_sleep, mock_weather_cls, mock_webcam, mock_config, tmp_path):
     """Verify that live command runs a loop and stops on KeyboardInterrupt."""
-    mock_config.return_value.webcam_url = 'http://cam.jpg'
+    mock_config.return_value.webcam_url = 'Cam_JPG'
     mock_config.return_value.metar_station = 'KSEA'
     mock_config.return_value.collection_seconds = 1
     
@@ -57,9 +78,10 @@ def test_live_collection_loop(mock_sleep, mock_weather_cls, mock_webcam, mock_co
     mock_stream.capture_raw.return_value = MagicMock()
     mock_webcam.return_value = mock_stream
     
+    runner = CliRunner()
     with patch('cv2.imwrite'):
         # This will run one iteration and then 'sleep' will raise KeyboardInterrupt
-        live(config='mountain.toml', data_root=str(tmp_path))
+        result = runner.invoke(live, ['--config', 'mountain.toml', '--data-root', str(tmp_path)])
         
         # Check if directories were created for the first run
         now_utc = datetime.now(UTC)

--- a/collect/tests/test_tray.py
+++ b/collect/tests/test_tray.py
@@ -57,7 +57,7 @@ def data_root(tmp_path):
 
 @pytest.fixture()
 def tray(data_root):
-    return MountainTray(data_root=str(data_root))
+    return MountainTray(data_root=str(data_root), session_id="abc123")
 
 @pytest.fixture()
 def base_state():
@@ -92,21 +92,21 @@ def test_initial_status_placeholder(tray):
 
 def test_write_and_read_state_roundtrip(data_root, base_state):
     write_state(data_root, base_state)
-    result = read_state(data_root)
+    result = read_state(data_root, base_state.session_id)
     assert result == base_state
 
 
 def test_read_state_returns_none_when_missing(data_root):
-    assert read_state(data_root) is None
+    assert read_state(data_root, "missing_session") is None
 
 
 def test_write_is_atomic(data_root, base_state):
     """write_state uses a tmp file + rename — no partial reads."""
     write_state(data_root, base_state)
-    path = data_root / "collector_state.json"
+    path = data_root / f"collector_state_{base_state.session_id}.json"
     assert path.exists()
     # No .tmp file should remain
-    assert not (data_root / "collector_state.tmp").exists()
+    assert not (data_root / f"collector_state_{base_state.session_id}.tmp").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -235,7 +235,7 @@ def test_derive_initial_last_capture_at_from_plan_past(tmp_path):
     future = "2026-03-15T20:00:00+00:00"
     from datetime import datetime, timezone
     now = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
-    result = _derive_initial_last_capture_at([past, future], str(tmp_path), now)
+    result = _derive_initial_last_capture_at([past, future], str(tmp_path), now, "sess")
     assert result == past
 
 
@@ -248,7 +248,7 @@ def test_derive_initial_last_capture_at_falls_back_to_state_file(tmp_path):
     future = "2026-03-15T20:00:00+00:00"
     from datetime import datetime, timezone
     now = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
-    result = _derive_initial_last_capture_at([future], str(tmp_path), now)
+    result = _derive_initial_last_capture_at([future], str(tmp_path), now, "prev")
     assert result == past_time
 
 
@@ -260,14 +260,14 @@ def test_derive_initial_last_capture_at_ignores_future_state(tmp_path):
                                      last_capture_at=future_time))
     from datetime import datetime, timezone
     now = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
-    result = _derive_initial_last_capture_at([], str(tmp_path), now)
+    result = _derive_initial_last_capture_at([], str(tmp_path), now, "prev")
     assert result is None
 
 
 def test_derive_initial_last_capture_at_no_plan_no_state(tmp_path):
     from datetime import datetime, timezone
     now = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
-    assert _derive_initial_last_capture_at([], str(tmp_path), now) is None
+    assert _derive_initial_last_capture_at([], str(tmp_path), now, "any") is None
 
 
 def test_make_state_resets_last_capture_at_when_omitted(tmp_path):
@@ -283,5 +283,5 @@ def test_capturing_state_preserves_last_capture_at(tmp_path):
     write_state(tmp_path, make_state("sess1", "Capturing...", capture_count=0,
                                      interval_seconds=600, plan_total=5,
                                      last_capture_at=past_time))
-    state = read_state(tmp_path)
+    state = read_state(tmp_path, "sess1")
     assert state.last_capture_at == past_time

--- a/collect/tests/test_tray.py
+++ b/collect/tests/test_tray.py
@@ -1,49 +1,9 @@
 """Tests for MountainTray — mocks rumps so no GUI event loop is needed."""
 import sys
-import types
 from unittest.mock import MagicMock
 import pytest
 
 from collect.state import CollectorState, write_state, read_state, make_state
-
-
-# ---------------------------------------------------------------------------
-# Minimal rumps stub
-# ---------------------------------------------------------------------------
-
-def _make_rumps_stub():
-    rumps_mod = types.ModuleType("rumps")
-
-    class MenuItem:
-        def __init__(self, title, callback=None):
-            self.title = title
-            self.callback = callback
-
-    class Timer:
-        def __init__(self, callback, interval):
-            self.callback = callback
-            self.interval = interval
-        def start(self): pass
-        def stop(self): pass
-
-    class App:
-        def __init__(self, name, title="", quit_button=None):
-            self.name = name
-            self.title = title
-            self.menu = []
-        def run(self): pass
-
-    rumps_mod.App = App
-    rumps_mod.MenuItem = MenuItem
-    rumps_mod.Timer = Timer
-    rumps_mod.separator = "---"
-    rumps_mod.quit_application = MagicMock()
-    return rumps_mod
-
-
-_rumps_stub = _make_rumps_stub()
-sys.modules["rumps"] = _rumps_stub
-
 from collect.tray import MountainTray, _fmt_time  # noqa: E402
 
 

--- a/collect/tests/test_tray.py
+++ b/collect/tests/test_tray.py
@@ -142,26 +142,6 @@ def test_render_shows_placeholder_when_next_is_none(tray, base_state):
     assert "—" in tray.next_item.title
 
 
-def test_render_spinner_cycles(tray, base_state):
-    from collect.tray import SPINNER
-    base_state.status = "capturing"
-    
-    # First frame
-    tray._render(base_state)
-    assert tray.title == f"🗻{SPINNER[0]}"
-    
-    # Second frame
-    tray._render(base_state)
-    assert tray.title == f"🗻{SPINNER[1]}"
-    
-    # Wrap around (after len(SPINNER) calls)
-    tray._spinner_idx = len(SPINNER) - 1
-    tray._render(base_state)
-    assert tray.title == f"🗻{SPINNER[-1]}"
-    tray._render(base_state)
-    assert tray.title == f"🗻{SPINNER[0]}"
-
-
 # ---------------------------------------------------------------------------
 # _refresh reads from state file
 # ---------------------------------------------------------------------------
@@ -175,7 +155,7 @@ def test_refresh_reads_state_file(tray, data_root, base_state):
 
 def test_refresh_shows_error_when_no_state_file(tray):
     tray._refresh()
-    assert "No state found" in tray.status_item.title
+    assert "No state file" in tray.status_item.title
 
 
 def test_refresh_skips_rerender_when_state_unchanged(tray, data_root, base_state):

--- a/collect/tests/test_tray.py
+++ b/collect/tests/test_tray.py
@@ -142,6 +142,26 @@ def test_render_shows_placeholder_when_next_is_none(tray, base_state):
     assert "—" in tray.next_item.title
 
 
+def test_render_spinner_cycles(tray, base_state):
+    from collect.tray import SPINNER
+    base_state.status = "capturing"
+    
+    # First frame
+    tray._render(base_state)
+    assert tray.title == f"🗻{SPINNER[0]}"
+    
+    # Second frame
+    tray._render(base_state)
+    assert tray.title == f"🗻{SPINNER[1]}"
+    
+    # Wrap around (after len(SPINNER) calls)
+    tray._spinner_idx = len(SPINNER) - 1
+    tray._render(base_state)
+    assert tray.title == f"🗻{SPINNER[-1]}"
+    tray._render(base_state)
+    assert tray.title == f"🗻{SPINNER[0]}"
+
+
 # ---------------------------------------------------------------------------
 # _refresh reads from state file
 # ---------------------------------------------------------------------------
@@ -155,7 +175,7 @@ def test_refresh_reads_state_file(tray, data_root, base_state):
 
 def test_refresh_shows_error_when_no_state_file(tray):
     tray._refresh()
-    assert "No state file" in tray.status_item.title
+    assert "No state found" in tray.status_item.title
 
 
 def test_refresh_skips_rerender_when_state_unchanged(tray, data_root, base_state):

--- a/collect/tray.py
+++ b/collect/tray.py
@@ -112,9 +112,9 @@ class MountainTray(rumps.App):
     def _on_capture_additional(self, _):
         logger.info(f"Triggering ad-hoc capture for session {self.session_id}...")
         try:
-            # We trigger the nomad job via tools/capture_now.py
-            script_path = Path(__file__).parent.parent / "tools" / "capture_now.py"
-            subprocess.Popen(["python3", str(script_path), "--session-id", self.session_id])
+            trigger_file = self.data_root / f"trigger_{self.session_id}"
+            trigger_file.touch()
+            logger.info(f"Created trigger file: {trigger_file}")
         except Exception as e:
             logger.error(f"Failed to trigger ad-hoc capture: {e}")
 

--- a/collect/tray.py
+++ b/collect/tray.py
@@ -66,8 +66,17 @@ class MountainTray(rumps.App):
         if state is None:
             self.status_item.title = "Status: No state file found"
             return
-        if state == self._last_state:
-            return
+        
+        # Compare essential fields to decide if we need a rerender
+        if self._last_state:
+            is_same = (
+                state.capture_count == self._last_state.capture_count and
+                state.status == self._last_state.status and
+                state.next_capture_at == self._last_state.next_capture_at
+            )
+            if is_same:
+                return
+
         self._last_state = state
         self._render(state)
 

--- a/collect/tray.py
+++ b/collect/tray.py
@@ -22,7 +22,8 @@ REFRESH_INTERVAL = 10  # seconds between state file reads
 
 class MountainTray(rumps.App):
     def __init__(self, data_root: str = "data", session_id: Optional[str] = None):
-        name = f"Mountain Collector ({session_id})" if session_id else "Mountain Collector"
+        self.session_id = session_id or "persistent"
+        name = f"Mountain Collector ({self.session_id})" if self.session_id != "persistent" else "Mountain Collector"
         super().__init__(name, title="🗻", quit_button=None)
         self.data_root = Path(data_root).absolute()
         self._last_state: Optional[CollectorState] = None
@@ -36,6 +37,7 @@ class MountainTray(rumps.App):
         self.final_item        = rumps.MenuItem("Final Capture: —")
         self.session_item      = rumps.MenuItem("Session: —")
         self.open_item         = rumps.MenuItem("Open Index File", callback=self._on_open_folder)
+        self.ad_hoc_item       = rumps.MenuItem("Capture additional image", callback=self._on_capture_additional)
         self.menu = [
             self.progress_bar_item,
             rumps.separator,
@@ -48,6 +50,7 @@ class MountainTray(rumps.App):
             self.session_item,
             rumps.separator,
             self.open_item,
+            self.ad_hoc_item,
             rumps.separator,
             rumps.MenuItem("Quit Capture Job", callback=self._on_quit),
         ]
@@ -59,7 +62,7 @@ class MountainTray(rumps.App):
     # ------------------------------------------------------------------
 
     def _refresh(self, _=None) -> None:
-        state = read_state(self.data_root)
+        state = read_state(self.data_root, self.session_id)
         if state is None:
             self.status_item.title = "Status: No state file found"
             return
@@ -105,6 +108,15 @@ class MountainTray(rumps.App):
                 subprocess.Popen(["open", str(self.data_root)])
         else:
             subprocess.Popen(["xdg-open", str(self.data_root)])
+
+    def _on_capture_additional(self, _):
+        logger.info("Triggering ad-hoc capture...")
+        try:
+            # We trigger the nomad job via tools/capture_now.py
+            script_path = Path(__file__).parent.parent / "tools" / "capture_now.py"
+            subprocess.Popen(["python3", str(script_path)])
+        except Exception as e:
+            logger.error(f"Failed to trigger ad-hoc capture: {e}")
 
     def _on_quit(self, _):
         logger.info("Quitting tray...")

--- a/collect/tray.py
+++ b/collect/tray.py
@@ -11,20 +11,32 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-import rumps
+try:
+    import rumps
+except ImportError:
+    rumps = None
 
-from collect.state import CollectorState, read_state
+from collect.state import CollectorState, read_state, fetch_remote_state
 
 logger = logging.getLogger(__name__)
 
-REFRESH_INTERVAL = 300  # seconds between state file reads
+REFRESH_INTERVAL = 2  # seconds between state file reads
 
 
-class MountainTray(rumps.App):
-    def __init__(self, data_root: str = "data"):
-        super().__init__("Mountain Collector", title="🗻", quit_button=None)
+SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+class MountainTray(rumps.App if rumps else object):
+    def __init__(self, data_root: str = "data", worker_url: Optional[str] = None, cloud_enabled: bool = False):
+        if rumps:
+            super().__init__("Mountain Collector", title="🗻", quit_button=None)
         self.data_root = Path(data_root).absolute()
+        self.worker_url = worker_url
+        self.cloud_enabled = cloud_enabled
         self._last_state: Optional[CollectorState] = None
+        self._spinner_idx = 0
+
+        if not rumps:
+            return
 
         # --- Static menu skeleton ---
         self.status_item       = rumps.MenuItem("Status: —")
@@ -55,9 +67,13 @@ class MountainTray(rumps.App):
     # ------------------------------------------------------------------
 
     def _refresh(self, _=None) -> None:
-        state = read_state(self.data_root)
+        if self.cloud_enabled and self.worker_url:
+            state = fetch_remote_state(f"{self.worker_url}/state")
+        else:
+            state = read_state(self.data_root)
+
         if state is None:
-            self.status_item.title = "Status: No state file found"
+            self.status_item.title = "Status: No state found"
             return
         if state == self._last_state:
             return
@@ -65,6 +81,14 @@ class MountainTray(rumps.App):
         self._render(state)
 
     def _render(self, state: CollectorState) -> None:
+        # Update menu bar title with a simple Fuji mountain and a spinner if active
+        if state.status == "capturing":
+            spinner = SPINNER[self._spinner_idx % len(SPINNER)]
+            self._spinner_idx += 1
+            self.title = f"🗻{spinner}"
+        else:
+            self.title = "🗻"
+
         self.status_item.title   = f"Status: {state.status}"
         total_str = str(state.plan_total) if state.plan_total > 0 else "?"
         self.progress_item.title = (

--- a/collect/tray.py
+++ b/collect/tray.py
@@ -11,34 +11,24 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-try:
-    import rumps
-except ImportError:
-    rumps = None
+import rumps
 
-from collect.state import CollectorState, read_state, fetch_remote_state
+from collect.state import CollectorState, read_state
 
 logger = logging.getLogger(__name__)
 
-REFRESH_INTERVAL = 2  # seconds between state file reads
+REFRESH_INTERVAL = 10  # seconds between state file reads
 
 
-SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-
-class MountainTray(rumps.App if rumps else object):
-    def __init__(self, data_root: str = "data", worker_url: Optional[str] = None, cloud_enabled: bool = False):
-        if rumps:
-            super().__init__("Mountain Collector", title="🗻", quit_button=None)
+class MountainTray(rumps.App):
+    def __init__(self, data_root: str = "data", session_id: Optional[str] = None):
+        name = f"Mountain Collector ({session_id})" if session_id else "Mountain Collector"
+        super().__init__(name, title="🗻", quit_button=None)
         self.data_root = Path(data_root).absolute()
-        self.worker_url = worker_url
-        self.cloud_enabled = cloud_enabled
         self._last_state: Optional[CollectorState] = None
-        self._spinner_idx = 0
-
-        if not rumps:
-            return
 
         # --- Static menu skeleton ---
+        self.progress_bar_item = rumps.MenuItem("—")
         self.status_item       = rumps.MenuItem("Status: —")
         self.progress_item     = rumps.MenuItem("Progress: —")
         self.last_capture_item = rumps.MenuItem("Last Capture: —")
@@ -47,6 +37,8 @@ class MountainTray(rumps.App if rumps else object):
         self.session_item      = rumps.MenuItem("Session: —")
         self.open_item         = rumps.MenuItem("Open Index File", callback=self._on_open_folder)
         self.menu = [
+            self.progress_bar_item,
+            rumps.separator,
             self.status_item,
             self.progress_item,
             self.last_capture_item,
@@ -67,13 +59,9 @@ class MountainTray(rumps.App if rumps else object):
     # ------------------------------------------------------------------
 
     def _refresh(self, _=None) -> None:
-        if self.cloud_enabled and self.worker_url:
-            state = fetch_remote_state(f"{self.worker_url}/state")
-        else:
-            state = read_state(self.data_root)
-
+        state = read_state(self.data_root)
         if state is None:
-            self.status_item.title = "Status: No state found"
+            self.status_item.title = "Status: No state file found"
             return
         if state == self._last_state:
             return
@@ -81,13 +69,11 @@ class MountainTray(rumps.App if rumps else object):
         self._render(state)
 
     def _render(self, state: CollectorState) -> None:
-        # Update menu bar title with a simple Fuji mountain and a spinner if active
-        if state.status == "capturing":
-            spinner = SPINNER[self._spinner_idx % len(SPINNER)]
-            self._spinner_idx += 1
-            self.title = f"🗻{spinner}"
-        else:
-            self.title = "🗻"
+        # Progress bar as the first item in the menu
+        bar_len = 20
+        filled_len = int(round(bar_len * state.pct_complete / 100))
+        bar = "█" * filled_len + "░" * (bar_len - filled_len)
+        self.progress_bar_item.title = f"[{bar}] {state.pct_complete}%"
 
         self.status_item.title   = f"Status: {state.status}"
         total_str = str(state.plan_total) if state.plan_total > 0 else "?"

--- a/collect/tray.py
+++ b/collect/tray.py
@@ -110,11 +110,11 @@ class MountainTray(rumps.App):
             subprocess.Popen(["xdg-open", str(self.data_root)])
 
     def _on_capture_additional(self, _):
-        logger.info("Triggering ad-hoc capture...")
+        logger.info(f"Triggering ad-hoc capture for session {self.session_id}...")
         try:
             # We trigger the nomad job via tools/capture_now.py
             script_path = Path(__file__).parent.parent / "tools" / "capture_now.py"
-            subprocess.Popen(["python3", str(script_path)])
+            subprocess.Popen(["python3", str(script_path), "--session-id", self.session_id])
         except Exception as e:
             logger.error(f"Failed to trigger ad-hoc capture: {e}")
 

--- a/mountain-capture/SKILL.md
+++ b/mountain-capture/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: mountain-capture
+description: Schedule and manage webcam captures of Mount Rainier via Nomad. Supports ad-hoc single captures and persistent collection services. Use when the mountain is confirmed "out" or for scheduled monitoring.
+---
+
+# Mountain Capture
+
+This skill manages image collection jobs for Mount Rainier via Nomad.
+
+## Capture Modes
+
+### 1. Ad-Hoc Single Capture (Batch)
+Use this to trigger an immediate, one-off capture regardless of whether a persistent collector is running.
+- **Nomad Job:** `mountain-capture-single`
+- **Execution:** 
+  ```bash
+  python3 scripts/capture_now.py
+  ```
+- **Menu Bar Feature:** From any active capture job's tray icon, select **"Capture additional image"** to trigger this Nomad job instantly.
+- **Storage:** Images are stored in `data/` with unique session prefixes (e.g., `manual-177...`). Each will spawn its own tray icon briefly during capture.
+
+### 2. Persistent Collection (Service)
+The long-running collector service managed by Nomad.
+- **Nomad Job:** `mountain-collector`
+- **Status:** 
+  ```bash
+  nomad job status mountain-collector
+  ```
+- **Control:**
+  - Start: `nomad job run nomad/collect.hcl`
+  - Stop: `nomad job stop mountain-collector`
+
+### 3. Custom Batch (e.g., "The Mountain is Out")
+For capturing multiple images over a window (e.g., 10 captures in 1 hour).
+- **Tool:** `tools/capture_out.py`
+- **Nomad Job:** `mountain-capture-out`
+
+## Key Files
+- `nomad/once.hcl`: Template for single batch captures.
+- `nomad/collect.hcl`: Template for the persistent service.
+- `data/collector_state.json`: Real-time status of the active collector.
+- `data/capture_plan.json`: The current schedule for the active collector.
+
+## Troubleshooting
+- **No images captured:** Check Nomad logs: `nomad alloc logs <alloc-id> tray`
+- **Port conflicts:** The collector automatically finds an available port and writes to `data/classifier_server.port`.

--- a/mountain-capture/assets/once.hcl
+++ b/mountain-capture/assets/once.hcl
@@ -1,0 +1,29 @@
+job "mountain-capture-single" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  group "capture" {
+    count = 1
+    
+    task "run-once" {
+      driver = "raw_exec"
+
+      env {
+        PATH = "/Users/tommydoerr/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+      }
+
+      config {
+        command = "/bin/bash"
+        args    = [
+          "-c",
+          "cd /Users/tommydoerr/dev/is-the-mountain-out && export SESSION_ID=manual-$(date +%s) && uv run collect once --session-id $SESSION_ID"
+        ]
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+  }
+}

--- a/mountain-capture/assets/once.hcl
+++ b/mountain-capture/assets/once.hcl
@@ -1,3 +1,8 @@
+variable "session_id" {
+  type    = string
+  default = ""
+}
+
 job "mountain-capture-single" {
   datacenters = ["dc1"]
   type        = "batch"
@@ -16,7 +21,7 @@ job "mountain-capture-single" {
         command = "/bin/bash"
         args    = [
           "-c",
-          "cd /Users/tommydoerr/dev/is-the-mountain-out && export SESSION_ID=manual-$(date +%s) && uv run collect once --session-id $SESSION_ID"
+          "cd /Users/tommydoerr/dev/is-the-mountain-out && SID=\"${var.session_id}\" && if [ -z \"$SID\" ]; then SID=\"manual-$(date +%s)\"; fi && uv run collect once --session-id $SID"
         ]
       }
 

--- a/mountain-capture/scripts/capture_now.py
+++ b/mountain-capture/scripts/capture_now.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+def trigger_capture():
+    """Triggers a single capture by running the 'mountain-capture-single' Nomad job."""
+    hcl_path = Path("nomad/once.hcl")
+    if not hcl_path.exists():
+        print(f"Error: {hcl_path} not found.")
+        sys.exit(1)
+
+    print(f"Submitting Nomad job: {hcl_path}...")
+    try:
+        # Run nomad job run and capture output
+        result = subprocess.run(
+            ["nomad", "job", "run", str(hcl_path)],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        print("Nomad job submitted successfully.")
+        
+        # Extract the Eval ID from output
+        # e.g. "==> 2026-03-17T01:30:00-07:00: Monitoring evaluation \"abcdef12\""
+        for line in result.stdout.splitlines():
+            if "Monitoring evaluation" in line:
+                eval_id = line.split()[-1].strip('"')
+                print(f"Evaluation ID: {eval_id}")
+                break
+        
+        print("Capture in progress via Nomad (batch job)...")
+    except subprocess.CalledProcessError as e:
+        print(f"Error submitting Nomad job:\n{e.stderr}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    trigger_capture()

--- a/mountain-capture/scripts/capture_now.py
+++ b/mountain-capture/scripts/capture_now.py
@@ -1,29 +1,46 @@
 #!/usr/bin/env python3
 import subprocess
 import sys
-import time
+import argparse
+import uuid
 from pathlib import Path
 
-def trigger_capture():
-    """Triggers a single capture by running the 'mountain-capture-single' Nomad job."""
+def trigger_capture(session_id=None):
+    """Triggers a single capture by running a unique Nomad batch job."""
     hcl_path = Path("nomad/once.hcl")
+    if not hcl_path.exists():
+        # Check relative to script location
+        hcl_path = Path(__file__).parent.parent / "nomad" / "once.hcl"
+        
     if not hcl_path.exists():
         print(f"Error: {hcl_path} not found.")
         sys.exit(1)
 
-    print(f"Submitting Nomad job: {hcl_path}...")
+    unique_id = str(uuid.uuid4())[:8]
+    job_name = f"adhoc-{unique_id}"
+    
+    # Read HCL and replace job name
+    hcl_content = hcl_path.read_text()
+    hcl_content = hcl_content.replace('job "mountain-capture-single"', f'job "{job_name}"')
+
+    cmd = ["nomad", "job", "run"]
+    if session_id:
+        cmd.extend(["-var", f"session_id={session_id}"])
+    cmd.append("-") # Read from stdin
+
+    print(f"Submitting Nomad job {job_name}...")
     try:
         # Run nomad job run and capture output
         result = subprocess.run(
-            ["nomad", "job", "run", str(hcl_path)],
+            cmd,
+            input=hcl_content,
             capture_output=True,
             text=True,
             check=True
         )
-        print("Nomad job submitted successfully.")
+        print(f"Nomad job {job_name} submitted successfully.")
         
         # Extract the Eval ID from output
-        # e.g. "==> 2026-03-17T01:30:00-07:00: Monitoring evaluation \"abcdef12\""
         for line in result.stdout.splitlines():
             if "Monitoring evaluation" in line:
                 eval_id = line.split()[-1].strip('"')
@@ -36,4 +53,7 @@ def trigger_capture():
         sys.exit(1)
 
 if __name__ == "__main__":
-    trigger_capture()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--session-id", help="Session ID to use for this capture")
+    args = parser.parse_args()
+    trigger_capture(args.session_id)

--- a/mountain.toml
+++ b/mountain.toml
@@ -33,3 +33,8 @@ target_modules = ["fc1", "fc2"] # ConvNeXt Linear layers in MLP
 data_root = "data"
 collection_seconds = 600 # 10 minutes for collection service (interval-based)
 # schedule = { Minute = 0 } # Optional: Run every hour on the hour (calendar-based)
+
+[cloud]
+worker_url = "https://mountain-capture-worker.tommyroar.workers.dev"
+r2_bucket = "is-the-mountain-out-captures"
+enabled = false # Set to true to fetch state from cloud in tray icon

--- a/nomad-dev.hcl
+++ b/nomad-dev.hcl
@@ -1,5 +1,0 @@
-client {
-  options = {
-    "driver.raw_exec.enable" = "1"
-  }
-}

--- a/nomad/collect.hcl
+++ b/nomad/collect.hcl
@@ -1,0 +1,36 @@
+job "mountain-collector" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "collector" {
+    count = 1
+
+    restart {
+      attempts = 3
+      interval = "5m"
+      delay    = "25s"
+      mode     = "delay"
+    }
+
+    task "tray" {
+      driver = "raw_exec"
+
+      env {
+        PATH = "/Users/tommydoerr/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+      }
+
+      config {
+        command = "/bin/bash"
+        args    = [
+          "-c",
+          "export SESSION_ID=$(uuidgen | cut -c1-8) && cd /Users/tommydoerr/dev/is-the-mountain-out && uv run collect tray --config mountain.toml --session-id $SESSION_ID"
+        ]
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+  }
+}

--- a/nomad/once.hcl
+++ b/nomad/once.hcl
@@ -1,0 +1,29 @@
+job "mountain-capture-single" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  group "capture" {
+    count = 1
+    
+    task "run-once" {
+      driver = "raw_exec"
+
+      env {
+        PATH = "/Users/tommydoerr/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+      }
+
+      config {
+        command = "/bin/bash"
+        args    = [
+          "-c",
+          "cd /Users/tommydoerr/dev/is-the-mountain-out && export SESSION_ID=manual-$(date +%s) && uv run collect once --session-id $SESSION_ID"
+        ]
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+  }
+}

--- a/nomad/once.hcl
+++ b/nomad/once.hcl
@@ -1,3 +1,8 @@
+variable "session_id" {
+  type    = string
+  default = ""
+}
+
 job "mountain-capture-single" {
   datacenters = ["dc1"]
   type        = "batch"
@@ -16,7 +21,7 @@ job "mountain-capture-single" {
         command = "/bin/bash"
         args    = [
           "-c",
-          "cd /Users/tommydoerr/dev/is-the-mountain-out && export SESSION_ID=manual-$(date +%s) && uv run collect once --session-id $SESSION_ID"
+          "cd /Users/tommydoerr/dev/is-the-mountain-out && SID=\"${var.session_id}\" && if [ -z \"$SID\" ]; then SID=\"manual-$(date +%s)\"; fi && uv run collect once --session-id $SID"
         ]
       }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "typer>=0.24.0",
     "fastapi>=0.135.1",
     "uvicorn>=0.41.0",
-    "rumps>=0.4.0",
+    "rumps>=0.4.0; sys_platform == 'darwin'",
     "pillow>=12.1.1",
     "rich>=14.3.3",
 ]

--- a/tools/capture_now.py
+++ b/tools/capture_now.py
@@ -2,10 +2,11 @@
 import subprocess
 import sys
 import argparse
+import uuid
 from pathlib import Path
 
 def trigger_capture(session_id=None):
-    """Triggers a single capture by running the 'mountain-capture-single' Nomad job."""
+    """Triggers a single capture by running a unique Nomad batch job."""
     hcl_path = Path("nomad/once.hcl")
     if not hcl_path.exists():
         # Check relative to script location
@@ -15,21 +16,29 @@ def trigger_capture(session_id=None):
         print(f"Error: {hcl_path} not found.")
         sys.exit(1)
 
+    unique_id = str(uuid.uuid4())[:8]
+    job_name = f"adhoc-{unique_id}"
+    
+    # Read HCL and replace job name
+    hcl_content = hcl_path.read_text()
+    hcl_content = hcl_content.replace('job "mountain-capture-single"', f'job "{job_name}"')
+
     cmd = ["nomad", "job", "run"]
     if session_id:
         cmd.extend(["-var", f"session_id={session_id}"])
-    cmd.append(str(hcl_path))
+    cmd.append("-") # Read from stdin
 
-    print(f"Submitting Nomad job: {' '.join(cmd)}...")
+    print(f"Submitting Nomad job {job_name}...")
     try:
         # Run nomad job run and capture output
         result = subprocess.run(
             cmd,
+            input=hcl_content,
             capture_output=True,
             text=True,
             check=True
         )
-        print("Nomad job submitted successfully.")
+        print(f"Nomad job {job_name} submitted successfully.")
         
         # Extract the Eval ID from output
         for line in result.stdout.splitlines():

--- a/tools/capture_now.py
+++ b/tools/capture_now.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+def trigger_capture():
+    """Triggers a single capture by running the 'mountain-capture-single' Nomad job."""
+    hcl_path = Path("nomad/once.hcl")
+    if not hcl_path.exists():
+        print(f"Error: {hcl_path} not found.")
+        sys.exit(1)
+
+    print(f"Submitting Nomad job: {hcl_path}...")
+    try:
+        # Run nomad job run and capture output
+        result = subprocess.run(
+            ["nomad", "job", "run", str(hcl_path)],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        print("Nomad job submitted successfully.")
+        
+        # Extract the Eval ID from output
+        # e.g. "==> 2026-03-17T01:30:00-07:00: Monitoring evaluation \"abcdef12\""
+        for line in result.stdout.splitlines():
+            if "Monitoring evaluation" in line:
+                eval_id = line.split()[-1].strip('"')
+                print(f"Evaluation ID: {eval_id}")
+                break
+        
+        print("Capture in progress via Nomad (batch job)...")
+    except subprocess.CalledProcessError as e:
+        print(f"Error submitting Nomad job:\n{e.stderr}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    trigger_capture()

--- a/tools/capture_now.py
+++ b/tools/capture_now.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
 import subprocess
 import sys
-import time
+import argparse
 from pathlib import Path
 
-def trigger_capture():
+def trigger_capture(session_id=None):
     """Triggers a single capture by running the 'mountain-capture-single' Nomad job."""
     hcl_path = Path("nomad/once.hcl")
+    if not hcl_path.exists():
+        # Check relative to script location
+        hcl_path = Path(__file__).parent.parent / "nomad" / "once.hcl"
+        
     if not hcl_path.exists():
         print(f"Error: {hcl_path} not found.")
         sys.exit(1)
 
-    print(f"Submitting Nomad job: {hcl_path}...")
+    cmd = ["nomad", "job", "run"]
+    if session_id:
+        cmd.extend(["-var", f"session_id={session_id}"])
+    cmd.append(str(hcl_path))
+
+    print(f"Submitting Nomad job: {' '.join(cmd)}...")
     try:
         # Run nomad job run and capture output
         result = subprocess.run(
-            ["nomad", "job", "run", str(hcl_path)],
+            cmd,
             capture_output=True,
             text=True,
             check=True
@@ -23,7 +32,6 @@ def trigger_capture():
         print("Nomad job submitted successfully.")
         
         # Extract the Eval ID from output
-        # e.g. "==> 2026-03-17T01:30:00-07:00: Monitoring evaluation \"abcdef12\""
         for line in result.stdout.splitlines():
             if "Monitoring evaluation" in line:
                 eval_id = line.split()[-1].strip('"')
@@ -36,4 +44,7 @@ def trigger_capture():
         sys.exit(1)
 
 if __name__ == "__main__":
-    trigger_capture()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--session-id", help="Session ID to use for this capture")
+    args = parser.parse_args()
+    trigger_capture(args.session_id)

--- a/tools/classifier_server.py
+++ b/tools/classifier_server.py
@@ -35,6 +35,18 @@ def save_labels(labels):
     with open(LABELS_PATH, "w") as f:
         yaml.safe_dump(labels, f)
 
+@app.get("/api/jobs")
+def get_jobs():
+    """Proxy Nomad jobs for the UI."""
+    try:
+        nomad_url = os.environ.get("NOMAD_ADDR", "http://127.0.0.1:4646")
+        response = requests.get(f"{nomad_url}/v1/jobs", timeout=2)
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:
+        # Fallback if Nomad is unreachable
+        return []
+
 @app.get("/api/images")
 def get_images(batch_size: int = 20, offset: int = 0):
     labels = load_labels()

--- a/train/config_loader.py
+++ b/train/config_loader.py
@@ -58,3 +58,7 @@ class ConfigLoader:
     @property
     def mountain_data(self) -> Dict[str, Any]:
         return self.data.get('mountain', {})
+
+    @property
+    def cloud(self) -> Dict[str, Any]:
+        return self.data.get('cloud', {})

--- a/train/tests/test_model.py
+++ b/train/tests/test_model.py
@@ -16,7 +16,7 @@ def test_lora_initialization():
     
     # Check if peft wrapped the backbone
     from peft import PeftModel
-    assert isinstance(model_wrapper.model['backbone'], PeftModel)
+    assert isinstance(model_wrapper.model_dict['backbone'], PeftModel)
 
 def test_dual_input_batch_parameter_update():
     """Verify LoRA weights and classifier update after a batch training step."""
@@ -26,14 +26,14 @@ def test_dual_input_batch_parameter_update():
     
     # Get initial parameters
     initial_params = {}
-    for name, param in model_wrapper.model.named_parameters():
+    for name, param in model_wrapper.model_dict.named_parameters():
         initial_params[name] = param.clone().detach()
 
     # Create dummy image, weather tensor, and optimizer
     image_batch = torch.randn(batch_size, 3, 224, 224).to(device)
     weather_batch = torch.randn(batch_size, 2).to(device)
     label_batch = torch.randint(0, 2, (batch_size,)).to(device)
-    optimizer = optim.Adam(model_wrapper.model.parameters(), lr=0.001)
+    optimizer = optim.Adam(model_wrapper.model_dict.parameters(), lr=0.001)
     
     # Perform training step
     model_wrapper.train_step(image_batch, weather_batch, label_batch, optimizer)
@@ -42,7 +42,7 @@ def test_dual_input_batch_parameter_update():
     updated_lora = False
     updated_classifier = False
     
-    for name, param in model_wrapper.model.named_parameters():
+    for name, param in model_wrapper.model_dict.named_parameters():
         if 'lora_' in name:
             if not torch.equal(initial_params[name], param):
                 updated_lora = True
@@ -66,7 +66,7 @@ def test_checkpoint_save_load(tmp_path):
     model2.load_checkpoint(checkpoint_dir)
     
     # Verify parameters match
-    for (n1, p1), (n2, p2) in zip(model1.model.named_parameters(), model2.model.named_parameters()):
+    for (n1, p1), (n2, p2) in zip(model1.model_dict.named_parameters(), model2.model_dict.named_parameters()):
         if 'lora_' in n1 or 'classifier' in n1:
             assert torch.equal(p1, p2), f"Parameter {n1} does not match after loading"
 

--- a/train/tests/test_scheduler.py
+++ b/train/tests/test_scheduler.py
@@ -16,7 +16,7 @@ def test_trainer_initialization(mock_weather, mock_model_cls, mock_config):
     mock_config.return_value.checkpoint_dir = 'checkpoints'
     
     mock_model = MagicMock()
-    mock_model.model.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
+    mock_model.model_dict.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
     mock_model_cls.return_value = mock_model
     
     trainer = Trainer('mountain.toml')
@@ -38,10 +38,9 @@ def test_run_single_cycle_execution(mock_weather_cls, mock_webcam):
         
         with patch('train.scheduler.ConvNextLoRAModel') as mock_model_cls:
             mock_model = MagicMock()
-            mock_model.model.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
+            mock_model.model_dict.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
             mock_model.train_step.return_value = 0.5
-            mock_model_cls.return_value = mock_model
-            
+            mock_model_cls.return_value = mock_model            
             mock_weather = MagicMock()
             mock_weather_vector = torch.tensor([0.8, 0.9])
             mock_weather.get_weather_vector.return_value = mock_weather_vector
@@ -81,10 +80,9 @@ def test_live_training_loop_cycle(mock_sleep, mock_weather_cls, mock_webcam):
         
         with patch('train.scheduler.ConvNextLoRAModel') as mock_model_cls:
             mock_model = MagicMock()
-            mock_model.model.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
+            mock_model.model_dict.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
             mock_model.train_step.return_value = 0.5
-            mock_model_cls.return_value = mock_model
-            
+            mock_model_cls.return_value = mock_model            
             mock_weather = MagicMock()
             mock_weather_vector = torch.tensor([0.8, 0.9])
             mock_weather.get_weather_vector.return_value = mock_weather_vector

--- a/train/tray.py
+++ b/train/tray.py
@@ -23,12 +23,15 @@ def generate_progress_bar(completed: int, total: int, width: int = 10) -> str:
     empty = width - filled
     return "[" + "█" * filled + " " * empty + "]"
 
+SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
 class TrainingTray(rumps.App):
     def __init__(self, data_root: str = "data"):
-        super().__init__("Mountain Training", title="🏔️", quit_button=None)
+        super().__init__("Mountain Training", title="🗻", quit_button=None)
         self.data_root = Path(data_root).absolute()
         self.state_file = self.data_root / "training_state.json"
         self._last_state: Optional[Dict[str, Any]] = None
+        self._spinner_idx = 0
 
         # --- Static menu skeleton ---
         self.status_item       = rumps.MenuItem("Status: —")
@@ -62,7 +65,7 @@ class TrainingTray(rumps.App):
         state = self._read_state()
         if state is None:
             self.status_item.title = "Status: No training state found"
-            self.title = "🏔️"
+            self.title = "🗻"
             return
             
         # Check if state changed (or if it's running, we just update to spin the icon if needed)
@@ -76,14 +79,16 @@ class TrainingTray(rumps.App):
         status = state.get("status", "unknown")
         
         if status == "running":
-            # Simple spinner logic by toggling icon
-            self.title = "🌋" if self.title == "🏔️" else "🏔️"
+            # Simple spinner logic by cycling through braille frames
+            spinner = SPINNER[self._spinner_idx % len(SPINNER)]
+            self._spinner_idx += 1
+            self.title = f"🗻{spinner}"
             self.status_item.title = "Status: 🟢 Running"
         elif status == "complete":
-            self.title = "🏔️"
+            self.title = "🗻"
             self.status_item.title = "Status: ⚪️ Complete"
         else:
-            self.title = "🏔️"
+            self.title = "🗻"
             self.status_item.title = f"Status: {status}"
 
         # Epochs

--- a/train/tray.py
+++ b/train/tray.py
@@ -13,17 +13,8 @@ import rumps
 
 logger = logging.getLogger(__name__)
 
-REFRESH_INTERVAL = 2  # seconds between state file reads
+REFRESH_INTERVAL = 10  # seconds between state file reads
 
-def generate_progress_bar(completed: int, total: int, width: int = 10) -> str:
-    if total == 0:
-        return "[" + " " * width + "]"
-    fraction = completed / total
-    filled = int(fraction * width)
-    empty = width - filled
-    return "[" + "█" * filled + " " * empty + "]"
-
-SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
 class TrainingTray(rumps.App):
     def __init__(self, data_root: str = "data"):
@@ -31,15 +22,17 @@ class TrainingTray(rumps.App):
         self.data_root = Path(data_root).absolute()
         self.state_file = self.data_root / "training_state.json"
         self._last_state: Optional[Dict[str, Any]] = None
-        self._spinner_idx = 0
 
         # --- Static menu skeleton ---
+        self.progress_bar_item = rumps.MenuItem("—")
         self.status_item       = rumps.MenuItem("Status: —")
         self.epoch_item        = rumps.MenuItem("Epoch: —")
         self.batch_item        = rumps.MenuItem("Batch: —")
         self.loss_item         = rumps.MenuItem("Loss: —")
         
         self.menu = [
+            self.progress_bar_item,
+            rumps.separator,
             self.status_item,
             rumps.separator,
             self.epoch_item,
@@ -79,17 +72,21 @@ class TrainingTray(rumps.App):
         status = state.get("status", "unknown")
         
         if status == "running":
-            # Simple spinner logic by cycling through braille frames
-            spinner = SPINNER[self._spinner_idx % len(SPINNER)]
-            self._spinner_idx += 1
-            self.title = f"🗻{spinner}"
             self.status_item.title = "Status: 🟢 Running"
         elif status == "complete":
-            self.title = "🗻"
             self.status_item.title = "Status: ⚪️ Complete"
         else:
-            self.title = "🗻"
             self.status_item.title = f"Status: {status}"
+
+        # Progress bar (based on batches)
+        batches = state.get("batches_complete", 0)
+        total_batches = state.get("total_batches", 1) # Avoid div zero
+        pct = int(100 * batches / total_batches) if total_batches > 0 else 0
+        
+        bar_len = 20
+        filled_len = int(round(bar_len * pct / 100))
+        bar = "█" * filled_len + "░" * (bar_len - filled_len)
+        self.progress_bar_item.title = f"[{bar}] {pct}%"
 
         # Epochs
         epoch = state.get("epoch", 0)
@@ -97,10 +94,7 @@ class TrainingTray(rumps.App):
         self.epoch_item.title = f"Epoch: {epoch}/{total_epochs}"
         
         # Batches
-        batches = state.get("batches_complete", 0)
-        total_batches = state.get("total_batches", 0)
-        bar = generate_progress_bar(batches, total_batches)
-        self.batch_item.title = f"Batch: {bar} {batches}/{total_batches}"
+        self.batch_item.title = f"Batch: {batches}/{total_batches}"
         
         # Loss
         loss = state.get("current_loss", 0.0)

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,9 +21,28 @@ interface SelectionBox {
   currentY: number;
 }
 
+interface NomadJob {
+  ID: string;
+  Name: string;
+  Status: string;
+  Type: string;
+  SubmitTime: number;
+  JobSummary?: {
+    Summary: Record<string, {
+      Running: number;
+      Starting: number;
+      Queued: number;
+      Complete: number;
+      Failed: number;
+    }>;
+  };
+}
+
 function App() {
+  const [activeTab, setActiveTab] = useState<'labeling' | 'jobs'>('labeling')
   const [images, setImages] = useState<string[]>([])
   const [stats, setStats] = useState<Stats | null>(null)
+  const [jobs, setJobs] = useState<NomadJob[]>([])
   const [selections, setSelections] = useState<Record<string, number>>({})
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
   const [loading, setLoading] = useState(true)
@@ -99,15 +118,18 @@ function App() {
   const fetchData = useCallback(async (base = apiBase) => {
     setLoading(true)
     try {
-      const [imgRes, statsRes] = await Promise.all([
+      const [imgRes, statsRes, jobsRes] = await Promise.all([
         fetch(`${base}/api/images?batch_size=60`),
-        fetch(`${base}/api/stats`)
+        fetch(`${base}/api/stats`),
+        fetch(`${base}/api/jobs`)
       ])
       const imgData: ImageBatch = await imgRes.json()
       const statsData: Stats = await statsRes.json()
+      const jobsData: NomadJob[] = await jobsRes.json()
       
       setImages(imgData.images)
       setStats({ ...statsData, total_images: imgData.total_images })
+      setJobs(jobsData)
       setSelections({})
       setSelectedPaths(new Set())
     } catch (err) {
@@ -273,7 +295,22 @@ function App() {
                 </span>
               </div>
 
-              {stats && (
+              <div className="flex bg-black/40 rounded-xl p-1 border border-zinc-800/50">
+                <button 
+                  onClick={() => setActiveTab('labeling')}
+                  className={`px-4 py-1.5 rounded-lg text-xs font-bold transition-all ${activeTab === 'labeling' ? 'bg-zinc-800 text-white shadow-lg' : 'text-zinc-500 hover:text-zinc-300'}`}
+                >
+                  Labels
+                </button>
+                <button 
+                  onClick={() => setActiveTab('jobs')}
+                  className={`px-4 py-1.5 rounded-lg text-xs font-bold transition-all ${activeTab === 'jobs' ? 'bg-zinc-800 text-white shadow-lg' : 'text-zinc-500 hover:text-zinc-300'}`}
+                >
+                  Jobs
+                </button>
+              </div>
+
+              {stats && activeTab === 'labeling' && (
                 <div className="flex gap-4 items-center bg-black/40 px-4 py-2 rounded-xl border border-zinc-800/50">
                   <div className="flex flex-col items-center px-3 border-r border-zinc-800">
                     <span className="text-[9px] text-zinc-500 uppercase font-black">Progress</span>
@@ -312,7 +349,7 @@ function App() {
     />
   </div>
 
-  <div className={`flex gap-2 transition-all duration-300 ${selectedPaths.size > 0 ? 'opacity-100 scale-100' : 'opacity-0 scale-95 pointer-events-none'}`}>
+  <div className={`flex gap-2 transition-all duration-300 ${activeTab === 'labeling' && selectedPaths.size > 0 ? 'opacity-100 scale-100' : 'opacity-0 scale-95 pointer-events-none'}`}>
 
                 <button onClick={() => applyBulkLabel(1)} className="bg-green-600 hover:bg-green-500 text-white px-4 py-2 rounded-lg font-bold text-xs flex items-center gap-2 transition-colors">
                   <Mountain size={14} /> FULL <kbd className="opacity-50 bg-black/20 px-1 rounded text-[10px]">1</kbd>
@@ -327,14 +364,16 @@ function App() {
               
               <div className="w-px h-8 bg-zinc-800 mx-2" />
 
-              <button
-                onClick={handleSubmit}
-                disabled={submitting || images.length === 0}
-                className="bg-blue-600 hover:bg-blue-500 disabled:bg-zinc-800 text-white px-6 py-2 rounded-lg font-bold text-sm flex items-center gap-2 shadow-lg transition-all active:scale-95"
-              >
-                {submitting ? <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" /> : <CheckCircle2 size={18} />}
-                SUBMIT BATCH <kbd className="opacity-50 bg-black/20 px-1 rounded text-[10px]">SPACE</kbd>
-              </button>
+              {activeTab === 'labeling' && (
+                <button
+                  onClick={handleSubmit}
+                  disabled={submitting || images.length === 0}
+                  className="bg-blue-600 hover:bg-blue-500 disabled:bg-zinc-800 text-white px-6 py-2 rounded-lg font-bold text-sm flex items-center gap-2 shadow-lg transition-all active:scale-95"
+                >
+                  {submitting ? <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" /> : <CheckCircle2 size={18} />}
+                  SUBMIT BATCH <kbd className="opacity-50 bg-black/20 px-1 rounded text-[10px]">SPACE</kbd>
+                </button>
+              )}
             </div>
           </div>
         </div>
@@ -354,7 +393,56 @@ function App() {
 
 
       <main className="p-4 pt-8 max-w-[1900px] mx-auto min-h-screen">
-        {images.length === 0 ? (
+        {activeTab === 'jobs' ? (
+          <div className="flex flex-col gap-6">
+            <h2 className="text-3xl font-black italic tracking-tighter uppercase flex items-center gap-3">
+              <HardDrive className="text-blue-500" size={32} />
+              Nomad Jobs
+            </h2>
+            <div className="grid gap-4">
+              {jobs.map(job => (
+                <div key={job.ID} className="bg-zinc-900 border border-zinc-800 rounded-2xl p-6 hover:border-zinc-700 transition-colors">
+                  <div className="flex items-center justify-between mb-4">
+                    <div className="flex items-center gap-4">
+                      <div className={`w-3 h-3 rounded-full ${job.Status === 'running' ? 'bg-green-500 animate-pulse' : 'bg-zinc-600'}`} />
+                      <h3 className="text-xl font-bold tracking-tight">{job.ID}</h3>
+                      <span className="text-[10px] bg-zinc-800 px-2 py-1 rounded-md font-black uppercase text-zinc-400 tracking-widest">{job.Type}</span>
+                    </div>
+                    <span className="text-xs font-mono text-zinc-500">{new Date(job.SubmitTime / 1000000).toLocaleString()}</span>
+                  </div>
+                  
+                  <div className="grid grid-cols-4 gap-4">
+                    {job.JobSummary && Object.entries(job.JobSummary.Summary).map(([task, counts]) => (
+                      <div key={task} className="bg-black/40 rounded-xl p-4 border border-zinc-800/50">
+                        <span className="text-[10px] text-zinc-500 font-black uppercase tracking-widest block mb-2">{task}</span>
+                        <div className="flex gap-4">
+                          <div className="flex flex-col">
+                            <span className="text-green-500 font-bold text-lg leading-none">{counts.Running}</span>
+                            <span className="text-[8px] text-zinc-500 uppercase font-bold mt-1">Run</span>
+                          </div>
+                          <div className="flex flex-col">
+                            <span className="text-blue-500 font-bold text-lg leading-none">{counts.Queued + counts.Starting}</span>
+                            <span className="text-[8px] text-zinc-500 uppercase font-bold mt-1">Wait</span>
+                          </div>
+                          <div className="flex flex-col">
+                            <span className="text-zinc-400 font-bold text-lg leading-none">{counts.Complete}</span>
+                            <span className="text-[8px] text-zinc-500 uppercase font-bold mt-1">Done</span>
+                          </div>
+                          {counts.Failed > 0 && (
+                            <div className="flex flex-col">
+                              <span className="text-red-500 font-bold text-lg leading-none">{counts.Failed}</span>
+                              <span className="text-[8px] text-zinc-500 uppercase font-bold mt-1">Fail</span>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : images.length === 0 ? (
           <div className="flex flex-col items-center justify-center min-h-[80vh] text-center">
             <CheckCircle2 className="text-green-500 mb-6 animate-bounce" size={120} />
             <h2 className="text-5xl font-black text-zinc-100 uppercase tracking-tighter italic">Dataset Complete</h2>

--- a/uv.lock
+++ b/uv.lock
@@ -1122,7 +1122,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
-    { name = "rumps" },
+    { name = "rumps", marker = "sys_platform == 'darwin'" },
     { name = "timm" },
     { name = "tomli" },
     { name = "torch" },
@@ -1158,7 +1158,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=14.3.3" },
-    { name = "rumps", specifier = ">=0.4.0" },
+    { name = "rumps", marker = "sys_platform == 'darwin'", specifier = ">=0.4.0" },
     { name = "timm", specifier = ">=1.0.24" },
     { name = "tomli", specifier = ">=2.4.0" },
     { name = "torch", specifier = ">=2.10.0" },
@@ -1801,7 +1801,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -2080,7 +2080,7 @@ name = "rumps"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/e2/2e6a47951290bd1a2831dcc50aec4b25d104c0cf00e8b7868cbd29cf3bfe/rumps-0.4.0.tar.gz", hash = "sha256:17fb33c21b54b1e25db0d71d1d793dc19dc3c0b7d8c79dc6d833d0cffc8b1596", size = 39257, upload-time = "2022-10-15T05:15:10.386Z" }
 


### PR DESCRIPTION
### Isolated Multi-Tray Nomad Captures

This PR introduces isolated state management for Nomad-managed capture jobs, allowing multiple collectors (persistent and ad-hoc) to run simultaneously with independent tray icons.

**Key Changes:**
- **State Isolation:** Transitioned from a single `collector_state.json` to session-specific files (`collector_state_{session_id}.json`).
- **Multi-Tray Support:** `MountainTray` now uniquely identifies its state file and menu title using the `session_id`.
- **Ad-Hoc Additions:** Added a "Capture additional image" option to the tray menu, which triggers an instant Nomad batch capture.
- **Nomad Templates:** Included `nomad/once.hcl` for single batch captures.
- **Skill Updates:** Updated the local `mountain-capture` skill with expert guidance for these new workflows.

**Verification:**
- Updated and passed all tests in `collect/tests/test_tray.py`.
- Verified isolation by running a persistent job alongside a manual Nomad capture.