### PR TITLE
Add Cloudflare R2 storage backend with local caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,7 @@ openjd_rfcs.md
 *.tfstate
 *.tfstate.backup
 *.tfvars
+terraform/r2_credentials.env
+
+# R2 local cache
+.r2cache/

--- a/collect/collector.py
+++ b/collect/collector.py
@@ -92,32 +92,34 @@ def log_event(event: str, status: str, metadata: Optional[Dict] = None):
     with open(log_path, "a") as f:
         f.write(json.dumps(entry) + "\n")
 
-def perform_capture(config_loader: ConfigLoader, weather_fetcher: WeatherFetcher, data_root: str, session_uuid: Optional[str] = None, step_info: Optional[Dict] = None) -> Optional[Path]:
+def perform_capture(config_loader: ConfigLoader, weather_fetcher: WeatherFetcher, data_root: str, session_uuid: Optional[str] = None, step_info: Optional[Dict] = None, remote_storage=None) -> Optional[Path]:
     now_utc = datetime.now(UTC)
     date_str = now_utc.strftime("%Y%m%d")
     time_str = now_utc.strftime("%H%M%S_%f_UTC")
-    
+
     capture_dir = Path(data_root) / date_str / time_str
     image_dir = capture_dir / "images"
     metar_dir = capture_dir / "metar"
-    
+
     image_dir.mkdir(parents=True, exist_ok=True)
     metar_dir.mkdir(parents=True, exist_ok=True)
-    
+
     logging.info(f"Starting collection into {capture_dir}...")
-    
+
     metar_text = weather_fetcher.fetch_latest_metar()
     if metar_text:
-        (metar_dir / "metar.txt").write_text(metar_text)
+        metar_path = metar_dir / "metar.txt"
+        metar_path.write_text(metar_text)
         logging.info("METAR data saved.")
     else:
+        metar_path = None
         logging.warning("METAR capture failed.")
 
     source = config_loader.webcam_url
     if not source:
         logging.error("No webcam source configured.")
         return False
-        
+
     stream = WebcamStream(source)
     try:
         frame = stream.capture_raw()
@@ -127,12 +129,31 @@ def perform_capture(config_loader: ConfigLoader, weather_fetcher: WeatherFetcher
             image_path = image_dir / filename
             cv2.imwrite(str(image_path), frame)
             logging.info(f"Source {source}: Saved as {filename}")
+
+            # Upload to R2 if a remote storage backend is provided
+            if remote_storage is not None:
+                _upload_to_remote(remote_storage, data_root, image_path, frame, metar_path, metar_text)
+
             return image_path
         else:
             logging.warning(f"Source {source}: Capture failed.")
             return None
     finally:
         stream.release()
+
+
+def _upload_to_remote(storage, data_root: str, image_path: Path, frame, metar_path: Optional[Path], metar_text: Optional[str]) -> None:
+    """Best-effort upload of a capture to the remote storage backend."""
+    try:
+        root = Path(data_root)
+        # Encode the frame as JPEG bytes
+        _, buf = cv2.imencode(".jpg", frame)
+        storage.put(str(image_path.relative_to(root)), buf.tobytes())
+        if metar_text and metar_path:
+            storage.put_text(str(metar_path.relative_to(root)), metar_text)
+        logging.info("R2 upload complete.")
+    except Exception as e:
+        logging.warning(f"R2 upload failed (non-fatal): {e}")
 
 # --- CLI using Click ---
 
@@ -154,6 +175,17 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
     config_loader = ConfigLoader(config_path)
     weather_fetcher = WeatherFetcher(config_loader.metar_station)
     fallback_interval = config_loader.collection_seconds
+
+    # Optional remote storage for R2 uploads
+    remote_storage = None
+    if config_loader.storage_backend == "r2":
+        try:
+            from collect.storage import R2Storage
+            cfg = config_loader.storage_config
+            remote_storage = R2Storage(account_id=cfg["r2_account_id"], bucket=cfg["r2_bucket"])
+            logging.info(f"R2 upload enabled: {cfg['r2_bucket']}")
+        except Exception as e:
+            logging.warning(f"R2 storage init failed, continuing local-only: {e}")
 
     # Load plan if one exists
     all_plan_timestamps = read_plan(data_root) or []
@@ -236,7 +268,7 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
                 final_capture_at=plan_final_capture_at,
             ))
 
-            image_path = perform_capture(config_loader, weather_fetcher, data_root, session_uuid=session_id)
+            image_path = perform_capture(config_loader, weather_fetcher, data_root, session_uuid=session_id, remote_storage=remote_storage)
 
             if image_path:
                 capture_count += 1
@@ -289,7 +321,7 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
                     final_capture_at=plan_final_capture_at,
                 ))
                 
-                image_path = perform_capture(config_loader, weather_fetcher, data_root, session_uuid=session_id)
+                image_path = perform_capture(config_loader, weather_fetcher, data_root, session_uuid=session_id, remote_storage=remote_storage)
                 if image_path:
                     capture_count += 1
                     last_capture_at = datetime.now(timezone.utc).isoformat()
@@ -389,14 +421,27 @@ def live(config: str, data_root: str):
     config_loader = ConfigLoader(config)
     weather_fetcher = WeatherFetcher(config_loader.metar_station)
     interval = config_loader.collection_seconds
-    
+
+    remote_storage = None
+    if config_loader.storage_backend == "r2":
+        try:
+            from collect.storage import R2Storage
+            cfg = config_loader.storage_config
+            remote_storage = R2Storage(account_id=cfg["r2_account_id"], bucket=cfg["r2_bucket"])
+            logging.info(f"R2 upload enabled: {cfg['r2_bucket']}")
+        except Exception as e:
+            logging.warning(f"R2 storage init failed, continuing local-only: {e}")
+
     logging.info(f"Starting live collection loop (interval: {interval}s). Press Ctrl+C to stop.")
     try:
         while True:
-            perform_capture(config_loader, weather_fetcher, data_root, session_uuid=session_id)
+            perform_capture(config_loader, weather_fetcher, data_root, session_uuid=session_id, remote_storage=remote_storage)
             time.sleep(interval)
     except KeyboardInterrupt:
         logging.info("Stopping live collection.")
+
+from collect.sync import sync
+cli.add_command(sync)
 
 if __name__ == "__main__":
     cli()

--- a/collect/storage.py
+++ b/collect/storage.py
@@ -1,0 +1,222 @@
+"""Storage backends for capture data, labels, and checkpoints.
+
+Provides a Protocol-based abstraction with three implementations:
+- LocalStorage: filesystem (default, backwards-compatible)
+- R2Storage: Cloudflare R2 via S3-compatible API (boto3)
+- CachedR2Storage: R2 with batched local disk cache for training
+"""
+
+import io
+import logging
+import os
+import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class StorageBackend(Protocol):
+    """Minimal storage interface shared by all backends."""
+
+    def put(self, key: str, data: bytes) -> None: ...
+    def get(self, key: str) -> bytes: ...
+    def put_text(self, key: str, text: str) -> None: ...
+    def get_text(self, key: str) -> str: ...
+    def list_keys(self, prefix: str = "") -> list[str]: ...
+    def exists(self, key: str) -> bool: ...
+
+
+class LocalStorage:
+    """Filesystem backend rooted at *data_root*. Keys are relative paths."""
+
+    def __init__(self, data_root: str):
+        self.root = Path(data_root)
+
+    def put(self, key: str, data: bytes) -> None:
+        p = self.root / key
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+
+    def get(self, key: str) -> bytes:
+        return (self.root / key).read_bytes()
+
+    def put_text(self, key: str, text: str) -> None:
+        p = self.root / key
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text)
+
+    def get_text(self, key: str) -> str:
+        return (self.root / key).read_text()
+
+    def list_keys(self, prefix: str = "") -> list[str]:
+        base = self.root / prefix
+        if not base.exists():
+            return []
+        return sorted(
+            str(p.relative_to(self.root))
+            for p in base.rglob("*")
+            if p.is_file()
+        )
+
+    def exists(self, key: str) -> bool:
+        return (self.root / key).exists()
+
+
+class R2Storage:
+    """Cloudflare R2 via the S3-compatible API (boto3).
+
+    Credentials are read from constructor args or environment variables:
+      R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY
+    """
+
+    def __init__(
+        self,
+        account_id: str,
+        bucket: str,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+    ):
+        import boto3
+        from botocore.config import Config as BotoConfig
+
+        self.bucket = bucket
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+            aws_access_key_id=access_key_id or os.environ["R2_ACCESS_KEY_ID"],
+            aws_secret_access_key=secret_access_key or os.environ["R2_SECRET_ACCESS_KEY"],
+            config=BotoConfig(
+                retries={"max_attempts": 3, "mode": "adaptive"},
+                signature_version="s3v4",
+            ),
+            region_name="auto",
+        )
+
+    def put(self, key: str, data: bytes) -> None:
+        self._client.put_object(Bucket=self.bucket, Key=key, Body=data)
+
+    def get(self, key: str) -> bytes:
+        resp = self._client.get_object(Bucket=self.bucket, Key=key)
+        return resp["Body"].read()
+
+    def put_text(self, key: str, text: str) -> None:
+        self.put(key, text.encode("utf-8"))
+
+    def get_text(self, key: str) -> str:
+        return self.get(key).decode("utf-8")
+
+    def list_keys(self, prefix: str = "") -> list[str]:
+        keys: list[str] = []
+        paginator = self._client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                keys.append(obj["Key"])
+        return keys
+
+    def exists(self, key: str) -> bool:
+        try:
+            self._client.head_object(Bucket=self.bucket, Key=key)
+            return True
+        except self._client.exceptions.ClientError:
+            return False
+
+    def presign(self, key: str, expires: int = 3600) -> str:
+        """Return a pre-signed GET URL valid for *expires* seconds."""
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket, "Key": key},
+            ExpiresIn=expires,
+        )
+
+
+class CachedR2Storage:
+    """Wraps R2Storage with a local disk cache for batched reads.
+
+    Usage for batch training:
+        cached = CachedR2Storage(r2, cache_dir=".r2cache")
+        cached.prefetch(list_of_keys)   # parallel download
+        data = cached.get(key)          # served from cache
+        cached.clear_cache()            # cleanup
+    """
+
+    def __init__(self, r2: R2Storage, cache_dir: str = ".r2cache"):
+        self.r2 = r2
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- Delegated writes go straight to R2 --
+
+    def put(self, key: str, data: bytes) -> None:
+        self.r2.put(key, data)
+
+    def put_text(self, key: str, text: str) -> None:
+        self.r2.put_text(key, text)
+
+    # -- Reads check cache first --
+
+    def get(self, key: str) -> bytes:
+        cached = self.cache_dir / key
+        if cached.exists():
+            return cached.read_bytes()
+        data = self.r2.get(key)
+        cached.parent.mkdir(parents=True, exist_ok=True)
+        cached.write_bytes(data)
+        return data
+
+    def get_text(self, key: str) -> str:
+        return self.get(key).decode("utf-8")
+
+    def list_keys(self, prefix: str = "") -> list[str]:
+        return self.r2.list_keys(prefix)
+
+    def exists(self, key: str) -> bool:
+        cached = self.cache_dir / key
+        return cached.exists() or self.r2.exists(key)
+
+    def presign(self, key: str, expires: int = 3600) -> str:
+        return self.r2.presign(key, expires)
+
+    # -- Batch operations --
+
+    def prefetch(self, keys: list[str], workers: int = 8) -> None:
+        """Download *keys* from R2 into the local cache in parallel.
+
+        Skips keys already present in cache.
+        """
+        to_fetch = [k for k in keys if not (self.cache_dir / k).exists()]
+        if not to_fetch:
+            logger.info("Cache is warm — nothing to prefetch.")
+            return
+        logger.info(f"Prefetching {len(to_fetch)} files from R2 ({len(keys) - len(to_fetch)} already cached)...")
+
+        def _download(key: str) -> str | None:
+            try:
+                data = self.r2.get(key)
+                dest = self.cache_dir / key
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(data)
+                return None
+            except Exception as e:
+                return f"{key}: {e}"
+
+        errors: list[str] = []
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {pool.submit(_download, k): k for k in to_fetch}
+            for fut in as_completed(futures):
+                err = fut.result()
+                if err:
+                    errors.append(err)
+
+        if errors:
+            logger.warning(f"Prefetch completed with {len(errors)} errors:\n  " + "\n  ".join(errors[:10]))
+        else:
+            logger.info(f"Prefetch complete: {len(to_fetch)} files downloaded.")
+
+    def clear_cache(self) -> None:
+        """Remove all cached files."""
+        if self.cache_dir.exists():
+            shutil.rmtree(self.cache_dir)
+            logger.info(f"Cache cleared: {self.cache_dir}")

--- a/collect/sync.py
+++ b/collect/sync.py
@@ -1,0 +1,139 @@
+"""CLI subcommands for syncing data between local filesystem and R2."""
+
+import click
+import yaml
+import logging
+from pathlib import Path
+
+from train.config_loader import ConfigLoader
+from collect.storage import LocalStorage, R2Storage
+
+logger = logging.getLogger(__name__)
+
+
+def _get_r2(config_path: str) -> R2Storage:
+    config = ConfigLoader(config_path)
+    if config.storage_backend != "r2":
+        raise click.ClickException("R2 storage is not configured. Add [storage] section to mountain.toml.")
+    cfg = config.storage_config
+    return R2Storage(account_id=cfg["r2_account_id"], bucket=cfg["r2_bucket"])
+
+
+@click.group()
+def sync():
+    """Sync data between local filesystem and Cloudflare R2."""
+    pass
+
+
+@sync.command()
+@click.option("--config", default="mountain.toml", help="Path to config file.")
+@click.option("--data-root", default="data", help="Local data root.")
+def push(config: str, data_root: str):
+    """Upload all local captures to R2 (skips files that already exist in R2)."""
+    logging.basicConfig(level=logging.INFO)
+    r2 = _get_r2(config)
+    local = LocalStorage(data_root)
+
+    all_keys = local.list_keys()
+    # Filter to capture data only (images + metar), skip state/config files
+    capture_keys = [k for k in all_keys if "/" in k and (k.endswith(".jpg") or k.endswith(".txt"))]
+
+    uploaded = 0
+    skipped = 0
+    for key in capture_keys:
+        if r2.exists(key):
+            skipped += 1
+            continue
+        try:
+            data = local.get(key)
+            r2.put(key, data)
+            uploaded += 1
+        except Exception as e:
+            logger.warning(f"Failed to upload {key}: {e}")
+
+    click.echo(f"Push complete: {uploaded} uploaded, {skipped} skipped (already in R2).")
+
+
+@sync.command()
+@click.option("--config", default="mountain.toml", help="Path to config file.")
+@click.option("--data-root", default="data", help="Local data root.")
+def pull(config: str, data_root: str):
+    """Download R2 captures to local filesystem (skips files that already exist locally)."""
+    logging.basicConfig(level=logging.INFO)
+    r2 = _get_r2(config)
+    local = LocalStorage(data_root)
+
+    all_keys = r2.list_keys()
+    # Filter to capture data only
+    capture_keys = [k for k in all_keys if "/" in k and (k.endswith(".jpg") or k.endswith(".txt"))]
+
+    downloaded = 0
+    skipped = 0
+    for key in capture_keys:
+        if local.exists(key):
+            skipped += 1
+            continue
+        try:
+            data = r2.get(key)
+            local.put(key, data)
+            downloaded += 1
+        except Exception as e:
+            logger.warning(f"Failed to download {key}: {e}")
+
+    click.echo(f"Pull complete: {downloaded} downloaded, {skipped} skipped (already local).")
+
+
+@sync.group()
+def labels():
+    """Sync labels.yaml between local and R2."""
+    pass
+
+
+@labels.command("push")
+@click.option("--config", default="mountain.toml", help="Path to config file.")
+@click.option("--data-root", default="data", help="Local data root.")
+def labels_push(config: str, data_root: str):
+    """Union-merge local labels.yaml into R2 (never deletes remote labels)."""
+    logging.basicConfig(level=logging.INFO)
+    r2 = _get_r2(config)
+
+    labels_path = Path(data_root) / "labels.yaml"
+    if not labels_path.exists():
+        raise click.ClickException(f"Local labels file not found: {labels_path}")
+
+    with open(labels_path, "r") as f:
+        local_labels = yaml.safe_load(f) or {}
+
+    # Merge with remote (union — local wins on conflict, remote keys preserved)
+    try:
+        remote_text = r2.get_text("labels.yaml")
+        remote_labels = yaml.safe_load(remote_text) or {}
+    except Exception:
+        remote_labels = {}
+
+    merged = {**remote_labels, **local_labels}
+    r2.put_text("labels.yaml", yaml.safe_dump(merged))
+
+    added = len(merged) - len(remote_labels)
+    click.echo(f"Labels pushed: {len(merged)} total ({added} new, {len(local_labels)} from local).")
+
+
+@labels.command("pull")
+@click.option("--config", default="mountain.toml", help="Path to config file.")
+@click.option("--data-root", default="data", help="Local data root.")
+def labels_pull(config: str, data_root: str):
+    """Overwrite local labels.yaml from R2 (R2 is source of truth)."""
+    logging.basicConfig(level=logging.INFO)
+    r2 = _get_r2(config)
+
+    try:
+        remote_text = r2.get_text("labels.yaml")
+    except Exception as e:
+        raise click.ClickException(f"Failed to read labels from R2: {e}")
+
+    labels_path = Path(data_root) / "labels.yaml"
+    labels_path.parent.mkdir(parents=True, exist_ok=True)
+    labels_path.write_text(remote_text)
+
+    remote_labels = yaml.safe_load(remote_text) or {}
+    click.echo(f"Labels pulled: {len(remote_labels)} labels written to {labels_path}.")

--- a/collect/tests/test_storage.py
+++ b/collect/tests/test_storage.py
@@ -1,0 +1,180 @@
+"""Tests for collect.storage backends."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+from collect.storage import LocalStorage, R2Storage, CachedR2Storage
+
+
+# ---------- LocalStorage ----------
+
+
+class TestLocalStorage:
+    def test_put_get_bytes(self, tmp_path):
+        store = LocalStorage(str(tmp_path))
+        store.put("a/b/file.bin", b"hello")
+        assert store.get("a/b/file.bin") == b"hello"
+
+    def test_put_text_get_text(self, tmp_path):
+        store = LocalStorage(str(tmp_path))
+        store.put_text("notes.txt", "world")
+        assert store.get_text("notes.txt") == "world"
+
+    def test_exists(self, tmp_path):
+        store = LocalStorage(str(tmp_path))
+        assert not store.exists("missing.txt")
+        store.put_text("present.txt", "x")
+        assert store.exists("present.txt")
+
+    def test_list_keys(self, tmp_path):
+        store = LocalStorage(str(tmp_path))
+        store.put_text("20260322/001/images/a.jpg", "img")
+        store.put_text("20260322/001/metar/metar.txt", "metar")
+        store.put_text("20260323/002/images/b.jpg", "img2")
+
+        keys = store.list_keys("20260322")
+        assert len(keys) == 2
+        assert "20260322/001/images/a.jpg" in keys
+        assert "20260322/001/metar/metar.txt" in keys
+
+    def test_list_keys_empty(self, tmp_path):
+        store = LocalStorage(str(tmp_path))
+        assert store.list_keys("nonexistent") == []
+
+    def test_creates_parent_dirs(self, tmp_path):
+        store = LocalStorage(str(tmp_path))
+        store.put("deep/nested/dir/file.bin", b"data")
+        assert (tmp_path / "deep" / "nested" / "dir" / "file.bin").exists()
+
+
+# ---------- R2Storage (mocked boto3) ----------
+
+
+class TestR2Storage:
+    @patch.dict("sys.modules", {"boto3": MagicMock(), "botocore": MagicMock(), "botocore.config": MagicMock()})
+    def test_init_from_env(self, monkeypatch):
+        import sys
+        mock_boto3 = sys.modules["boto3"]
+        monkeypatch.setenv("R2_ACCESS_KEY_ID", "test-key-id")
+        monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test-secret")
+
+        # Re-import to pick up mocked boto3
+        import importlib
+        import collect.storage
+        importlib.reload(collect.storage)
+
+        store = collect.storage.R2Storage(account_id="abc123", bucket="my-bucket")
+        mock_boto3.client.assert_called_once()
+        call_kwargs = mock_boto3.client.call_args
+        assert call_kwargs[1]["endpoint_url"] == "https://abc123.r2.cloudflarestorage.com"
+        assert call_kwargs[1]["aws_access_key_id"] == "test-key-id"
+        assert store.bucket == "my-bucket"
+
+    def test_put(self, monkeypatch):
+        mock_client = MagicMock()
+        store = R2Storage.__new__(R2Storage)
+        store.bucket = "b"
+        store._client = mock_client
+
+        store.put("key.jpg", b"data")
+        mock_client.put_object.assert_called_once_with(Bucket="b", Key="key.jpg", Body=b"data")
+
+    def test_get(self):
+        mock_client = MagicMock()
+        mock_client.get_object.return_value = {"Body": MagicMock(read=lambda: b"img-data")}
+        store = R2Storage.__new__(R2Storage)
+        store.bucket = "b"
+        store._client = mock_client
+
+        assert store.get("key.jpg") == b"img-data"
+
+    def test_put_text(self):
+        mock_client = MagicMock()
+        store = R2Storage.__new__(R2Storage)
+        store.bucket = "b"
+        store._client = mock_client
+
+        store.put_text("metar.txt", "KSEA 221153Z")
+        mock_client.put_object.assert_called_once_with(Bucket="b", Key="metar.txt", Body=b"KSEA 221153Z")
+
+    def test_presign(self):
+        mock_client = MagicMock()
+        mock_client.generate_presigned_url.return_value = "https://signed.url"
+        store = R2Storage.__new__(R2Storage)
+        store.bucket = "b"
+        store._client = mock_client
+
+        url = store.presign("img.jpg", expires=600)
+        assert url == "https://signed.url"
+
+    def test_list_keys(self):
+        mock_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {"Contents": [{"Key": "a.jpg"}, {"Key": "b.txt"}]},
+        ]
+        mock_client.get_paginator.return_value = paginator
+        store = R2Storage.__new__(R2Storage)
+        store.bucket = "b"
+        store._client = mock_client
+
+        keys = store.list_keys("prefix/")
+        assert keys == ["a.jpg", "b.txt"]
+
+
+# ---------- CachedR2Storage ----------
+
+
+class TestCachedR2Storage:
+    def test_get_caches_locally(self, tmp_path):
+        mock_r2 = MagicMock(spec=R2Storage)
+        mock_r2.get.return_value = b"image-bytes"
+
+        cached = CachedR2Storage(mock_r2, cache_dir=str(tmp_path / "cache"))
+        result = cached.get("20260322/img.jpg")
+        assert result == b"image-bytes"
+
+        # Second call should read from cache, not R2
+        result2 = cached.get("20260322/img.jpg")
+        assert result2 == b"image-bytes"
+        assert mock_r2.get.call_count == 1  # only called once
+
+    def test_prefetch_skips_cached(self, tmp_path):
+        mock_r2 = MagicMock(spec=R2Storage)
+        mock_r2.get.return_value = b"data"
+
+        cache_dir = tmp_path / "cache"
+        cached = CachedR2Storage(mock_r2, cache_dir=str(cache_dir))
+
+        # Pre-populate one file in cache
+        (cache_dir / "existing.jpg").parent.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "existing.jpg").write_bytes(b"cached")
+
+        cached.prefetch(["existing.jpg", "new.jpg"])
+
+        # Only "new.jpg" should be fetched from R2
+        mock_r2.get.assert_called_once_with("new.jpg")
+
+    def test_put_delegates_to_r2(self, tmp_path):
+        mock_r2 = MagicMock(spec=R2Storage)
+        cached = CachedR2Storage(mock_r2, cache_dir=str(tmp_path / "cache"))
+
+        cached.put("key", b"data")
+        mock_r2.put.assert_called_once_with("key", b"data")
+
+    def test_clear_cache(self, tmp_path):
+        mock_r2 = MagicMock(spec=R2Storage)
+        cache_dir = tmp_path / "cache"
+        cached = CachedR2Storage(mock_r2, cache_dir=str(cache_dir))
+        (cache_dir / "some_file").write_bytes(b"x")
+
+        cached.clear_cache()
+        assert not cache_dir.exists()
+
+    def test_presign_delegates(self, tmp_path):
+        mock_r2 = MagicMock(spec=R2Storage)
+        mock_r2.presign.return_value = "https://signed"
+        cached = CachedR2Storage(mock_r2, cache_dir=str(tmp_path / "cache"))
+
+        assert cached.presign("key") == "https://signed"

--- a/mountain.toml
+++ b/mountain.toml
@@ -33,3 +33,9 @@ target_modules = ["fc1", "fc2"] # ConvNeXt Linear layers in MLP
 data_root = "data"
 collection_seconds = 600 # 10 minutes for collection service (interval-based)
 # schedule = { Minute = 0 } # Optional: Run every hour on the hour (calendar-based)
+
+# [storage]
+# backend = "r2"                              # "local" (default) or "r2"
+# r2_account_id = "your-cloudflare-account-id"
+# r2_bucket = "is-the-mountain-out-captures"
+# cache_dir = ".r2cache"                      # local cache for batch training

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "astral>=3.2",
+    "boto3>=1.38.0",
     "ipython>=9.0.0",
     "ipywidgets>=8.1.5",
     "nbclassic>=1.2.0",

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -1,0 +1,68 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+# ---------- R2 Bucket ----------
+
+resource "cloudflare_r2_bucket" "captures" {
+  account_id = var.cloudflare_account_id
+  name       = "is-the-mountain-out-captures"
+  location   = "WNAM" # Western North America — closest to Seattle
+}
+
+# ---------- Permission groups data source ----------
+
+data "cloudflare_api_token_permission_groups" "all" {}
+
+# ---------- Scoped API token for R2 read/write ----------
+
+resource "cloudflare_api_token" "r2_rw" {
+  name = "mountain-r2-readwrite"
+
+  policy {
+    permission_groups = [
+      data.cloudflare_api_token_permission_groups.all.account["Workers R2 Storage Read"],
+      data.cloudflare_api_token_permission_groups.all.account["Workers R2 Storage Write"],
+    ]
+    resources = {
+      "com.cloudflare.api.account.${var.cloudflare_account_id}" = "*"
+    }
+  }
+}
+
+# ---------- S3-compatible credentials via Cloudflare API ----------
+# The Terraform provider lacks a native resource for R2 S3 API tokens,
+# so we create one via local-exec and write it to a .env file.
+
+resource "null_resource" "r2_s3_credentials" {
+  depends_on = [cloudflare_r2_bucket.captures]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      curl -sf -X POST \
+        "https://api.cloudflare.com/client/v4/accounts/${var.cloudflare_account_id}/r2/tokens" \
+        -H "Authorization: Bearer ${var.cloudflare_api_token}" \
+        -H "Content-Type: application/json" \
+        -d '${jsonencode({
+    name        = "mountain-s3-access"
+    permissions = ["object-read-write"]
+    buckets     = [cloudflare_r2_bucket.captures.name]
+})}' \
+        | jq -r '.result | "R2_ACCESS_KEY_ID=\(.id)\nR2_SECRET_ACCESS_KEY=\(.value)"' \
+        > "${path.module}/r2_credentials.env"
+    EOT
+}
+
+triggers = {
+  bucket = cloudflare_r2_bucket.captures.name
+}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "r2_bucket_name" {
+  description = "Name of the R2 bucket"
+  value       = cloudflare_r2_bucket.captures.name
+}
+
+output "r2_endpoint" {
+  description = "S3-compatible endpoint for boto3"
+  value       = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,10 @@
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token with R2 permissions"
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}

--- a/tools/classifier_server.py
+++ b/tools/classifier_server.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import yaml
 import json
 from pathlib import Path
@@ -8,6 +9,8 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from datetime import datetime, UTC
+
+from train.config_loader import ConfigLoader
 
 app = FastAPI(title="Mountain Classifier API")
 
@@ -22,10 +25,34 @@ app.add_middleware(
 DATA_ROOT = Path(os.environ.get("MOUNTAIN_DATA_ROOT", "data"))
 LABELS_PATH = Path(os.environ.get("MOUNTAIN_LABELS_FILE", DATA_ROOT / "labels.yaml"))
 
+# Optional R2 storage — initialized at module level for use by endpoints
+_r2_storage = None
+try:
+    _config = ConfigLoader(os.environ.get("MOUNTAIN_CONFIG", "mountain.toml"))
+    if _config.storage_backend == "r2":
+        from collect.storage import R2Storage
+        _cfg = _config.storage_config
+        _r2_storage = R2Storage(account_id=_cfg["r2_account_id"], bucket=_cfg["r2_bucket"])
+        logging.info(f"Classifier server: R2 storage enabled ({_cfg['r2_bucket']})")
+except Exception as e:
+    logging.info(f"Classifier server: R2 not configured, using local only ({e})")
+
+
 class LabelBatch(BaseModel):
     labels: Dict[str, int] # path -> label
 
 def load_labels():
+    # Pull from R2 if available (R2 is source of truth)
+    if _r2_storage is not None:
+        try:
+            remote_text = _r2_storage.get_text("labels.yaml")
+            remote_labels = yaml.safe_load(remote_text) or {}
+            # Also write to local as cache
+            with open(LABELS_PATH, "w") as f:
+                yaml.safe_dump(remote_labels, f)
+            return remote_labels
+        except Exception:
+            pass  # Fall through to local
     if LABELS_PATH.exists():
         with open(LABELS_PATH, "r") as f:
             return yaml.safe_load(f) or {}
@@ -34,6 +61,19 @@ def load_labels():
 def save_labels(labels):
     with open(LABELS_PATH, "w") as f:
         yaml.safe_dump(labels, f)
+    # Push to R2 (union merge: never delete keys)
+    if _r2_storage is not None:
+        try:
+            # Merge with remote to avoid overwriting labels added elsewhere
+            try:
+                remote_text = _r2_storage.get_text("labels.yaml")
+                remote_labels = yaml.safe_load(remote_text) or {}
+            except Exception:
+                remote_labels = {}
+            remote_labels.update(labels)
+            _r2_storage.put_text("labels.yaml", yaml.safe_dump(remote_labels))
+        except Exception as e:
+            logging.warning(f"Failed to push labels to R2: {e}")
 
 @app.get("/api/jobs")
 def get_jobs():
@@ -79,6 +119,25 @@ def post_labels(batch: LabelBatch):
     labels.update(batch.labels)
     save_labels(labels)
     return {"status": "success", "new_count": len(labels)}
+
+@app.get("/api/image-url/{path:path}")
+def get_image_url(path: str):
+    """Return a pre-signed R2 URL for direct browser access.
+
+    Falls back to the local /data/ static path when R2 is not configured.
+    """
+    if _r2_storage is not None:
+        try:
+            url = _r2_storage.presign(path, expires=3600)
+            return {"url": url, "source": "r2"}
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to generate pre-signed URL: {e}")
+    return {"url": f"/data/{path}", "source": "local"}
+
+@app.get("/api/storage-mode")
+def get_storage_mode():
+    """Report whether the server is using R2 or local storage."""
+    return {"backend": "r2" if _r2_storage is not None else "local"}
 
 # Serve the actual data directory for image access
 # Access via /data/YYYYMMDD/...

--- a/train/config_loader.py
+++ b/train/config_loader.py
@@ -5,7 +5,7 @@ class ConfigLoader:
     def __init__(self, config_path: str = "mountain.toml"):
         self.config_path = config_path
         self.data = self._load_toml_config(self.config_path)
-        
+
         self._validate_config()
 
     def _load_toml_config(self, path: str) -> Dict[str, Any]:
@@ -58,4 +58,35 @@ class ConfigLoader:
     @property
     def mountain_data(self) -> Dict[str, Any]:
         return self.data.get('mountain', {})
+
+    # -- Optional storage backend (R2) --
+
+    @property
+    def storage_backend(self) -> str:
+        """Return 'local' or 'r2'. Defaults to 'local' when [storage] is absent."""
+        return self.data.get('storage', {}).get('backend', 'local')
+
+    @property
+    def storage_config(self) -> Dict[str, Any]:
+        """Return the raw [storage] section, or empty dict."""
+        return self.data.get('storage', {})
+
+    def get_storage(self, data_root: str = "data"):
+        """Factory: return the appropriate StorageBackend based on config.
+
+        Returns LocalStorage when backend='local' or [storage] is absent.
+        Returns R2Storage (or CachedR2Storage) when backend='r2'.
+        """
+        from collect.storage import LocalStorage, R2Storage, CachedR2Storage
+
+        if self.storage_backend != "r2":
+            return LocalStorage(data_root)
+
+        cfg = self.storage_config
+        r2 = R2Storage(
+            account_id=cfg["r2_account_id"],
+            bucket=cfg["r2_bucket"],
+        )
+        cache_dir = cfg.get("cache_dir", ".r2cache")
+        return CachedR2Storage(r2, cache_dir=cache_dir)
 

--- a/train/model.py
+++ b/train/model.py
@@ -82,19 +82,56 @@ class ConvNextLoRAModel(nn.Module):
             _, predicted = torch.max(outputs, 1)
             return predicted
 
-    def save_checkpoint(self, checkpoint_dir: str):
-        """Saves LoRA adapters and classifier head."""
+    def save_checkpoint(self, checkpoint_dir: str, storage=None):
+        """Saves LoRA adapters and classifier head locally, then uploads to R2 if storage is provided."""
         os.makedirs(checkpoint_dir, exist_ok=True)
         self.model_dict['backbone'].save_pretrained(checkpoint_dir)
         torch.save(self.model_dict['classifier'].state_dict(), os.path.join(checkpoint_dir, "classifier.pt"))
         print(f"Checkpoint saved to {checkpoint_dir}")
 
-    def load_checkpoint(self, checkpoint_dir: str):
-        """Loads LoRA adapters and classifier head."""
+        if storage is not None:
+            self._upload_checkpoint(checkpoint_dir, storage)
+
+    def _upload_checkpoint(self, checkpoint_dir: str, storage):
+        """Upload checkpoint files to remote storage under checkpoints/ prefix."""
+        import logging
+        checkpoint_files = ["adapter_config.json", "adapter_model.safetensors", "classifier.pt"]
+        for fname in checkpoint_files:
+            local_path = os.path.join(checkpoint_dir, fname)
+            if os.path.exists(local_path):
+                try:
+                    with open(local_path, "rb") as f:
+                        storage.put(f"checkpoints/{fname}", f.read())
+                except Exception as e:
+                    logging.warning(f"Failed to upload {fname} to R2: {e}")
+        print("Checkpoints uploaded to R2.")
+
+    def load_checkpoint(self, checkpoint_dir: str, storage=None):
+        """Loads LoRA adapters and classifier head. Falls back to R2 if local is missing."""
         classifier_path = os.path.join(checkpoint_dir, "classifier.pt")
+
+        # Try downloading from R2 if local checkpoint doesn't exist
+        if storage is not None and not os.path.exists(classifier_path):
+            self._download_checkpoint(checkpoint_dir, storage)
+
         if os.path.exists(checkpoint_dir) and os.path.exists(classifier_path):
             self.model_dict['backbone'].load_adapter(checkpoint_dir, "default")
             self.model_dict['classifier'].load_state_dict(torch.load(classifier_path, map_location=self.device))
             print(f"Checkpoint loaded from {checkpoint_dir}")
             return True
         return False
+
+    def _download_checkpoint(self, checkpoint_dir: str, storage):
+        """Download checkpoint files from remote storage if available."""
+        import logging
+        os.makedirs(checkpoint_dir, exist_ok=True)
+        checkpoint_files = ["adapter_config.json", "adapter_model.safetensors", "classifier.pt"]
+        for fname in checkpoint_files:
+            try:
+                data = storage.get(f"checkpoints/{fname}")
+                with open(os.path.join(checkpoint_dir, fname), "wb") as f:
+                    f.write(data)
+            except Exception as e:
+                logging.info(f"Could not download {fname} from R2: {e}")
+                return  # If any file is missing, don't partially load
+        print(f"Checkpoints downloaded from R2 to {checkpoint_dir}")

--- a/train/scheduler.py
+++ b/train/scheduler.py
@@ -134,8 +134,12 @@ def batch(
     
     import yaml
     import cv2
+    import numpy as np
     from torchvision import transforms
     from metar import Metar
+
+    # Resolve storage backend (local or R2 with cache)
+    storage = trainer.config_loader.get_storage(str(data_root))
 
     # Strategy: Use labels.yaml if exists, otherwise fallback to folder-wide label
     labels_map = {}
@@ -181,9 +185,22 @@ def batch(
 
     print(f"Final training set size: {len(final_training_list)} samples.")
 
+    # Prefetch all needed files from R2 into local cache (no-op for LocalStorage)
+    from collect.storage import CachedR2Storage
+    if isinstance(storage, CachedR2Storage):
+        prefetch_keys = []
+        for rel_path, _ in final_training_list:
+            prefetch_keys.append(rel_path)
+            # Also add METAR file keys (try all fallback patterns)
+            img_p = Path(rel_path)
+            prefetch_keys.append(str(img_p.parent.parent / "metar" / f"{img_p.stem}.txt"))
+            prefetch_keys.append(str(img_p.parent.parent / "metar" / "metar.txt"))
+            prefetch_keys.append(str(img_p.parent / f"{img_p.stem}.txt"))
+        storage.prefetch(prefetch_keys)
+
     batch_size = 16
     total_batches = (len(final_training_list) + batch_size - 1) // batch_size
-    
+
     from torchvision import transforms
     transform = transforms.Compose([
         transforms.ToPILImage(),
@@ -216,18 +233,31 @@ def batch(
             batches_complete = 0
 
             for rel_path, img_label in final_training_list:
-                img_p = data_root / rel_path
-                metar_p = img_p.parent.parent / "metar" / f"{img_p.stem}.txt"
-                if not metar_p.exists(): metar_p = img_p.parent.parent / "metar" / "metar.txt"
-                if not metar_p.exists(): metar_p = img_p.parent / f"{img_p.stem}.txt"
-                if not metar_p.exists(): continue
+                # Resolve METAR key via fallback pattern
+                img_rel = Path(rel_path)
+                metar_candidates = [
+                    str(img_rel.parent.parent / "metar" / f"{img_rel.stem}.txt"),
+                    str(img_rel.parent.parent / "metar" / "metar.txt"),
+                    str(img_rel.parent / f"{img_rel.stem}.txt"),
+                ]
+                metar_key = None
+                for candidate in metar_candidates:
+                    if storage.exists(candidate):
+                        metar_key = candidate
+                        break
+                if metar_key is None:
+                    continue
 
-                frame = cv2.imread(str(img_p))
+                try:
+                    img_bytes = storage.get(rel_path)
+                except Exception:
+                    continue
+                frame = cv2.imdecode(np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR)
                 if frame is None: continue
                 frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                 tensor = transform(frame_rgb).to(trainer.device)
 
-                with open(metar_p, 'r') as f: metar_text = f.read().strip()
+                metar_text = storage.get_text(metar_key).strip()
                 vis, ceil = 0.0, 1.0
                 try:
                     obs = Metar.Metar(metar_text)
@@ -290,7 +320,12 @@ def batch(
             json.dump(state, f)
         state_file.with_suffix(".tmp").rename(state_file)
     
-    trainer.model_wrapper.save_checkpoint(trainer.config_loader.checkpoint_dir)
+    trainer.model_wrapper.save_checkpoint(trainer.config_loader.checkpoint_dir, storage=storage)
+
+    # Clean up R2 cache if used
+    if isinstance(storage, CachedR2Storage):
+        storage.clear_cache()
+
     print("\nTraining complete. Running final evaluation on the dataset...")
     import sys
     sys.path.append(str(Path.cwd()))

--- a/train/tests/test_config_r2.py
+++ b/train/tests/test_config_r2.py
@@ -1,0 +1,92 @@
+"""Tests for ConfigLoader storage properties and get_storage() factory."""
+
+import pytest
+import tomli_w
+from unittest.mock import patch, MagicMock
+from train.config_loader import ConfigLoader
+
+
+def _base_config():
+    """Minimal valid config without [storage]."""
+    return {
+        "mountain": {"name": "Mount Rainier", "height": 14411},
+        "webcam": {"url": "http://cam.jpg", "name": "Cam"},
+        "weather": {"station_id": "KSEA"},
+        "training": {
+            "schedule_seconds": 1800,
+            "capture_interval_seconds": 300,
+            "gradient_accumulation_steps": 4,
+            "checkpoint_dir": "checkpoints",
+            "lora": {"rank": 4, "alpha": 8, "target_modules": ["fc1"]},
+        },
+        "collection": {"collection_seconds": 600},
+    }
+
+
+def _write_config(tmp_path, data):
+    config_file = tmp_path / "mountain.toml"
+    config_file.write_bytes(tomli_w.dumps(data).encode())
+    return str(config_file)
+
+
+class TestStorageConfigDefaults:
+    def test_no_storage_section(self, tmp_path):
+        loader = ConfigLoader(_write_config(tmp_path, _base_config()))
+        assert loader.storage_backend == "local"
+        assert loader.storage_config == {}
+
+    def test_storage_local_explicit(self, tmp_path):
+        cfg = _base_config()
+        cfg["storage"] = {"backend": "local"}
+        loader = ConfigLoader(_write_config(tmp_path, cfg))
+        assert loader.storage_backend == "local"
+
+    def test_storage_r2(self, tmp_path):
+        cfg = _base_config()
+        cfg["storage"] = {
+            "backend": "r2",
+            "r2_account_id": "abc123",
+            "r2_bucket": "my-bucket",
+            "cache_dir": ".cache",
+        }
+        loader = ConfigLoader(_write_config(tmp_path, cfg))
+        assert loader.storage_backend == "r2"
+        assert loader.storage_config["r2_bucket"] == "my-bucket"
+        assert loader.storage_config["cache_dir"] == ".cache"
+
+
+class TestGetStorageFactory:
+    def test_local_default(self, tmp_path):
+        from collect.storage import LocalStorage
+
+        loader = ConfigLoader(_write_config(tmp_path, _base_config()))
+        storage = loader.get_storage(str(tmp_path / "data"))
+        assert isinstance(storage, LocalStorage)
+
+    @patch.dict("sys.modules", {"boto3": MagicMock(), "botocore": MagicMock(), "botocore.config": MagicMock()})
+    def test_r2_returns_cached(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("R2_ACCESS_KEY_ID", "k")
+        monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "s")
+
+        # Reload storage module so it picks up the mocked boto3
+        import importlib
+        import collect.storage
+        importlib.reload(collect.storage)
+        from collect.storage import CachedR2Storage
+
+        cfg = _base_config()
+        cfg["storage"] = {
+            "backend": "r2",
+            "r2_account_id": "abc123",
+            "r2_bucket": "test-bucket",
+        }
+        loader = ConfigLoader(_write_config(tmp_path, cfg))
+        storage = loader.get_storage(str(tmp_path / "data"))
+        assert isinstance(storage, CachedR2Storage)
+        assert storage.r2.bucket == "test-bucket"
+
+    def test_validation_still_passes_without_storage(self, tmp_path):
+        """[storage] is optional — validation should not require it."""
+        loader = ConfigLoader(_write_config(tmp_path, _base_config()))
+        # Should not raise
+        assert loader.webcam_url == "http://cam.jpg"


### PR DESCRIPTION
## Summary
This PR introduces a pluggable storage abstraction layer that enables the mountain classifier to store captures, labels, and checkpoints in Cloudflare R2 (S3-compatible object storage) instead of just the local filesystem. A `CachedR2Storage` wrapper provides transparent local disk caching for efficient batch training workflows.

## Key Changes

### Storage Abstraction (`collect/storage.py`)
- **`StorageBackend` Protocol**: Minimal interface defining `put`, `get`, `put_text`, `get_text`, `list_keys`, and `exists` methods
- **`LocalStorage`**: Filesystem implementation (default, backwards-compatible)
- **`R2Storage`**: Cloudflare R2 via boto3 S3-compatible API with:
  - Automatic credential resolution from environment variables (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`)
  - Pre-signed URL generation for direct browser access
  - Paginated listing support
- **`CachedR2Storage`**: Wraps R2 with local disk cache for training:
  - Transparent read-through caching
  - `prefetch()` method for parallel batch downloads with progress logging
  - `clear_cache()` for cleanup
  - Write-through delegation to R2

### Configuration (`train/config_loader.py`)
- Added `storage_backend` property (defaults to `'local'`)
- Added `storage_config` property for raw `[storage]` section
- Added `get_storage()` factory method that instantiates the appropriate backend based on config

### CLI Sync Tools (`collect/sync.py`)
- `sync push`: Upload local captures to R2 (skips existing files)
- `sync pull`: Download R2 captures to local filesystem
- `sync labels push`: Union-merge local `labels.yaml` into R2 (never deletes remote labels)
- `sync labels pull`: Overwrite local `labels.yaml` from R2 (R2 as source of truth)

### Integration Points
- **`collect/collector.py`**: `perform_capture()` now accepts optional `remote_storage` parameter; uploads images and METAR data to R2 immediately after capture
- **`train/scheduler.py`**: Prefetches all training data from R2 cache before batch training; resolves image/METAR paths via storage backend
- **`train/model.py`**: `save_checkpoint()` and `load_checkpoint()` now support optional `storage` parameter for R2 uploads/downloads
- **`tools/classifier_server.py`**: Labels endpoint now syncs with R2 (pull on read, union-merge push on write); added `/api/image-url/{path}` endpoint for pre-signed R2 URLs

### Infrastructure (`terraform/`)
- **`cloudflare.tf`**: Terraform resources for R2 bucket creation, scoped API token generation, and S3-compatible credentials provisioning
- **`variables.tf`** and **`outputs.tf`**: Configuration and outputs for Cloudflare account setup

### Configuration Example (`mountain.toml`)
```toml
[storage]
backend = "r2"
r2_account_id = "abc123"
r2_bucket = "is-the-mountain-out-captures"
cache_dir = ".r2cache"  # optional, defaults to .r2cache
```

## Notable Implementation Details
- **Backwards Compatible**: Absence of `[storage]` section defaults to local filesystem
- **Lazy Imports**: boto3 only imported when R2Storage is instantiated, avoiding hard dependency for local-only deployments
- **Error Resilience**: Capture and training workflows continue even if R2 operations fail (logged as warnings)
- **Union-Merge Labels**: Labels syncing never deletes remote entries, allowing concurrent labeling across multiple clients
- **Prefetch Optimization**: `CachedR2Storage.prefetch()` uses ThreadPoolExecutor for parallel downloads and skips files already in cache
- **Terraform Credentials**: S3 API tokens created via Cloudflare API and written to `terraform/r2_credentials.env` (git-ignored)

https://claude.ai/code/session_01RgWJGCsPH4kz6LgaXFmnZF