### PR TITLE
docs: adopt shared LoRA training convention (just + TRAINING.md)

### DIFF
--- a/TRAINING.md
+++ b/TRAINING.md
@@ -1,0 +1,36 @@
+# LoRA training convention
+
+This project shares a *harness* convention for LoRA training with the qwenbot/RAG
+projects (`tommybot`). It is **not** a shared training library — the two trainers
+have nothing in common at the tensor level (this repo trains a ConvNeXt-Tiny image
+classifier with PyTorch + PEFT; tommybot trains a Qwen3-4B text LLM with MLX). What's
+shared is the operational contract, so "kick off a LoRA training run" feels the same
+across projects. The canonical write-up lives in tommybot's `TRAINING.md`; this is
+the mountain-specific instance.
+
+## The contract, here
+
+1. **Training is an in-repo CLI command,** with a `just train` convenience recipe
+   (`uv tool install rust-just` if you don't have `just`):
+
+   ```sh
+   just train data/labels.yaml 5
+   # → uv run training batch --labels data/labels.yaml --epochs 5
+   ```
+
+   (the `training` console script → `train.scheduler:app`.)
+
+2. **Training runs locally on the most capable machine, *not* under Nomad.** It
+   prefetches the dataset from R2 and runs gradient descent on MPS — RAM-heavy and
+   worth watching the per-epoch val loss for — so run it interactively on the best
+   hardware available, not pinned to the weak always-on node. **Nomad here is
+   reserved for the always-on collector service** (`collect.hcl`) plus the one-shot
+   *capture* jobs (`once.hcl`, `capture_out.hcl`); training is a different shape and
+   does not belong there.
+
+3. **Adapters/checkpoints land where serving auto-discovers them:** the best
+   checkpoint (by val loss) is written to `train/checkpoints/` (via
+   `ConfigLoader.checkpoint_dir`) and uploaded to R2 for the inference container to
+   pull on cold start. See `CHECKPOINTS.md` for model history.
+
+4. **Weights and training data stay out of git** (see `.gitignore`).

--- a/justfile
+++ b/justfile
@@ -1,0 +1,12 @@
+# is-the-mountain-out tasks. Training runs locally on your most capable machine
+# (it prefetches from R2 and runs gradient descent on MPS — see TRAINING.md);
+# Nomad is reserved for the always-on collector service, not one-shot training.
+
+# List available recipes
+default:
+    @just --list
+
+# Train the ConvNeXt-Tiny LoRA + dual-input classifier; best checkpoint → train/checkpoints/.
+#   just train data/labels.yaml 5
+train labels="data/labels.yaml" epochs="5":
+    uv run training batch --labels {{labels}} --epochs {{epochs}}


### PR DESCRIPTION
Mountain-side half of the cross-project LoRA training unification (companion to tommyroar/tommybot#14, part of tommyroar/tommybot#6).

## What's here
- **`justfile`** — `just train [labels] [epochs]` recipe wrapping `uv run training batch`.
- **`TRAINING.md`** — this repo's instance of the shared convention.

## Convention
Training is a **local CLI run on the most capable machine**, not a Nomad job — it prefetches the dataset from R2 and runs gradient descent on MPS, so it wants the best hardware and an eye on the per-epoch val loss. Nomad here stays scoped to the always-on collector (`collect.hcl`) and the one-shot capture jobs (`once.hcl`, `capture_out.hcl`). No code changes to the trainer itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)