### PR TITLE
fix(ci): use npm install to survive cross-platform lockfile drift

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -68,7 +68,7 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Install web dependencies
-        run: npm ci
+        run: npm install --no-audit --no-fund
         working-directory: web
 
       - name: Build SPA


### PR DESCRIPTION
## Summary
- The first scheduled/manual run of \`update.yml\` failed at \`npm ci\` on the Linux runner because the macOS-generated \`package-lock.json\` is missing \`@emnapi/core\` and \`@emnapi/runtime\` entries required by \`@tailwindcss/oxide\`'s linux-x64 native binding.
- Switch the SPA install step to \`npm install --no-audit --no-fund\` so the workflow tolerates platform-specific lockfile drift. A ~3-file SPA doesn't need \`npm ci\`'s extra determinism guarantees.

## Test plan
- [ ] After merge, trigger \`update\` via \`workflow_dispatch\`; install step should succeed and \`actions/deploy-pages\` should publish.
- [ ] Visit the live URL and confirm hero + fresh timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)