### PR TITLE
Record GitHub Deployments on wrangler deploy

### DIFF
--- a/scripts/deploy-worker.sh
+++ b/scripts/deploy-worker.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Deploy the mountain-inference Worker + container via wrangler, and record a
+# GitHub Deployment so the repo's Environments page and the deployed commit show
+# deploy history plus the live URL.
+#
+# This is the wrangler-direct deploy path (auth via `wrangler login`); it does
+# NOT use Terraform. The container image must already be in the Cloudflare
+# managed registry and referenced by worker/wrangler.toml — build/push it with
+# `wrangler containers push` first (see worker/wrangler.toml and the README).
+#
+# The GitHub Deployment is best-effort: a gh/API hiccup logs a warning but never
+# blocks the actual deploy. A failed `wrangler deploy` marks the deployment
+# `failure` and exits non-zero.
+#
+# Requires: wrangler (authenticated), gh (authenticated), git.
+#
+# Env overrides:
+#   DEPLOY_ENV   GitHub Deployment environment      (default: production)
+#   WORKER_URL   live URL recorded on the status    (default: the workers.dev URL)
+#   GH_REPO      owner/repo                          (default: tommyroar/is-the-mountain-out)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKER_DIR="$REPO_ROOT/worker"
+GH_REPO="${GH_REPO:-tommyroar/is-the-mountain-out}"
+DEPLOY_ENV="${DEPLOY_ENV:-production}"
+WORKER_URL="${WORKER_URL:-https://mountain-inference.tommy-b-doerr.workers.dev}"
+
+log()  { printf '\033[1;34m▸\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!\033[0m %s\n' "$*" >&2; }
+
+command -v gh  >/dev/null 2>&1 || { echo "gh not found in PATH" >&2; exit 1; }
+command -v npx >/dev/null 2>&1 || { echo "npx (Node.js) not found in PATH" >&2; exit 1; }
+
+REF="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+DEPLOY_ID=""
+
+create_deployment() {
+  local body
+  body="$(printf '{"ref":"%s","environment":"%s","production_environment":true,"auto_merge":false,"required_contexts":[],"description":"wrangler deploy of mountain-inference"}' "$REF" "$DEPLOY_ENV")"
+  DEPLOY_ID="$(printf '%s' "$body" | gh api "repos/$GH_REPO/deployments" --input - --jq '.id' 2>/dev/null || true)"
+}
+
+set_status() { # $1=state  $2=description
+  [ -n "$DEPLOY_ID" ] || return 0
+  gh api "repos/$GH_REPO/deployments/$DEPLOY_ID/statuses" \
+    -f state="$1" \
+    -f environment="$DEPLOY_ENV" \
+    -f environment_url="$WORKER_URL" \
+    -f description="$2" >/dev/null 2>&1 || warn "could not set deployment status=$1"
+}
+
+log "Creating GitHub Deployment (env=$DEPLOY_ENV, ref=${REF:0:7})…"
+create_deployment
+if [ -n "$DEPLOY_ID" ]; then
+  log "GitHub Deployment #$DEPLOY_ID created"
+  set_status in_progress "Deploying via wrangler"
+else
+  warn "GitHub Deployment not created (continuing with deploy anyway)"
+fi
+
+log "Running wrangler deploy…"
+if ( cd "$WORKER_DIR" && npx wrangler deploy ); then
+  set_status success "Deployed to $WORKER_URL"
+  log "Deploy succeeded → $WORKER_URL"
+  [ -n "$DEPLOY_ID" ] && log "GitHub Deployment #$DEPLOY_ID marked success"
+else
+  rc=$?
+  set_status failure "wrangler deploy failed (exit $rc)"
+  warn "Deploy failed (exit $rc); GitHub Deployment marked failure"
+  exit "$rc"
+fi


### PR DESCRIPTION
Adds `scripts/deploy-worker.sh` — the **wrangler-direct** production deploy path (auth via `wrangler login`, no Terraform) that wraps `wrangler deploy` with the **GitHub Deployments** lifecycle.

## What it does
On each deploy it:
1. Creates a `production` GitHub Deployment for the current commit (`gh api repos/.../deployments`, `required_contexts: []`, `auto_merge: false`).
2. Marks it `in_progress`.
3. Runs `wrangler deploy` from `worker/`.
4. Marks it `success` (with `environment_url` = the live workers.dev URL) or `failure`.

So the repo's **Environments** page and each deployed commit show deploy history + the live URL — matching the workspace's `/dev` GitHub Deployments convention, but for the real production Worker.

## Behavior
- **Best-effort recording:** a `gh`/API hiccup logs a warning but never blocks the deploy.
- **Honest status:** a failed `wrangler deploy` marks the Deployment `failure` and exits non-zero.
- **Prereq:** the container image must already be in the Cloudflare managed registry and referenced by `worker/wrangler.toml` (`wrangler containers push`) — this script applies the Worker/container config, it doesn't build/push the image.

## Usage
```sh
./scripts/deploy-worker.sh
# overrides: DEPLOY_ENV=staging WORKER_URL=… GH_REPO=…
```

Requires `gh` + `wrangler` authenticated. Supersedes the Terraform-coupled `scripts/deploy-inference.sh` for the active (non-IaC) deploy flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)