### PR TITLE
feat(worker): replace ntfy.sh notifications with Discord webhook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,12 +75,11 @@ Inference runs as the `mountain-inference` Cloudflare Worker + Container (cron `
 - **wrangler (current, preferred):** `scripts/deploy-worker.sh` runs `npx wrangler deploy` from `worker/` and records a GitHub Deployment. This is what the live Worker uses (`last_deployed_from: wrangler`). Secrets are set out-of-band with `wrangler secret put` and only go live on the next `wrangler deploy`.
 - **Terraform (`scripts/deploy-inference.sh` + `terraform/`):** retained as the intended path for reproducibility/IaC later, but the `terraform/` dir is currently absent and the script's TF path is stale — don't rely on it until it's rebuilt. Treat it as aspirational, not the working deploy.
 
-Worker secrets (set via `wrangler secret put`, sourced from gitignored files at repo root):
-- `NTFY_TOPIC` ← `ntfy.key` — ntfy.sh topic to publish to.
-- `NTFY_TOKEN` ← `ntfy-token.key` — ntfy.sh access token. Required in practice: anonymous publishing is rate-limited per source IP and returns HTTP 429 from Cloudflare's shared egress IPs.
+Worker secrets (set via `wrangler secret put`):
+- `DISCORD_WEBHOOK_URL` — Discord channel webhook URL the Worker posts visibility embeds to (the URL *is* the secret). Set with `npx wrangler secret put DISCORD_WEBHOOK_URL` from `worker/`. See `NOTIFICATIONS.md`. (Replaced the former `NTFY_TOPIC`/`NTFY_TOKEN` ntfy.sh secrets — those and the gitignored `ntfy.key`/`ntfy-token.key` files are now obsolete.)
 - `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` ← `cf.env` — let the container pull its checkpoint from R2 on cold start.
 
-Notification failures are silent: `/notify-test` always returns `202` (publish is queued via `waitUntil`) and ntfy errors are only `console.error`'d. To diagnose, `cd worker && npx wrangler tail --format json` and look for `ntfy publish <status>`.
+Notifications fire on the **Not Out → visible** transition via `worker/src/discord-mountain-notify.ts`. Failures are silent: `/notify-test` always returns `202` (publish is queued via `waitUntil`) and Discord errors are only `console.error`'d. To diagnose, `cd worker && npx wrangler tail --format json` and look for `Discord ... failed` or `DISCORD_WEBHOOK_URL not set`.
 
 ## Key Design Constraints
 

--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -1,39 +1,41 @@
 # Notifications
 
-The project uses **ntfy.sh** for real-time push notifications to mobile devices (iOS/Android).
+The project uses a **Discord webhook** for real-time push notifications. Discord delivers to desktop and mobile (iOS/Android) via the Discord app, with no per-IP rate limit on incoming webhooks — which is why it replaced the old ntfy.sh path (anonymous ntfy publishing returned HTTP 429 from Cloudflare's shared egress IPs).
 
 ## Subscribe
 
-1. Install the **ntfy** app.
-2. Subscribe to the private topic UUID stored in `ntfy.key` at the repo root (gitignored — the topic value *is* the secret on ntfy.sh; anyone who knows it can publish or subscribe).
+1. In the Discord server/channel you want the alerts in: **Channel → Edit → Integrations → Webhooks → New Webhook**.
+2. Copy the webhook URL. It looks like `https://discord.com/api/webhooks/<id>/<token>`. **The URL is the secret** — anyone who has it can post to the channel. Store it only as a Worker secret (below), never in a committed file.
 
 ## What fires
 
-The `mountain-inference` Cloudflare Worker (`worker/src/index.ts`) sends one notification on the **Not Out → visible** transition (i.e. when the previous tick's `state.json` had `is_out: false` and the current tick predicts `Full` or `Partial`).
+The `mountain-inference` Cloudflare Worker (`worker/src/index.ts`) posts one embed on the **Not Out → visible** transition (i.e. when the previous tick's `state.json` had `is_out: false` and the current tick predicts `Full` or `Partial`). The Discord formatting lives in `worker/src/discord-mountain-notify.ts`.
 
-| Trigger | Title | Priority | Tag |
+| Trigger | Title | Color | Fields |
 |---|---|---|---|
-| Not Out → Full or Partial | 🏔️ THE MOUNTAIN IS OUT | 5 (max) | `mountain_snow_capped` |
+| Not Out → Full or Partial | 🏔️ The mountain is out! | green | Confidence (combined visible-class %), Classification (Full/Partial) |
 
-Message body includes the predicted class and the combined visible-class confidence.
+The embed also attaches the webcam snapshot (`webcam_url`) as its image and stamps the prediction's `timestamp_utc`.
 
 ## Secrets
 
-The Worker holds two ntfy secrets, set via `wrangler secret put` (the live deploy path is wrangler, not Terraform):
+The Worker holds a single Discord secret, set via `wrangler secret put` (the live deploy path is wrangler, not Terraform):
 
-| Secret | Required | Source | Purpose |
-|---|---|---|---|
-| `NTFY_TOPIC` | yes | `ntfy.key` | The private topic UUID to publish to. |
-| `NTFY_TOKEN` | recommended | `ntfy-token.key` | ntfy.sh access token. Without it, the Worker publishes anonymously and is rate-limited **per source IP** — which returns HTTP 429 from Cloudflare's shared egress IPs (the daily anonymous quota is shared and routinely exhausted). With a token, the quota is attributed to your ntfy account. |
+| Secret | Required | Purpose |
+|---|---|---|
+| `DISCORD_WEBHOOK_URL` | yes | The Discord channel webhook URL to POST embeds to. A missing secret degrades to a logged skip — notifications simply don't send. |
 
 ```bash
-# from worker/
-printf '%s' "$(tr -d '[:space:]' < ../ntfy.key)"       | npx wrangler secret put NTFY_TOPIC
-printf '%s' "$(tr -d '[:space:]' < ../ntfy-token.key)"  | npx wrangler secret put NTFY_TOKEN
+# from worker/ — paste the webhook URL at the prompt (or pipe it in):
+npx wrangler secret put DISCORD_WEBHOOK_URL
 npx wrangler deploy   # secrets only go live on the next deploy
 ```
 
-To mint a token: create a free account at https://ntfy.sh, then **Account → Access tokens → Create**. Save it to the gitignored `ntfy-token.key` at the repo root.
+> **Obsolete:** the former `NTFY_TOPIC` / `NTFY_TOKEN` secrets and the gitignored
+> `ntfy.key` / `ntfy-token.key` files at the repo root are no longer used by the Worker.
+> You can delete the old secrets with `npx wrangler secret delete NTFY_TOPIC` (and
+> `NTFY_TOKEN`) and remove the key files. (The local-only `tools/local_notifier.py`
+> fallback still references ntfy and is out of scope for this change.)
 
 ## Test
 
@@ -43,12 +45,11 @@ After deploying the Worker, hit the test endpoint:
 curl -X POST https://mountain-inference.<your-cf-subdomain>.workers.dev/notify-test
 ```
 
-That sends a one-shot test notification (priority 3) with no inference involved — useful for verifying the Worker secret + ntfy.sh path without waiting for a transition. The endpoint always returns `202` (the publish is queued via `waitUntil`); if nothing arrives on your phone, tail the Worker to see the real result: `cd worker && npx wrangler tail --format json` then re-fire — a `ntfy publish 429` line means the token is missing or invalid.
+That sends a one-shot blue test embed (no inference involved) — useful for verifying the Worker secret + Discord path without waiting for a transition. The endpoint always returns `202` (the publish is queued via `waitUntil`); if nothing arrives in Discord, tail the Worker to see the real result: `cd worker && npx wrangler tail --format json` then re-fire — a `Discord test notification failed: 401/404` line means the webhook URL is wrong or revoked, and `DISCORD_WEBHOOK_URL not set` means the secret is missing.
 
-You can also publish directly from the terminal (bypassing the Worker entirely):
+You can also post directly from the terminal (bypassing the Worker entirely):
 
 ```bash
-TOPIC=$(cat ntfy.key | tr -d '[:space:]')
-curl -sS -X POST https://ntfy.sh/ -H "Content-Type: application/json" \
-  -d "{\"topic\":\"$TOPIC\",\"title\":\"test\",\"message\":\"hello\"}"
+curl -sS -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" \
+  -d '{"embeds":[{"title":"test","description":"hello","color":3447003}]}'
 ```

--- a/worker/src/discord-mountain-notify.ts
+++ b/worker/src/discord-mountain-notify.ts
@@ -1,0 +1,112 @@
+// Discord webhook notification module for is-the-mountain-out.
+//
+// Replaces the legacy ntfy.sh push path. The Worker calls:
+//   - notifyMountainVisibility(env, result) on the Not Out -> visible transition
+//   - notifyDiscordTest(env)               from the /notify-test endpoint
+//
+// Integration (worker/src/index.ts):
+//   import { notifyMountainVisibility } from "./discord-mountain-notify";
+//   ctx.waitUntil(notifyMountainVisibility(env, result));
+//
+// Delivery never throws — webhook failures are logged and swallowed so they
+// cannot crash the scheduled handler or block the history append.
+
+export interface PredictionResult {
+  visible: boolean;
+  confidence: number; // 0..1, combined visible-class confidence
+  label: string; // "Full" | "Partial" | raw class name
+  imageUrl?: string; // webcam snapshot to embed
+  timestamp?: string; // ISO 8601; defaults to now
+}
+
+export interface Env {
+  // Discord webhook URL. Optional so a missing secret degrades to a logged
+  // skip rather than a thrown error (mirrors the old NTFY_TOPIC guard).
+  DISCORD_WEBHOOK_URL?: string;
+}
+
+const COLOR_VISIBLE = 0x2ecc71; // green
+const COLOR_NOT_VISIBLE = 0x95a5a6; // gray
+const COLOR_TEST = 0x3498db; // blue
+
+interface DiscordEmbed {
+  title: string;
+  description?: string;
+  color: number;
+  fields?: { name: string; value: string; inline?: boolean }[];
+  image?: { url: string };
+  footer?: { text: string };
+  timestamp?: string;
+}
+
+// Single delivery path for every embed. Guards on a missing webhook, logs
+// non-2xx responses with a truncated body, and swallows network errors.
+async function postWebhook(env: Env, embed: DiscordEmbed, context: string): Promise<boolean> {
+  if (!env.DISCORD_WEBHOOK_URL) {
+    console.warn(`DISCORD_WEBHOOK_URL not set; skipping Discord ${context}`);
+    return false;
+  }
+  try {
+    const response = await fetch(env.DISCORD_WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ embeds: [embed] }),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "(unreadable body)");
+      console.error(
+        `Discord ${context} failed: ${response.status} ${response.statusText} — ${body.slice(0, 200)}`,
+      );
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error(
+      `Discord ${context} request error:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return false;
+  }
+}
+
+/**
+ * Post a Discord embed announcing the mountain visibility prediction.
+ * Returns true if the webhook was delivered successfully, false otherwise.
+ */
+export async function notifyMountainVisibility(env: Env, result: PredictionResult): Promise<boolean> {
+  const { visible, confidence, label, imageUrl, timestamp } = result;
+  const confidencePct = (confidence * 100).toFixed(1);
+  const ts = timestamp ?? new Date().toISOString();
+
+  const embed: DiscordEmbed = {
+    title: visible ? "🏔️ The mountain is out!" : "☁️ The mountain is not visible",
+    color: visible ? COLOR_VISIBLE : COLOR_NOT_VISIBLE,
+    fields: [
+      { name: "Confidence", value: `${confidencePct}%`, inline: true },
+      { name: "Classification", value: label, inline: true },
+    ],
+    footer: { text: "is-the-mountain-out • Automated prediction" },
+    timestamp: ts,
+  };
+  if (imageUrl) {
+    embed.image = { url: imageUrl };
+  }
+
+  return postWebhook(env, embed, "visibility notification");
+}
+
+/**
+ * Post a one-shot Discord test embed (no inference involved) so the
+ * Worker -> Discord webhook path can be verified end to end.
+ */
+export async function notifyDiscordTest(env: Env): Promise<boolean> {
+  const embed: DiscordEmbed = {
+    title: "🏔️ Worker notification test",
+    description:
+      "Test from the mountain-inference Worker. If you see this in Discord, the Worker → Discord webhook path is healthy.",
+    color: COLOR_TEST,
+    footer: { text: "is-the-mountain-out • Notification test" },
+    timestamp: new Date().toISOString(),
+  };
+  return postWebhook(env, embed, "test notification");
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -14,17 +14,17 @@
 // directly — no GitHub Contents API in the inference path.
 
 import { Container, getContainer } from "@cloudflare/containers";
+import { notifyDiscordTest, notifyMountainVisibility } from "./discord-mountain-notify";
 
 interface Env {
   INFERENCE_CONTAINER: DurableObjectNamespace<InferenceContainer>;
   STATE_BUCKET: R2Bucket;
   R2_ACCESS_KEY_ID: string;
   R2_SECRET_ACCESS_KEY: string;
-  NTFY_TOPIC: string;
-  // Optional ntfy.sh access token. Without it, publishing goes out anonymously
-  // and is rate-limited per source IP — which fails (HTTP 429) from Cloudflare's
-  // shared egress IPs. With a token, the quota is attributed to the ntfy account.
-  NTFY_TOKEN?: string;
+  // Discord webhook URL the Worker posts visibility transitions to. Optional so
+  // a missing secret degrades to a logged skip rather than a thrown error. Set
+  // out-of-band with `wrangler secret put DISCORD_WEBHOOK_URL`.
+  DISCORD_WEBHOOK_URL?: string;
 }
 
 export class InferenceContainer extends Container<Env> {
@@ -96,49 +96,23 @@ async function getPreviousState(env: Env): Promise<PredictionState | null> {
   }
 }
 
-async function ntfyPublish(env: Env, payload: Record<string, unknown>): Promise<void> {
-  if (!env.NTFY_TOPIC) {
-    console.warn("NTFY_TOPIC not set; skipping notification");
-    return;
-  }
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (env.NTFY_TOKEN) headers["Authorization"] = `Bearer ${env.NTFY_TOKEN}`;
-  try {
-    const resp = await fetch("https://ntfy.sh/", {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ topic: env.NTFY_TOPIC, ...payload }),
-    });
-    if (!resp.ok) {
-      const body = await resp.text().catch(() => "<unreadable>");
-      console.error(`ntfy publish ${resp.status}: ${body.slice(0, 200)}`);
-    }
-  } catch (e) {
-    console.error("ntfy publish threw:", e);
-  }
-}
-
 // Fire only on the Not Out → visible transition, mirroring tools/detect_mountain.py.
 async function notifyTransition(env: Env, prev: PredictionState | null, next: PredictionState): Promise<void> {
   if (!next.is_out) return;
   if (prev?.is_out) return;
   const visible = (next.confidence?.full ?? 0) + (next.confidence?.partial ?? 0);
   const label = next.class_name === "full" ? "Full" : "Partial";
-  await ntfyPublish(env, {
-    title: "🏔️ THE MOUNTAIN IS OUT",
-    message: `Mount Rainier is visible (${label}). Confidence: ${(visible * 100).toFixed(1)}%`,
-    priority: 5,
-    tags: ["mountain_snow_capped"],
+  await notifyMountainVisibility(env, {
+    visible: true,
+    confidence: visible,
+    label,
+    imageUrl: next.webcam_url,
+    timestamp: next.timestamp_utc,
   });
 }
 
 async function sendNotificationTest(env: Env): Promise<void> {
-  await ntfyPublish(env, {
-    title: "🏔️ Worker notification test",
-    message: "Test from mountain-inference Worker. If you see this on your phone, the Worker → ntfy.sh path is healthy.",
-    priority: 3,
-    tags: ["test_tube"],
-  });
+  await notifyDiscordTest(env);
 }
 
 async function appendHistory(env: Env, record: HistoryRecord): Promise<void> {


### PR DESCRIPTION
`WORKER` — **NOTIFICATIONS**

# The mountain now pings Discord, not ntfy

> _Anonymous ntfy.sh publishing kept getting 429'd from Cloudflare's shared egress IPs. The Worker now posts a rich embed straight to a Discord webhook — no per-IP quota, richer alerts._

> [!NOTE]
> **worker** · feat · risk: low

The `mountain-inference` Worker fires one alert on the **Not Out → visible** transition. On ntfy.sh that meant anonymous publishes rate-limited per source IP — and from Cloudflare's shared egress that returns HTTP 429, silently dropping the alert. This swaps the whole path for a Discord channel webhook: no per-IP limit, and a color-coded embed that carries the confidence, classification, and the live webcam snapshot.

## What changed
- **New module `worker/src/discord-mountain-notify.ts`** — exports `notifyMountainVisibility(env, result)` and `notifyDiscordTest(env)`. Single guarded delivery path: skips on a missing webhook, logs non-2xx with a truncated body, never throws.
- **`worker/src/index.ts`** — deleted `ntfyPublish()`; `notifyTransition()` now builds a `PredictionResult` (confidence = full+partial, label, `webcam_url` image, `timestamp_utc`) and calls the module. `/notify-test` posts a blue test embed.
- **Env** — dropped `NTFY_TOPIC` / `NTFY_TOKEN`, added `DISCORD_WEBHOOK_URL` (optional → missing-secret degrades to a logged skip).
- **Docs** — `NOTIFICATIONS.md` rewritten for the webhook path; `CLAUDE.md` deploy/secrets section updated. `ntfy.key` / `ntfy-token.key` are now obsolete.

> _"A missing webhook is a logged skip, not a crash — and never blocks the history append."_

## How it flows
```mermaid
flowchart TD
  A[cron */15 tick] --> B[callContainer /predict]
  B --> C{Not Out -> visible?}
  C -->|no| E[append history]
  C -->|yes| D[notifyMountainVisibility]
  D --> F{DISCORD_WEBHOOK_URL set?}
  F -->|no| G[console.warn, skip]
  F -->|yes| H[POST embed to Discord]
  D --> E
```

## Verification
- Isolated `tsc --noEmit` over `worker/src` (workers-types + containers) → **passes, 0 errors**.
- No webhook value committed — it's a `wrangler secret`.
- Not deployed.

## Risk & rollout
- [ ] `npx wrangler secret put DISCORD_WEBHOOK_URL` (from `worker/`), then `wrangler deploy`.
- [ ] Smoke-test: `curl -X POST .../notify-test` → blue embed in Discord.
- Old secrets are inert after deploy; optionally `wrangler secret delete NTFY_TOPIC` / `NTFY_TOKEN` and remove the key files.
- Rollback: revert this PR and re-`deploy` (ntfy secrets still exist until deleted).
- Out of scope: `tools/local_notifier.py` (local-only fallback) still uses ntfy.
