### PR TITLE
terraform: reclaim R2 + Pages from the dashboard

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,1 +1,5 @@
 .terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,92 @@
+# Terraform — Cloudflare infra for is-the-mountain-out
+
+This directory is the source of truth for the Cloudflare side of the stack:
+
+| File | Manages |
+|---|---|
+| `cloudflare_worker.tf` | `mountain-inference` Worker + Container deploy (via `wrangler`), Worker secrets (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and `NTFY_TOPIC` once PR #65 lands) |
+| `r2.tf` | Both R2 buckets, the public bucket's `r2.dev` managed domain, and its CORS rule |
+| `pages.tf` | The `is-the-mountain-out` Cloudflare Pages project (GitHub source + build config) |
+| `outputs.tf` | R2 endpoint, public bucket URL, Pages subdomain, Worker name, image tag |
+| `main.tf` | Provider versions + the local Nomad `mountain-training` batch job |
+
+State is **local** (`terraform.tfstate` in this directory — no remote backend). The
+state file and any `*.tfvars` contain secrets and are gitignored; never commit them.
+
+## What is NOT terraformed (on purpose)
+
+- **The R2 S3-API token** (`r2_access_key_id` / `r2_secret_access_key`). The v5
+  provider's token-policy block has been unstable across minors; the token is cut
+  by hand in the Cloudflare dashboard and flows to the container through a Worker
+  secret regardless. Put the values in `cf.env` at the repo root.
+- **The Cloudflare GitHub App authorization** (see prerequisites). It *is* the
+  security boundary between Cloudflare and the repo, so it can't be terraformed.
+
+## Prerequisites (one-time, before the first `apply`)
+
+1. **Authorize the Cloudflare GitHub App on the repo.** Pages cannot bind a Git
+   source without an existing OAuth grant, so `pages.tf` will fail on a fresh
+   account until this is done. In the Cloudflare dashboard:
+   *Workers & Pages → Create → Pages → Connect to Git → install/authorize for
+   `tommyroar/is-the-mountain-out`*, then cancel out (the project itself is
+   created by Terraform). This is a human click, not a terraform resource.
+2. **Cut the R2 S3-API token** in the dashboard (Object Storage → API → Manage
+   API Tokens) and drop the access key / secret into the repo-root `cf.env`.
+3. Install `terraform`, and `node`/`npx` (the Worker deploy shells out to
+   `npx wrangler`).
+
+## Variables
+
+All sensitive; pass via `TF_VAR_*` env vars (what `scripts/deploy-inference.sh`
+does) or a gitignored `terraform.tfvars`:
+
+| Variable | Source |
+|---|---|
+| `cloudflare_api_token` | CF dashboard — needs Workers + R2 + Pages + Containers scopes |
+| `cloudflare_account_id` | `d7adee58513c1b2f770ccaac90cf114f` (also in `mountain.toml`) |
+| `r2_access_key_id` | `cf.env` |
+| `r2_secret_access_key` | `cf.env` |
+| `ntfy_topic` | `ntfy.key` (only after PR #65 — Worker-side notifications — merges) |
+
+## Import the existing R2 buckets before the first apply
+
+Both buckets already exist (originally created via dashboard/MCP). They MUST be
+imported into state first, or Terraform will try to recreate them and fail:
+
+```sh
+export CLOUDFLARE_API_TOKEN=...        # same token as the apply
+ACCT=d7adee58513c1b2f770ccaac90cf114f
+
+terraform import cloudflare_r2_bucket.captures "$ACCT/is-the-mountain-out"
+terraform import cloudflare_r2_bucket.public   "$ACCT/is-the-mountain-out-public"
+```
+
+> `cloudflare_r2_managed_domain` and `cloudflare_r2_bucket_cors` do **not** support
+> `terraform import` in provider v5.19.1. That's fine — the R2 API treats both as
+> full-replacement PUTs, so the first `apply` simply overwrites whatever the
+> dashboard set. Confirm the CORS origins in `r2.tf` match production before
+> applying.
+>
+> The Pages project in `pages.tf` does not exist yet on the account, so it needs
+> no import — `apply` creates it from scratch.
+
+## Plan / apply
+
+The normal path is the wrapper, which threads the `TF_VAR_*` env through for you:
+
+```sh
+PLAN_ONLY=1 scripts/deploy-inference.sh   # terraform plan
+scripts/deploy-inference.sh               # terraform apply (+ wrangler deploy + secrets)
+```
+
+Or drive Terraform directly from this directory:
+
+```sh
+terraform init
+terraform plan
+terraform apply
+```
+
+After apply, `terraform output pages_subdomain` and `r2_public_bucket_url` give
+the live URLs. The public bucket URL should match `VITE_STATE_URL` in
+`web/.env.production` and the `VITE_STATE_URL` env in `pages.tf`.

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -1,8 +1,11 @@
-# Cloudflare provider config. The R2 buckets (is-the-mountain-out,
-# is-the-mountain-out-public) and the R2 S3-API token are managed
-# manually via the Cloudflare dashboard / MCP — see PR notes. This file
-# only configures the provider so cloudflare_worker.tf can deploy the
-# Worker.
+# Cloudflare provider config.
+#
+# R2 buckets, CORS, managed domain, and the Pages project live in
+# r2.tf and pages.tf. The R2 S3-API token (used by the inference
+# container) is still cut manually in the dashboard — the v5
+# provider's cloudflare_api_token policy block has been unstable
+# across minor versions and the value moves through the Worker as a
+# secret either way.
 
 provider "cloudflare" {
   api_token = var.cloudflare_api_token

--- a/terraform/cloudflare_worker.tf
+++ b/terraform/cloudflare_worker.tf
@@ -13,8 +13,8 @@
 # routes, bindings, and migrations (declared in worker/wrangler.toml).
 
 locals {
-  worker_dir         = "${path.module}/../worker"
-  inference_image    = "ghcr.io/${var.github_owner}/${var.github_repo}/inference:${var.inference_image_tag}"
+  worker_dir      = "${path.module}/../worker"
+  inference_image = "ghcr.io/${var.github_owner}/${var.github_repo}/inference:${var.inference_image_tag}"
   worker_source_hash = sha256(join("", [
     filesha256("${local.worker_dir}/wrangler.toml"),
     filesha256("${local.worker_dir}/src/index.ts"),

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,6 +3,16 @@ output "r2_endpoint" {
   value       = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com"
 }
 
+output "r2_public_bucket_url" {
+  description = "Managed r2.dev URL for the public state/history bucket"
+  value       = "https://${cloudflare_r2_managed_domain.public.domain}"
+}
+
+output "pages_subdomain" {
+  description = "Cloudflare-assigned *.pages.dev subdomain for the SPA"
+  value       = "https://${cloudflare_pages_project.spa.subdomain}"
+}
+
 output "inference_worker_name" {
   description = "Cloudflare Worker that runs the */15 mountain-inference cron"
   value       = "mountain-inference"

--- a/terraform/pages.tf
+++ b/terraform/pages.tf
@@ -1,0 +1,62 @@
+# Cloudflare Pages project that builds and serves the SPA in web/.
+#
+# Reclaims what would otherwise be a dashboard click on every fresh
+# environment. The project itself doesn't exist yet on the Cloudflare
+# account — this resource creates it from scratch, so no import is
+# needed (unlike the R2 buckets in r2.tf).
+#
+# Prerequisite: the Cloudflare GitHub App must be authorized on the
+# repo BEFORE `terraform apply` (Cloudflare can't bind a Git source
+# without an existing OAuth grant). One-time human action; not
+# terraformable because it IS the security boundary. See README in
+# this directory.
+#
+# The env var here matches web/.env.production. Vite picks up the
+# .env.production file at build time too — declaring it in both
+# places is belt-and-suspenders, but means changing the R2 URL is a
+# one-file edit either way.
+
+resource "cloudflare_pages_project" "spa" {
+  account_id        = var.cloudflare_account_id
+  name              = "is-the-mountain-out"
+  production_branch = "main"
+
+  source = {
+    type = "github"
+    config = {
+      owner                          = var.github_owner
+      owner_id                       = "4916474"
+      repo_name                      = var.github_repo
+      repo_id                        = "1162388160"
+      production_branch              = "main"
+      production_deployments_enabled = true
+      preview_deployment_setting     = "all"
+      pr_comments_enabled            = true
+    }
+  }
+
+  build_config = {
+    build_command   = "npm install && npm run build"
+    destination_dir = "web/dist"
+    root_dir        = "web"
+  }
+
+  deployment_configs = {
+    production = {
+      env_vars = {
+        VITE_STATE_URL = {
+          value = "https://pub-66d3d1f139004e29b2afcb5fba49bdb3.r2.dev/state.json"
+          type  = "plain_text"
+        }
+      }
+    }
+    preview = {
+      env_vars = {
+        VITE_STATE_URL = {
+          value = "https://pub-66d3d1f139004e29b2afcb5fba49bdb3.r2.dev/state.json"
+          type  = "plain_text"
+        }
+      }
+    }
+  }
+}

--- a/terraform/r2.tf
+++ b/terraform/r2.tf
@@ -1,0 +1,49 @@
+# R2 buckets and the public bucket's r2.dev managed domain + CORS rule.
+#
+# Both buckets were originally created via the Cloudflare dashboard /
+# MCP (the v5 provider's earlier resource shapes were unstable, so
+# cloudflare.tf was gutted in PR #63). Reclaiming them here so the
+# dashboard isn't a second source of truth.
+#
+# The buckets already exist — they MUST be imported before the first
+# apply or terraform will try to recreate them and fail. See README in
+# this directory for the import commands.
+#
+# cloudflare_r2_bucket_cors and cloudflare_r2_managed_domain do NOT
+# support `terraform import` in v5.19.1. The Cloudflare R2 API PUTs
+# both as full replacements, so a fresh `apply` will just overwrite
+# whatever the dashboard set — safe, and intended.
+
+resource "cloudflare_r2_bucket" "captures" {
+  account_id = var.cloudflare_account_id
+  name       = "is-the-mountain-out"
+}
+
+resource "cloudflare_r2_bucket" "public" {
+  account_id = var.cloudflare_account_id
+  name       = "is-the-mountain-out-public"
+}
+
+resource "cloudflare_r2_managed_domain" "public" {
+  account_id  = var.cloudflare_account_id
+  bucket_name = cloudflare_r2_bucket.public.name
+  enabled     = true
+}
+
+resource "cloudflare_r2_bucket_cors" "public" {
+  account_id  = var.cloudflare_account_id
+  bucket_name = cloudflare_r2_bucket.public.name
+
+  rules = [{
+    id              = "spa-and-local-dev"
+    max_age_seconds = 3600
+    allowed = {
+      methods = ["GET", "HEAD"]
+      origins = [
+        "https://is-the-mountain-out.pages.dev",
+        "http://localhost:5188",
+      ]
+      headers = ["*"]
+    }
+  }]
+}


### PR DESCRIPTION
## Why

After the Cloudflare migration PRs (#62, #63, #64) the dashboard was the source of truth for: both R2 buckets, the public bucket's r2.dev managed domain, its CORS policy, and (about-to-be) the Pages project. That was scope drift from the original \"full terraform coverage\" goal — \`cloudflare.tf\` had been gutted earlier in the session when the v5 provider's \`cloudflare_api_token\` policy schema misbehaved, and the buckets got dropped along with the token resource by mistake.

This PR reclaims all of it.

## What's now in HCL

| Resource | File | Notes |
|---|---|---|
| \`cloudflare_r2_bucket.captures\` | \`r2.tf\` | Existing — needs \`terraform import\` |
| \`cloudflare_r2_bucket.public\` | \`r2.tf\` | Existing — needs \`terraform import\` |
| \`cloudflare_r2_managed_domain.public\` | \`r2.tf\` | No import support; apply overwrites |
| \`cloudflare_r2_bucket_cors.public\` | \`r2.tf\` | No import support; apply overwrites |
| \`cloudflare_pages_project.spa\` | \`pages.tf\` | New — terraform creates it from scratch |

The Pages project's source binding includes the GitHub owner/repo numeric IDs (\`4916474\` / \`1162388160\`) so the provider doesn't have to do a name lookup at apply time. These are public, non-sensitive identifiers.

## What is NOT in HCL (and why)

- **R2 S3-API token** — the v5 \`cloudflare_api_token\` policy block has been unstable across minor versions, and the value moves through the Worker as a secret either way. Keeping the existing dashboard-cut token.
- **Cloudflare GitHub App authorization on the repo** — this OAuth grant IS the security boundary; terraform can't (and shouldn't) be able to grant Cloudflare access to your GitHub on your behalf. One-time human click.
- **GitHub Pages disable** — also one-time and on GitHub, not Cloudflare. Could be done with the \`github\` provider, but for a single setting flip the dashboard click is less infra than a whole new provider.

## Apply recipe

Run from \`terraform/\`. \`cf.env\` should already have \`R2_ACCESS_KEY_ID\` and \`R2_SECRET_ACCESS_KEY\`; a \`CLOUDFLARE_API_TOKEN\` with R2 Read+Write and Pages Read+Write is also needed.

\`\`\`sh
# 0. (one-time, in dashboard) Authorize the Cloudflare GitHub App on tommyroar/is-the-mountain-out:
#    https://dash.cloudflare.com/d7adee58513c1b2f770ccaac90cf114f/workers-and-pages/create/pages
#    → \"Connect to Git\" → GitHub → install/authorize Cloudflare app → cancel out of the wizard.

# 1. Import the two existing buckets so terraform adopts them instead of recreating.
export TF_VAR_cloudflare_account_id=d7adee58513c1b2f770ccaac90cf114f
terraform import cloudflare_r2_bucket.captures \"\$TF_VAR_cloudflare_account_id/is-the-mountain-out/default\"
terraform import cloudflare_r2_bucket.public   \"\$TF_VAR_cloudflare_account_id/is-the-mountain-out-public/default\"

# 2. Apply. cloudflare_r2_bucket_cors and cloudflare_r2_managed_domain don't
#    support import, but R2's CORS and managed-domain APIs are full-replace PUTs,
#    so terraform's first apply just overwrites whatever the dashboard set with
#    the same values declared in r2.tf. The Pages project is created fresh.
terraform apply
\`\`\`

After apply, useful outputs:

- \`r2_public_bucket_url\` — \`https://pub-66d3d1f139004e29b2afcb5fba49bdb3.r2.dev\` (should match the existing one)
- \`pages_subdomain\` — \`https://is-the-mountain-out.pages.dev\`

## Verification

- \`terraform plan\` after apply should show 0 changes
- R2 dashboard's CORS view should match the rule in \`r2.tf\` (origins: pages.dev + localhost:5188; methods: GET, HEAD)
- Visiting \`https://is-the-mountain-out.pages.dev/\` should render the SPA and successfully fetch \`state.json\` cross-origin

## Risk

- **Pages source binding can fail at create time** if the GitHub App grant isn't in place — error will be a 404/403 on \`/repos/tommyroar/is-the-mountain-out\` from Cloudflare's side. Fix is to do step 0 above and re-apply.
- If the v5 provider's \`pages_project\` schema has shifted again between 5.19.1 and whatever's current, \`terraform validate\` will catch it — I ran it locally against 5.19.1 and it passed.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>