### PR TITLE
Migrate training data to Cloudflare R2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,7 @@ __pycache__/
 mapbox.key
 ntfy.key
 openjd_rfcs.md
+cf.env
 
 # Terraform state (contains sensitive data)
 *.tfstate

--- a/collect/storage.py
+++ b/collect/storage.py
@@ -27,6 +27,7 @@ class StorageBackend(Protocol):
     def get_text(self, key: str) -> str: ...
     def list_keys(self, prefix: str = "") -> list[str]: ...
     def exists(self, key: str) -> bool: ...
+    def delete(self, key: str) -> None: ...
 
 
 class LocalStorage:
@@ -63,6 +64,9 @@ class LocalStorage:
 
     def exists(self, key: str) -> bool:
         return (self.root / key).exists()
+
+    def delete(self, key: str) -> None:
+        (self.root / key).unlink(missing_ok=True)
 
 
 class R2Storage:
@@ -123,6 +127,9 @@ class R2Storage:
         except self._client.exceptions.ClientError:
             return False
 
+    def delete(self, key: str) -> None:
+        self._client.delete_object(Bucket=self.bucket, Key=key)
+
     def presign(self, key: str, expires: int = 3600) -> str:
         """Return a pre-signed GET URL valid for *expires* seconds."""
         return self._client.generate_presigned_url(
@@ -175,6 +182,12 @@ class CachedR2Storage:
     def exists(self, key: str) -> bool:
         cached = self.cache_dir / key
         return cached.exists() or self.r2.exists(key)
+
+    def delete(self, key: str) -> None:
+        cached = self.cache_dir / key
+        if cached.exists():
+            cached.unlink()
+        self.r2.delete(key)
 
     def presign(self, key: str, expires: int = 3600) -> str:
         return self.r2.presign(key, expires)

--- a/mountain.toml
+++ b/mountain.toml
@@ -34,8 +34,8 @@ data_root = "data"
 collection_seconds = 600 # 10 minutes for collection service (interval-based)
 # schedule = { Minute = 0 } # Optional: Run every hour on the hour (calendar-based)
 
-# [storage]
-# backend = "r2"                              # "local" (default) or "r2"
-# r2_account_id = "your-cloudflare-account-id"
-# r2_bucket = "is-the-mountain-out-captures"
-# cache_dir = ".r2cache"                      # local cache for batch training
+[storage]
+backend = "r2"
+r2_account_id = "d7adee58513c1b2f770ccaac90cf114f"
+r2_bucket = "is-the-mountain-out"
+cache_dir = ".r2cache"

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -33,21 +33,19 @@ sys.path.append(str(Path.cwd()))
 from train.model import ConvNextLoRAModel
 from train.config_loader import ConfigLoader
 
-def get_metar_vector(img_path):
-    # ... (rest of function unchanged)
-    # Search for metar.txt
-    search_paths = [
-        img_path.parent.parent / "metar" / "metar.txt",
-        img_path.parent / "metar.txt",
-        img_path.parent / f"{img_path.stem}.txt"
+def get_metar_vector(storage, img_key: str):
+    img_rel = Path(img_key)
+    candidates = [
+        str(img_rel.parent.parent / "metar" / "metar.txt"),
+        str(img_rel.parent / "metar.txt"),
+        str(img_rel.parent / f"{img_rel.stem}.txt"),
     ]
     metar_text = None
-    for p in search_paths:
-        if p.exists():
-            with open(p, 'r') as f:
-                metar_text = f.read().strip()
+    for c in candidates:
+        if storage.exists(c):
+            metar_text = storage.get_text(c).strip()
             break
-    
+
     vis, ceil = 0.0, 1.0 # Default bad
     if metar_text:
         try:
@@ -59,7 +57,7 @@ def get_metar_vector(img_path):
         except: pass
     return [vis, ceil]
 
-def run_experiment(variant_name, data_list, folds=3):
+def run_experiment(variant_name, data_list, storage, folds=3):
     print(f"\n🚀 Starting Experiment: {variant_name}", flush=True)
     
     kf = StratifiedKFold(n_splits=folds, shuffle=True, random_state=42)
@@ -111,7 +109,11 @@ def run_experiment(variant_name, data_list, folds=3):
                 
                 imgs, weathers, lbls = [], [], []
                 for item in batch:
-                    img = cv2.imread(str(item['abs_path']))
+                    try:
+                        img_bytes = storage.get(item['path'])
+                    except Exception:
+                        continue
+                    img = cv2.imdecode(np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR)
                     if img is None: continue
                     img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
                     imgs.append(transform(img))
@@ -140,7 +142,11 @@ def run_experiment(variant_name, data_list, folds=3):
         with torch.no_grad():
             for i in val_idx:
                 item = data_list[i]
-                img = cv2.imread(str(item['abs_path']))
+                try:
+                    img_bytes = storage.get(item['path'])
+                except Exception:
+                    continue
+                img = cv2.imdecode(np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR)
                 if img is None: continue
                 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
                 img_tensor = transform(img).unsqueeze(0).to(device)
@@ -175,19 +181,19 @@ def run_experiment(variant_name, data_list, folds=3):
 
 if __name__ == "__main__":
     data_root = Path("data")
+    storage = ConfigLoader().get_storage(str(data_root))
+
     with open(data_root / "labels.yaml", "r") as f:
         labels_map = yaml.safe_load(f) or {}
-    
+
     print(f"Loading and pre-processing {len(labels_map)} images...")
     processed_data = []
     for rel_path, label in labels_map.items():
-        abs_path = data_root / rel_path
-        if not abs_path.exists(): continue
-        
-        weather = get_metar_vector(abs_path)
+        if not storage.exists(rel_path): continue
+
+        weather = get_metar_vector(storage, rel_path)
         processed_data.append({
             'path': rel_path,
-            'abs_path': abs_path,
             'label': label,
             'weather': weather
         })
@@ -212,9 +218,9 @@ if __name__ == "__main__":
         sparse_data.append(new_item)
 
     results = []
-    results.append(run_experiment("Vision Only", processed_data))
-    results.append(run_experiment("Full METAR", processed_data))
-    results.append(run_experiment("Sparse METAR", sparse_data))
+    results.append(run_experiment("Vision Only", processed_data, storage))
+    results.append(run_experiment("Full METAR", processed_data, storage))
+    results.append(run_experiment("Sparse METAR", sparse_data, storage))
 
     df = pd.DataFrame(results)
     print("\n📊 --- A/B TEST RESULTS ---")

--- a/tools/classifier_server.py
+++ b/tools/classifier_server.py
@@ -90,10 +90,13 @@ def get_jobs():
 @app.get("/api/images")
 def get_images(batch_size: int = 20, offset: int = 0):
     labels = load_labels()
-    all_images = sorted([str(p.relative_to(DATA_ROOT)) for p in DATA_ROOT.rglob("*.jpg")])
-    
+    if _r2_storage is not None:
+        all_images = sorted(k for k in _r2_storage.list_keys() if k.endswith(".jpg"))
+    else:
+        all_images = sorted(str(p.relative_to(DATA_ROOT)) for p in DATA_ROOT.rglob("*.jpg"))
+
     unlabeled = [img for img in all_images if img not in labels]
-    
+
     return {
         "images": unlabeled[:batch_size],
         "total_unlabeled": len(unlabeled),

--- a/tools/evaluate.py
+++ b/tools/evaluate.py
@@ -2,6 +2,7 @@ import os
 import sys
 import yaml
 import torch
+import numpy as np
 from pathlib import Path
 import cv2
 from torchvision import transforms
@@ -16,20 +17,21 @@ os.environ["PYTHONUNBUFFERED"] = "1"
 # Add root to path for imports
 sys.path.append(str(Path.cwd()))
 from train.model import ConvNextLoRAModel
+from train.config_loader import ConfigLoader
 
-def get_metar_vector(img_path):
-    search_paths = [
-        img_path.parent.parent / "metar" / "metar.txt",
-        img_path.parent / "metar.txt",
-        img_path.parent / f"{img_path.stem}.txt"
+def get_metar_vector(storage, img_key: str):
+    img_rel = Path(img_key)
+    candidates = [
+        str(img_rel.parent.parent / "metar" / "metar.txt"),
+        str(img_rel.parent / "metar.txt"),
+        str(img_rel.parent / f"{img_rel.stem}.txt"),
     ]
     metar_text = None
-    for p in search_paths:
-        if p.exists():
-            with open(p, 'r') as f:
-                metar_text = f.read().strip()
+    for c in candidates:
+        if storage.exists(c):
+            metar_text = storage.get_text(c).strip()
             break
-    
+
     vis, ceil = 0.0, 1.0 # Default bad
     if metar_text:
         try:
@@ -45,22 +47,23 @@ def evaluate(checkpoint_dir: str, labels_file: str):
     device = "mps" if torch.backends.mps.is_available() else "cpu"
     print(f"Loading checkpoint from: {checkpoint_dir}")
     print(f"Using device: {device}")
-    
+
     model = ConvNextLoRAModel(
-        num_classes=3, 
-        checkpoint_dir=checkpoint_dir, 
+        num_classes=3,
+        checkpoint_dir=checkpoint_dir,
         device=device
     )
     model.model_dict.eval()
 
     labels_path = Path(labels_file)
     data_root = labels_path.parent
-    
+    storage = ConfigLoader().get_storage(str(data_root))
+
     with open(labels_path, "r") as f:
         labels_map = yaml.safe_load(f) or {}
 
     print(f"Found {len(labels_map)} labels in {labels_file}")
-    
+
     transform = transforms.Compose([
         transforms.ToPILImage(),
         transforms.Resize(224),
@@ -71,27 +74,30 @@ def evaluate(checkpoint_dir: str, labels_file: str):
 
     true_labels = []
     pred_labels = []
-    
+
     print("Running inference...")
     with torch.no_grad():
         for rel_path, label in labels_map.items():
-            img_p = data_root / rel_path
-            if not img_p.exists():
+            if not storage.exists(rel_path):
                 continue
-                
-            frame = cv2.imread(str(img_p))
+
+            try:
+                img_bytes = storage.get(rel_path)
+            except Exception:
+                continue
+            frame = cv2.imdecode(np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR)
             if frame is None:
                 continue
-            
+
             frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             img_tensor = transform(frame_rgb).unsqueeze(0).to(device)
-            
-            weather = get_metar_vector(img_p)
+
+            weather = get_metar_vector(storage, rel_path)
             weather_tensor = torch.tensor([weather], dtype=torch.float32).to(device)
-            
+
             output = model(img_tensor, weather_tensor)
             pred = torch.argmax(output, dim=1).item()
-            
+
             true_labels.append(label)
             pred_labels.append(pred)
 

--- a/tools/prune_data.py
+++ b/tools/prune_data.py
@@ -1,12 +1,15 @@
-import os
-import shutil
+import io
+import sys
 import argparse
 import yaml
-import json
 from pathlib import Path
 from PIL import Image, ImageChops, ImageStat
 from metar import Metar
 from datetime import datetime, UTC
+
+sys.path.append(str(Path.cwd()))
+from train.config_loader import ConfigLoader
+
 
 def load_labels(data_root):
     labels_path = Path(data_root) / "labels.yaml"
@@ -15,70 +18,92 @@ def load_labels(data_root):
             return yaml.safe_load(f) or {}
     return {}
 
-def save_labels(data_root, labels):
-    labels_path = Path(data_root) / "labels.yaml"
-    with open(labels_path, 'w') as f:
-        yaml.safe_dump(labels, f)
 
-def get_metar_data(img_path):
-    # Try multiple paths for metar.txt
-    search_paths = [
-        img_path.parent.parent / "metar" / "metar.txt",
-        img_path.parent / "metar.txt",
-        img_path.parent / f"{img_path.stem}.txt"
+def save_labels(data_root, labels, storage):
+    # Mirror to both local and storage so subsequent runs see the new labels
+    # whether reading via storage.get_text or the local file directly.
+    labels_path = Path(data_root) / "labels.yaml"
+    labels_path.parent.mkdir(parents=True, exist_ok=True)
+    text = yaml.safe_dump(labels)
+    with open(labels_path, 'w') as f:
+        f.write(text)
+    storage.put_text("labels.yaml", text)
+
+
+def get_metar_data(storage, img_key: str):
+    img_rel = Path(img_key)
+    candidates = [
+        str(img_rel.parent.parent / "metar" / "metar.txt"),
+        str(img_rel.parent / "metar.txt"),
+        str(img_rel.parent / f"{img_rel.stem}.txt"),
     ]
-    for p in search_paths:
-        if p.exists():
-            with open(p, 'r') as f:
-                return f.read().strip()
+    for c in candidates:
+        if storage.exists(c):
+            return storage.get_text(c).strip()
     return None
 
-def prune_dataset(data_root="data", min_seconds=300, dark_thresh=10.0, diff_thresh=2.0, dry_run=True, force_keep_hourly=True, auto_label_metar=True):
-    root = Path(data_root)
-    labels = load_labels(root)
-    
-    images = []
-    for img_path in root.rglob("*.jpg"):
-        # Skip if already labeled
-        rel_path = str(img_path.relative_to(root))
-        if rel_path in labels:
-            continue
-        images.append((img_path.stat().st_mtime, img_path))
-    
-    images.sort(key=lambda x: x[0])
+
+def _capture_dir_for(img_key: str) -> str:
+    # data layout: <date>/<HHMMSS_us_UTC>/images/<...>.jpg
+    parts = Path(img_key).parts
+    if len(parts) < 3:
+        return ""
+    return f"{parts[0]}/{parts[1]}"
+
+
+def _mtime_from_key(img_key: str) -> float:
+    # Keys are YYYYMMDD/HHMMSS_us_UTC/images/...jpg — the directory name IS the
+    # capture timestamp, which is reliable across local and R2 (R2 list_keys
+    # gives no mtime through the storage protocol).
+    parts = Path(img_key).parts
+    date_str, time_str = parts[0], parts[1]  # 20260222, 220834_724181_UTC
+    hhmmss = time_str[:6]
+    return datetime.strptime(f"{date_str} {hhmmss}", "%Y%m%d %H%M%S").replace(tzinfo=UTC).timestamp()
+
+
+def _open_pil(storage, img_key: str):
+    return Image.open(io.BytesIO(storage.get(img_key)))
+
+
+def prune_dataset(data_root="data", min_seconds=300, dark_thresh=10.0, diff_thresh=2.0,
+                  dry_run=True, force_keep_hourly=True, auto_label_metar=True):
+    storage = ConfigLoader().get_storage(data_root)
+    labels = load_labels(data_root)
+
+    image_keys = [k for k in storage.list_keys("") if k.endswith(".jpg") and k not in labels]
+    image_keys.sort()  # Lexicographic == chronological for our key layout
+    images = [(_mtime_from_key(k), k) for k in image_keys]
+
     print(f"🔍 Found {len(images)} unlabeled images in '{data_root}'")
-    
-    to_delete_dirs = []
+
+    to_delete_dirs = set()
     reasons = {"time": 0, "dark": 0, "duplicate": 0, "metar_auto": 0}
-    
+
     last_kept_time = 0
     last_kept_img = None
     last_forced_hour = -1
 
-    for mtime, img_path in images:
-        capture_dir = img_path.parent.parent
-        rel_path = str(img_path.relative_to(root))
-        
+    for mtime, img_key in images:
+        capture_dir = _capture_dir_for(img_key)
+
         # 1. METAR Auto-Labeling (Obvious "Not Out")
         if auto_label_metar:
-            metar_text = get_metar_data(img_path)
+            metar_text = get_metar_data(storage, img_key)
             if metar_text:
                 try:
                     obs = Metar.Metar(metar_text)
                     vis = obs.vis.value('SM') if obs.vis else 10.0
-                    # Check for low ceiling (BKN or OVC layers)
                     ceil = 10000.0
                     if obs.sky:
                         layers = [l for l in obs.sky if l[0] in ['BKN', 'OVC']]
                         if layers: ceil = layers[0][1].value('FT')
-                    
-                    # Logic: If vis is crap OR ceiling is below Rainier's peak area (~8000ft)
+
+                    # Vis crap OR ceiling below Rainier's peak area (~8000ft)
                     if vis < 3.0 or ceil < 6000:
                         if not dry_run:
-                            labels[rel_path] = 0
+                            labels[img_key] = 0
                         reasons["metar_auto"] += 1
-                        # We don't delete these! We just auto-label them so the human skips them.
-                        continue
+                        continue  # Auto-label, do not delete
                 except: pass
 
         # 2. Force Keep Logic (1 per hour for darkness baseline)
@@ -88,71 +113,75 @@ def prune_dataset(data_root="data", min_seconds=300, dark_thresh=10.0, diff_thre
             last_forced_hour = hour_key
             last_kept_time = mtime
             try:
-                with Image.open(img_path) as img:
+                with _open_pil(storage, img_key) as img:
                     last_kept_img = img.convert("L").copy()
-                continue 
+                continue
             except: pass
 
         # 3. Temporal Pruning
         if mtime - last_kept_time < min_seconds:
-            to_delete_dirs.append(capture_dir)
+            to_delete_dirs.add(capture_dir)
             reasons["time"] += 1
             continue
-            
+
         try:
-            with Image.open(img_path) as img:
+            with _open_pil(storage, img_key) as img:
                 img_gray = img.convert("L")
                 stat = ImageStat.Stat(img_gray)
                 avg_brightness = stat.mean[0]
-                
+
                 # 4. Darkness Pruning
                 if avg_brightness < dark_thresh:
-                    to_delete_dirs.append(capture_dir)
+                    to_delete_dirs.add(capture_dir)
                     reasons["dark"] += 1
                     continue
-                    
+
                 # 5. Redundancy / Diff Pruning
                 if last_kept_img is not None:
                     diff = ImageChops.difference(img_gray, last_kept_img)
                     diff_stat = ImageStat.Stat(diff)
                     avg_diff = diff_stat.mean[0]
-                    
+
                     if avg_diff < diff_thresh:
-                        to_delete_dirs.append(capture_dir)
+                        to_delete_dirs.add(capture_dir)
                         reasons["duplicate"] += 1
                         continue
-                
-                # Keep this image, update baselines
+
                 last_kept_time = mtime
                 last_kept_img = img_gray.copy()
-                
+
         except Exception as e:
-            print(f"Error processing {img_path}: {e}")
+            print(f"Error processing {img_key}: {e}")
 
     if not dry_run:
-        save_labels(root, labels)
+        save_labels(data_root, labels, storage)
 
     total_deleted = len(to_delete_dirs)
-    
+
     print("\n📊 --- Pruning & Auto-Labeling Results ---")
     print(f"Auto-Labeled (METAR Low Vis/Ceiling): {reasons['metar_auto']}")
     print(f"Pruned (Time Constraints):           {reasons['time']}")
     print(f"Pruned (Too Dark):                   {reasons['dark']}")
     print(f"Pruned (No Scene Change):            {reasons['duplicate']}")
-    print(f"Total Folders to Delete:             {total_deleted}")
+    print(f"Total Capture Dirs to Delete:        {total_deleted}")
 
     if dry_run:
         print("\n🛑 DRY RUN: No files deleted, no labels saved.")
-    else:
-        print("\n🗑️ Executing deletions and saving auto-labels...")
-        deleted_count = 0
-        for d in set(to_delete_dirs):
-            if d.exists() and d.name != "data":
-                try:
-                    shutil.rmtree(d)
-                    deleted_count += 1
-                except: pass
-        print(f"Done. Deleted {deleted_count} directories.")
+        return
+
+    print("\n🗑️ Executing deletions and saving auto-labels...")
+    deleted_keys = 0
+    for d in to_delete_dirs:
+        prefix = d + "/"
+        keys = storage.list_keys(prefix)
+        for k in keys:
+            try:
+                storage.delete(k)
+                deleted_keys += 1
+            except Exception as e:
+                print(f"Failed to delete {k}: {e}")
+    print(f"Done. Deleted {deleted_keys} keys across {total_deleted} capture dirs.")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -161,5 +190,6 @@ if __name__ == "__main__":
     parser.add_argument("--dark", type=float, default=10.0)
     parser.add_argument("--diff", type=float, default=2.0)
     args = parser.parse_args()
-    
-    prune_dataset(dry_run=not args.execute, min_seconds=args.min_sec, dark_thresh=args.dark, diff_thresh=args.diff)
+
+    prune_dataset(dry_run=not args.execute, min_seconds=args.min_sec,
+                  dark_thresh=args.dark, diff_thresh=args.diff)


### PR DESCRIPTION
Closes #52 (partial — items 1 & 2; tray + integration-capture deferred to followups).

## Summary
- Flips on the already-built R2 backend by uncommenting `[storage]` in `mountain.toml` and pointing it at the new `is-the-mountain-out` R2 bucket
- Bulk-uploaded 4,135 capture files + `labels.yaml` to R2 via `uv run collect sync push` / `sync labels push` (one-shot, done in this session)
- Moved local `data/<YYYYMMDD>/` tree into `.r2cache/` so training stays warm without re-downloading 166 MB on first run; `data/` now holds only collector state/config files
- Refactored the three holdout analysis tools (`evaluate.py`, `prune_data.py`, `ab_test.py`) that were still calling `cv2.imread` on hard-coded local paths — they now route through the storage backend and work against R2
- Fixed `classifier_server.py`'s `/api/images` endpoint: it used `DATA_ROOT.rglob("*.jpg")`, which would return empty now that images live in `.r2cache/`; it now lists keys via the R2 client when R2 is configured
- Added a `delete()` method to the `StorageBackend` protocol (and all three implementations) so `prune_data.py` can actually delete the capture dirs it identifies

## What didn't change
- The R2 backend code itself (`collect/storage.py` LocalStorage/R2Storage/CachedR2Storage, `train/config_loader.py:get_storage()`, `collect/sync.py`, `collect/collector.py` upload plumbing, `train/scheduler.py` prefetch + reads, `train/model.py` checkpoint upload) was already merged on `main` via commits `78a4e12` / `dfe6c96` (PR #56's content landed via direct commits even though the PR was closed unmerged). This PR is the wiring + migration + tool refactor, not a build-from-scratch.

## Verification
- 17/17 storage tests pass: `uv run pytest collect/tests/test_storage.py -v`
- End-to-end training run against `CachedR2Storage` reached 97.6% val accuracy and uploaded the new checkpoint to R2:
  ```
  Loaded 2000 labels from data/labels.yaml
  ...
  Epoch 1: train_loss=0.0965  val_loss=0.0782  val_acc=97.6%
  Checkpoints uploaded to R2.
  ```
- `prune_data.py` dry-run against R2: listed 58 unlabeled images, identified 5 dark-prunable capture dirs
- All three refactored tools import cleanly

## Test plan
- [ ] Run a live collector cycle once captures resume (`uv run collect collect`) and confirm a new key appears in R2 via the dashboard
- [ ] Load the classifier UI (`uv run classify start`) and label a few images; confirm `labels.yaml` round-trips to R2
- [ ] Re-run `uv run training batch --labels data/labels.yaml --epochs 1` after captures resume to confirm new images are picked up

## Followups (separate issues)
- Menu-bar tray indicator for R2 data sink (item 3 of #52)
- Scheduled integration test that captures into an isolated R2 prefix (item 4 of #52)

## Notes
- `cf.env` (local R2 credentials) is gitignored. The Cloudflare account ID and bucket name in `mountain.toml` are not secrets — they're already used in URLs and the `terraform/` files in this repo.
- The Cloudflare account had to be enabled for R2 in the dashboard and an S3-compatible API token created before this could ship — both are now in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)