### PR TITLE
Terraform IaC for Cloudflare (deferred — rationale inside)

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,1 @@
+.terraform/

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,59 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.19.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:HkKPMZ/n+QiExkRUSLjGMTGnuIaph+k932LiTp7CKZM=",
+    "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
+    "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
+    "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
+    "zh:580786830d93e35b957754fd4c62d4681a3b19abc28b757e41acba26455663b1",
+    "zh:83c4bdfb0e74fd50e56fff3c461d76c1c1ec61af3f679e4de1aa70b5ed05a09f",
+    "zh:abb4d1052cee61d80f9cb51e5421e3c118312403afb7104b98bd7e310ac736ee",
+    "zh:b0aeeb3d66ea4d719989875e778c477065ba941e3a76e9a8caacc3be08208dd9",
+    "zh:e43b4b2dfcec1ce2115f5a5c86042d432deb49bee8eae103eb56d97ea02e2e3b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/nomad" {
+  version     = "2.5.2"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:mJKLi0Ks7yxwvT+ZRMIa9kNDfcJGjyXNvzHuE+17WuE=",
+    "zh:08746e4020b3359f5d3bd4587bc3f2e7ebd30013f9d020dd1d0c0b90ab720428",
+    "zh:0d55e8ee74ffe8b7183cb078532fc083aeb07705e1da38a93986362df1061ec4",
+    "zh:46093102717e3e72ae403b8e1c48f671d31f70d9df9e015f79be17f6a64447f4",
+    "zh:47115e31513cc979bb73a6199fc0e55da3a42d5674473c8dd8a8ee87cb9b63d7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8ec1758c3be3f22d95b9f2a6053aa01ee53e25c21819b703082fbb3f469fa5ac",
+    "zh:a14b6c90e60f8e4f5e04a533cfae856de819d229f23dfd96800f87c8c389c78c",
+    "zh:a66a61d91422824616559d120c8b6df849d6b82a499ba9515cb0ffef38defcfa",
+    "zh:aa1786847894b929901c5951ce93c0de1bc2c0524c786ce903cebfe33309abb1",
+    "zh:ae4a0edee5d9b671f8e734e8dc5498bc4404afafee056dc829a48f1198fe59f0",
+    "zh:c15e48d4a2b0dae942b1c5066e5b78d0461d32020783f53b290854801302b369",
+    "zh:e8ac7633802ba2771586ac862946652ca68630c14faa146449baa1168e582051",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.3.0"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,91 @@
+# Terraform for is-the-mountain-out — **deferred, not the active deploy path**
+
+This directory holds a working Terraform configuration for the Cloudflare side
+of the stack. **It is intentionally not used to deploy today.** It was stashed
+off `main` (branch `terraform-stash`) and is re-proposed here as a documented
+decision so the work isn't lost and can be adopted later if the trade-offs shift.
+
+If you just want to deploy, see `scripts/deploy-inference.sh` and the wrangler
+flow below — you do **not** need Terraform.
+
+---
+
+## The active deploy model: wrangler-direct
+
+The Worker + container is deployed directly with wrangler, authenticated by the
+operator's `wrangler login` **OAuth session**:
+
+```sh
+cd worker
+npx wrangler deploy                                   # Worker + container app
+printf '%s' "$VALUE" | npx wrangler secret put NAME   # secrets (R2 creds, NTFY_TOPIC)
+```
+
+R2 buckets and the Pages project already exist (created via the dashboard / MCP).
+Nothing in the live path requires a hand-cut API token.
+
+## Why Terraform is deferred
+
+1. **It would reintroduce a long-lived secret.** The Cloudflare Terraform
+   provider authenticates *only* via an `api_token` — there is no OAuth path.
+   Adopting Terraform means cutting, storing, and rotating a
+   `CLOUDFLARE_API_TOKEN` that the wrangler-direct model doesn't need.
+2. **For the Worker it adds indirection without declarative value.** Look at
+   `cloudflare_worker.tf`: every resource is a `null_resource` + `local-exec`
+   that just shells out to `wrangler deploy` / `wrangler secret put`. Terraform
+   isn't managing Worker state declaratively here — it's a wrapper around
+   wrangler, so it inherits wrangler's behaviour plus a token requirement and an
+   extra tool in the chain.
+3. **The infra it *would* manage declaratively (R2, Pages) already exists** and
+   isn't churning. Bringing it under Terraform is IaC hygiene, not a functional
+   need — and some resources can't be cleanly imported (see Caveats).
+4. **It isn't the current blocker.** Deploying the inference container is gated
+   on the **Workers Paid plan** ($5/mo), which Terraform does nothing to change.
+
+## Trade-offs
+
+| | wrangler-direct (current) | Terraform IaC (this dir) |
+|---|---|---|
+| Auth | OAuth session, no stored token | Requires a long-lived `CLOUDFLARE_API_TOKEN` |
+| Worker deploy | Native wrangler | `null_resource` → wrangler (same thing, wrapped) |
+| Infra source of truth | Dashboard / MCP / wrangler.toml | Declarative `.tf` (reviewable, reproducible) |
+| Drift / review | None; imperative, ad-hoc | `terraform plan` diff before apply |
+| Secrets | Set ad-hoc per deploy | Declared alongside infra in one place |
+| Ceremony | Minimal | init / plan / apply, state to manage |
+| R2 domain + CORS | Set once in dashboard | First apply **overwrites** dashboard (no import in v5) |
+
+**Recommendation:** keep wrangler-direct while the infra is small and stable.
+Revisit Terraform when there are enough Cloudflare resources that declarative
+review + reproducibility outweigh the token-management cost — e.g. if the stack
+grows beyond a single Worker + two buckets + one Pages project.
+
+## If/when you adopt it
+
+1. Authorize the Cloudflare GitHub App on the repo (Pages needs the OAuth grant
+   before a Git source can bind).
+2. Import the two pre-existing R2 buckets so the first apply doesn't try to
+   recreate them:
+   ```sh
+   terraform import cloudflare_r2_bucket.captures <account_id>/is-the-mountain-out
+   terraform import cloudflare_r2_bucket.public   <account_id>/is-the-mountain-out-public
+   ```
+3. Provide `cloudflare_api_token`, `cloudflare_account_id`, `r2_access_key_id`,
+   `r2_secret_access_key` via `terraform.tfvars` or `TF_VAR_*` env.
+4. `terraform plan` → review (the R2 managed-domain + CORS rules are
+   full-replacement PUTs that overwrite whatever the dashboard set — confirm the
+   CORS origins match production) → `terraform apply`.
+
+### Caveats
+- `cloudflare_r2_managed_domain` / `cloudflare_r2_bucket_cors` do **not** support
+  `terraform import` in provider v5.x — the first apply overwrites the
+  dashboard-set values (intended, but verify they match prod first).
+- The R2 S3-API token is still cut manually in the dashboard (the v5 provider's
+  token-policy block is unstable); it flows through the Worker as a secret either
+  way.
+
+## Relationship to PR #66
+
+PR #66 (`terraform-reclaim-cloudflare`) is a **superset** of this directory — it
+adds `r2.tf` and `pages.tf` to reclaim the buckets and Pages project. Both are
+deferred for the same reasons above. If Terraform is adopted, consolidate on the
+#66 branch (or fold its `r2.tf`/`pages.tf` in here) rather than maintaining two.

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -1,0 +1,9 @@
+# Cloudflare provider config. The R2 buckets (is-the-mountain-out,
+# is-the-mountain-out-public) and the R2 S3-API token are managed
+# manually via the Cloudflare dashboard / MCP — see PR notes. This file
+# only configures the provider so cloudflare_worker.tf can deploy the
+# Worker.
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}

--- a/terraform/cloudflare_worker.tf
+++ b/terraform/cloudflare_worker.tf
@@ -1,0 +1,112 @@
+# Cloudflare Worker + Container that owns the */15 mountain inference cadence.
+#
+# The Worker (worker/src/index.ts) is bound to a Container running the
+# inference Dockerfile (inference/Dockerfile). On each cron tick the Worker
+# invokes the container's /predict endpoint and writes the result to the
+# public R2 bucket the SPA reads from. The container itself pulls its
+# checkpoint from R2 on startup using the R2 creds passed in as env vars.
+#
+# The Cloudflare Terraform provider's first-class container resource is still
+# stabilizing across 5.x minor versions; rather than pin a specific resource
+# name that may rename, we drive `wrangler deploy` from a null_resource. This
+# also keeps the Worker's TypeScript source as the single source of truth for
+# routes, bindings, and migrations (declared in worker/wrangler.toml).
+
+locals {
+  worker_dir         = "${path.module}/../worker"
+  inference_image    = "ghcr.io/${var.github_owner}/${var.github_repo}/inference:${var.inference_image_tag}"
+  worker_source_hash = sha256(join("", [
+    filesha256("${local.worker_dir}/wrangler.toml"),
+    filesha256("${local.worker_dir}/src/index.ts"),
+    filesha256("${local.worker_dir}/package.json"),
+    var.inference_image_tag,
+  ]))
+}
+
+resource "null_resource" "worker_deploy" {
+  triggers = {
+    source_hash = local.worker_source_hash
+  }
+
+  provisioner "local-exec" {
+    working_dir = local.worker_dir
+    environment = {
+      CLOUDFLARE_API_TOKEN  = var.cloudflare_api_token
+      CLOUDFLARE_ACCOUNT_ID = var.cloudflare_account_id
+      INFERENCE_IMAGE       = local.inference_image
+    }
+    command = <<-EOT
+      set -euo pipefail
+      npm install --no-audit --no-fund
+      npx wrangler deploy
+    EOT
+  }
+}
+
+# R2 S3-API credentials passed to the container so it can pull the latest
+# checkpoint from the private is-the-mountain-out bucket on startup. These
+# are pushed to the Worker as secrets — the container reads them as env
+# vars via the InferenceContainer class in worker/src/index.ts.
+resource "null_resource" "worker_secret_r2_access_key_id" {
+  triggers = {
+    value_hash = sha256(var.r2_access_key_id)
+  }
+
+  provisioner "local-exec" {
+    working_dir = local.worker_dir
+    environment = {
+      CLOUDFLARE_API_TOKEN  = var.cloudflare_api_token
+      CLOUDFLARE_ACCOUNT_ID = var.cloudflare_account_id
+      SECRET_VALUE          = var.r2_access_key_id
+    }
+    command = <<-EOT
+      set -euo pipefail
+      printf '%s' "$SECRET_VALUE" | npx wrangler secret put R2_ACCESS_KEY_ID --name mountain-inference
+    EOT
+  }
+
+  depends_on = [null_resource.worker_deploy]
+}
+
+resource "null_resource" "worker_secret_r2_secret_access_key" {
+  triggers = {
+    value_hash = sha256(var.r2_secret_access_key)
+  }
+
+  provisioner "local-exec" {
+    working_dir = local.worker_dir
+    environment = {
+      CLOUDFLARE_API_TOKEN  = var.cloudflare_api_token
+      CLOUDFLARE_ACCOUNT_ID = var.cloudflare_account_id
+      SECRET_VALUE          = var.r2_secret_access_key
+    }
+    command = <<-EOT
+      set -euo pipefail
+      printf '%s' "$SECRET_VALUE" | npx wrangler secret put R2_SECRET_ACCESS_KEY --name mountain-inference
+    EOT
+  }
+
+  depends_on = [null_resource.worker_deploy]
+}
+
+# ntfy.sh topic the Worker publishes to on Not-Out → visible transitions.
+resource "null_resource" "worker_secret_ntfy_topic" {
+  triggers = {
+    value_hash = sha256(var.ntfy_topic)
+  }
+
+  provisioner "local-exec" {
+    working_dir = local.worker_dir
+    environment = {
+      CLOUDFLARE_API_TOKEN  = var.cloudflare_api_token
+      CLOUDFLARE_ACCOUNT_ID = var.cloudflare_account_id
+      SECRET_VALUE          = var.ntfy_topic
+    }
+    command = <<-EOT
+      set -euo pipefail
+      printf '%s' "$SECRET_VALUE" | npx wrangler secret put NTFY_TOPIC --name mountain-inference
+    EOT
+  }
+
+  depends_on = [null_resource.worker_deploy]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    nomad = {
+      source  = "hashicorp/nomad"
+      version = "~> 2.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "nomad" {
+  address = "http://127.0.0.1:4646"
+}
+
+resource "nomad_job" "training" {
+  jobspec = <<EOT
+job "mountain-training" {
+  datacenters = ["dc1"]
+  type        = "batch"
+  
+  group "ml" {
+    task "train" {
+      driver = "raw_exec"
+      
+      config {
+        command = "/bin/bash"
+        args    = ["-c", "cd /Users/tommydoerr/dev/is-the-mountain-out && uv run training batch --labels data/labels.yaml --epochs 10 --fresh"]
+      }
+      
+      env {
+        PYTHONUNBUFFERED = "1"
+        FORCE_COLOR      = "1"
+      }
+      
+      resources {
+        cpu    = 4000
+        memory = 8192
+      }
+    }
+  }
+}
+EOT
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "r2_endpoint" {
+  description = "S3-compatible endpoint for boto3"
+  value       = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com"
+}
+
+output "inference_worker_name" {
+  description = "Cloudflare Worker that runs the */15 mountain-inference cron"
+  value       = "mountain-inference"
+}
+
+output "inference_image" {
+  description = "Container image the Worker pulls for inference"
+  value       = local.inference_image
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,48 @@
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token with R2 permissions"
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+# ---------- Inference Worker + Container ----------
+
+variable "github_owner" {
+  description = "GitHub owner that backs the container image registry (ghcr.io)"
+  type        = string
+  default     = "tommyroar"
+}
+
+variable "github_repo" {
+  description = "GitHub repo that publishes the inference container image to GHCR"
+  type        = string
+  default     = "is-the-mountain-out"
+}
+
+variable "inference_image_tag" {
+  description = "Container image tag (typically a git SHA) for ghcr.io/<owner>/<repo>/inference"
+  type        = string
+  default     = "latest"
+}
+
+variable "r2_access_key_id" {
+  description = "R2 S3-API access key ID. Pushed to the Worker as a secret; the container reads it as an env var to pull the latest checkpoint from R2 on startup."
+  type        = string
+  sensitive   = true
+}
+
+variable "r2_secret_access_key" {
+  description = "R2 S3-API secret access key. Pushed to the Worker as a secret; the container reads it as an env var to pull the latest checkpoint from R2 on startup."
+  type        = string
+  sensitive   = true
+}
+
+variable "ntfy_topic" {
+  description = "ntfy.sh topic UUID the Worker publishes mountain-out notifications to. Pushed to the Worker as a secret. The topic value is the secret on ntfy.sh — anyone who knows it can publish to or subscribe from it."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
`INFRA` — **DECISION RECORD**

# Terraform for Cloudflare, kept on ice

> _A working Terraform config for the Worker, R2, and Pages — staged with the reasoning for why it's **not** the active deploy path, so the work survives until the trade-offs flip._

> [!NOTE]
> **infra** · docs/decision · risk: low (no deploy)

A decision to leave open, not merge now. The live deploy is **wrangler-direct**, auth'd by the operator's `wrangler login` OAuth session — `npx wrangler deploy` plus `wrangler secret put`, no hand-cut API token. This PR restores the Terraform config stashed off `main` (archived on `terraform-stash`) and adds [`terraform/README.md`](../blob/terraform-iac-deferred/terraform/README.md) recording why it's deferred and how to adopt it later. Merging re-adds `terraform/` to `main`.

## Why Terraform is deferred
- **Reintroduces a long-lived secret** — the Cloudflare provider auths *only* via `api_token`, no OAuth, so it means cutting/storing/rotating a `CLOUDFLARE_API_TOKEN` the current model avoids.
- **No declarative value for the Worker** — every resource in `cloudflare_worker.tf` is a `null_resource` + `local-exec` shelling out to wrangler; a wrapper, not declarative state.
- **The infra it'd manage (R2, Pages) already exists** and isn't churning; reclaiming it is hygiene, not need.
- **Not the blocker** — the container deploy is gated on the Workers Paid plan ($5/mo).

> _"Stay wrangler-direct while the stack is one Worker + two buckets + one Pages project."_

## What changed
- **`terraform/README.md`** — the decision: active model, why deferred, trade-offs, adopt-later steps, caveats.
- **`cloudflare_worker.tf`** — Worker deploy + three secrets (R2 access key/secret, `NTFY_TOPIC`), each a `null_resource` wrapping wrangler.
- **`main.tf`, `cloudflare.tf`, `variables.tf`, `outputs.tf`** — provider pins (Cloudflare v5, Nomad v2, null), Nomad training job, inputs, R2-endpoint outputs.
- **`.terraform.lock.hcl`, `.gitignore`** — pinned provider hashes; ignore `.terraform/`.

## How it flows
No runtime change — nothing deploys from this PR. The decision gate:

```mermaid
flowchart TD
  A[Need to deploy?] -->|yes| B[wrangler-direct, OAuth]
  A -->|want IaC| C{Stack past 1 Worker<br/>+ 2 buckets + 1 Pages?}
  C -->|no| B
  C -->|yes| D[Adopt: import R2,<br/>cut token, plan, apply]
```

## Verification
- Decision record only; no `terraform apply`, no deploy. Live path stays wrangler-direct.
- Providers resolve against the committed lock (Cloudflare 5.19.1, Nomad 2.5.2, null 3.3.0).

## Risk & rollout
- **Low** — adds an unused `terraform/` dir on a branch; nothing runs until someone invokes Terraform.
- **On adopt:** authorize the Cloudflare GitHub App, `import` the two existing R2 buckets, supply `TF_VAR_*`, then `plan` (confirm CORS origins) → `apply`. First apply overwrites dashboard-set R2 domain + CORS (no import in v5).
- **Related:** #66 (`terraform-reclaim-cloudflare`) is a superset adding `r2.tf` + `pages.tf`, deferred for the same reasons — consolidate on one branch if adopted.
