### PR TITLE
chore: The lint sweep that woke up the Nomad proxy

### DIFF
--- a/captures.ipynb
+++ b/captures.ipynb
@@ -20,7 +20,9 @@
     "from collect.notebook_helpers import CaptureBrowser, get_data_root\n",
     "\n",
     "data_root = get_data_root()\n",
-    "browser = CaptureBrowser(log_path=os.path.join(data_root, 'collection.log'), data_root=data_root)\n",
+    "browser = CaptureBrowser(\n",
+    "    log_path=os.path.join(data_root, \"collection.log\"), data_root=data_root\n",
+    ")\n",
     "browser.start()"
    ]
   }

--- a/collect/classifier.py
+++ b/collect/classifier.py
@@ -14,19 +14,20 @@ app = typer.Typer(help="Manage the interactive React classifier.")
 SERVER_PID_FILE = Path("data/classifier_server.pid")
 VITE_PID_FILE = Path("data/classifier_vite.pid")
 
+
 def get_folder_via_picker(title="Select Data Root"):
     """Opens a native folder picker and returns the selected path."""
     try:
         import tkinter as tk
         from tkinter import filedialog
+
         root = tk.Tk()
         root.withdraw()
         # Bring window to front
         root.attributes("-topmost", True)
         print("Opening native folder picker...")
         selected_dir = filedialog.askdirectory(
-            title=title,
-            initialdir=str(Path.cwd() / "data")
+            title=title, initialdir=str(Path.cwd() / "data")
         )
         root.destroy()
         return selected_dir
@@ -34,20 +35,24 @@ def get_folder_via_picker(title="Select Data Root"):
         print(f"Native picker failed: {e}. Defaulting to 'data/'.")
         return "data"
 
+
 @app.command("start")
 def start(port: int = 5173, data_root: str = None, labels_file: str = None):
     """Starts the FastAPI backend and Vite frontend for the classifier."""
-    
+
     # Check if already running
     if SERVER_PID_FILE.exists() or VITE_PID_FILE.exists():
-        print("Classifier processes may already be running. Use 'stop' first if needed.")
+        print(
+            "Classifier processes may already be running. Use 'stop' first if needed."
+        )
 
     if not data_root:
         data_root = get_folder_via_picker("Select Data Root for Classifier")
-        if not data_root: return
+        if not data_root:
+            return
 
     data_root = str(Path(data_root).absolute())
-    
+
     if not labels_file:
         labels_file = str(Path(data_root) / "labels.yaml")
     else:
@@ -55,12 +60,12 @@ def start(port: int = 5173, data_root: str = None, labels_file: str = None):
 
     print(f"🚀 Starting classifier for data: {data_root}")
     print(f"📄 Using labels file: {labels_file}")
-    
+
     # 1. Start FastAPI Backend (tools/classifier_server.py)
     env = os.environ.copy()
     env["MOUNTAIN_DATA_ROOT"] = data_root
     env["MOUNTAIN_LABELS_FILE"] = labels_file
-    
+
     # Force use of python from venv
     python_exe = str(Path(".venv/bin/python").absolute())
     if not Path(python_exe).exists():
@@ -72,11 +77,11 @@ def start(port: int = 5173, data_root: str = None, labels_file: str = None):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         env=env,
-        preexec_fn=os.setpgrp
+        preexec_fn=os.setpgrp,
     )
     SERVER_PID_FILE.parent.mkdir(parents=True, exist_ok=True)
     SERVER_PID_FILE.write_text(str(server_proc.pid))
-    
+
     # 2. Start Vite Frontend (ui/)
     ui_path = Path("ui")
     if not (ui_path / "node_modules").exists():
@@ -84,31 +89,44 @@ def start(port: int = 5173, data_root: str = None, labels_file: str = None):
         subprocess.run(["npm", "install"], cwd=ui_path, capture_output=True)
 
     # Use --host 0.0.0.0 to allow access via .local hostname
-    vite_cmd = ["npm", "run", "dev", "--", "--port", str(port), "--strictPort", "--host", "0.0.0.0"]
+    vite_cmd = [
+        "npm",
+        "run",
+        "dev",
+        "--",
+        "--port",
+        str(port),
+        "--strictPort",
+        "--host",
+        "0.0.0.0",
+    ]
     vite_proc = subprocess.Popen(
         vite_cmd,
         cwd=ui_path,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        preexec_fn=os.setpgrp
+        preexec_fn=os.setpgrp,
     )
     VITE_PID_FILE.write_text(str(vite_proc.pid))
-    
+
     # Wait for backend and read its port
     print("Verifying services...")
     backend_port = 8000
     port_file = Path(data_root) / "classifier_server.port"
-    
+
     backend_ok = False
     for _ in range(15):
         if port_file.exists():
             try:
                 backend_port = int(port_file.read_text().strip())
-                r = requests.get(f"http://localhost:{backend_port}/api/stats", timeout=1)
+                r = requests.get(
+                    f"http://localhost:{backend_port}/api/stats", timeout=1
+                )
                 if r.status_code == 200:
                     backend_ok = True
                     break
-            except: pass
+            except Exception:
+                pass
         time.sleep(1)
 
     if backend_ok:
@@ -124,25 +142,28 @@ def start(port: int = 5173, data_root: str = None, labels_file: str = None):
     # MANDATORY PLAYWRIGHT VALIDATION
     print("Performing Playwright validation...")
     try:
-        # We'll use a simple curl check first as a fast fallback, 
+        # We'll use a simple curl check first as a fast fallback,
         # but the mandate says headless playwright validation.
         # This will be handled by the agent turn after this command returns or within here if possible.
         # Since I am the agent, I will perform this via tool call after this write.
         pass
-    except: pass
+    except Exception:
+        pass
+
 
 @app.command("stop")
 def stop():
     """Stops all classifier processes."""
     print("Stopping classifier processes...")
-    
+
     for pid_file in [SERVER_PID_FILE, VITE_PID_FILE]:
         if pid_file.exists():
             try:
                 pid = int(pid_file.read_text().strip())
                 os.killpg(pid, signal.SIGTERM)
                 print(f"  Stopped process group {pid}")
-            except: pass
+            except Exception:
+                pass
             pid_file.unlink()
 
     # Fallback cleanup
@@ -150,8 +171,10 @@ def stop():
     subprocess.run(["pkill", "-9", "-f", "vite"], capture_output=True)
     print("✅ Cleanup complete.")
 
+
 def cli_wrapper():
     app()
+
 
 if __name__ == "__main__":
     app()

--- a/collect/collector.py
+++ b/collect/collector.py
@@ -1,10 +1,7 @@
 import click
 import time
-import os
-import subprocess
 import json
 import requests
-import signal
 import threading
 from pathlib import Path
 from datetime import datetime, UTC
@@ -18,12 +15,14 @@ import rumps
 # Assuming 'train' and 'collect' are in the python path.
 from train.config_loader import ConfigLoader
 from collect.tray import MountainTray
-from collect.state import make_state, write_state, read_state, read_label_counts, write_plan, read_plan, PLAN_FILENAME
+from collect.state import make_state, write_state, read_state, write_plan, read_plan
+from collect.sync import sync
 
 # --- Globals ---
 LOG_FILE = "data/collection.log"
 
 # --- Core Business Logic ---
+
 
 class WebcamStream:
     def __init__(self, url: str):
@@ -39,6 +38,7 @@ class WebcamStream:
     def release(self):
         self.cap.release()
 
+
 class WeatherFetcher:
     def __init__(self, station_id: str = "KSEA"):
         self.station_id = station_id
@@ -48,11 +48,12 @@ class WeatherFetcher:
         try:
             response = requests.get(self.base_url, timeout=10)
             response.raise_for_status()
-            lines = response.text.strip().split('\\n')
+            lines = response.text.strip().split("\\n")
             return lines[1] if len(lines) >= 2 else lines[0]
         except requests.RequestException as e:
             logging.warning(f"Error fetching METAR: {e}")
         return None
+
 
 def _derive_initial_last_capture_at(
     plan_timestamps: List[str],
@@ -65,7 +66,8 @@ def _derive_initial_last_capture_at(
     Priority: most recent past plan timestamp → previous state file value
     (only if it's actually in the past).
     """
-    from datetime import datetime, timezone
+    from datetime import datetime
+
     past = [t for t in plan_timestamps if datetime.fromisoformat(t) <= now_utc]
     if past:
         return past[-1]
@@ -87,12 +89,20 @@ def log_event(event: str, status: str, metadata: Optional[Dict] = None):
         "timestamp": datetime.now(UTC).isoformat(),
         "event": event,
         "status": status,
-        "metadata": metadata or {}
+        "metadata": metadata or {},
     }
     with open(log_path, "a") as f:
         f.write(json.dumps(entry) + "\n")
 
-def perform_capture(config_loader: ConfigLoader, weather_fetcher: WeatherFetcher, data_root: str, session_uuid: Optional[str] = None, step_info: Optional[Dict] = None, remote_storage=None) -> Optional[Path]:
+
+def perform_capture(
+    config_loader: ConfigLoader,
+    weather_fetcher: WeatherFetcher,
+    data_root: str,
+    session_uuid: Optional[str] = None,
+    step_info: Optional[Dict] = None,
+    remote_storage=None,
+) -> Optional[Path]:
     now_utc = datetime.now(UTC)
     date_str = now_utc.strftime("%Y%m%d")
     time_str = now_utc.strftime("%H%M%S_%f_UTC")
@@ -124,7 +134,9 @@ def perform_capture(config_loader: ConfigLoader, weather_fetcher: WeatherFetcher
     try:
         frame = stream.capture_raw()
         if frame is not None:
-            safe_name = str(source).replace("/", "_").replace(":", "_").replace(".", "_")
+            safe_name = (
+                str(source).replace("/", "_").replace(":", "_").replace(".", "_")
+            )
             filename = f"{time_str}_{safe_name}.jpg"
             image_path = image_dir / filename
             cv2.imwrite(str(image_path), frame)
@@ -132,7 +144,9 @@ def perform_capture(config_loader: ConfigLoader, weather_fetcher: WeatherFetcher
 
             # Upload to R2 if a remote storage backend is provided
             if remote_storage is not None:
-                _upload_to_remote(remote_storage, data_root, image_path, frame, metar_path, metar_text)
+                _upload_to_remote(
+                    remote_storage, data_root, image_path, frame, metar_path, metar_text
+                )
 
             return image_path
         else:
@@ -142,7 +156,14 @@ def perform_capture(config_loader: ConfigLoader, weather_fetcher: WeatherFetcher
         stream.release()
 
 
-def _upload_to_remote(storage, data_root: str, image_path: Path, frame, metar_path: Optional[Path], metar_text: Optional[str]) -> None:
+def _upload_to_remote(
+    storage,
+    data_root: str,
+    image_path: Path,
+    frame,
+    metar_path: Optional[Path],
+    metar_text: Optional[str],
+) -> None:
     """Best-effort upload of a capture to the remote storage backend."""
     try:
         root = Path(data_root)
@@ -155,7 +176,9 @@ def _upload_to_remote(storage, data_root: str, image_path: Path, frame, metar_pa
     except Exception as e:
         logging.warning(f"R2 upload failed (non-fatal): {e}")
 
+
 # --- CLI using Click ---
+
 
 @click.group(invoke_without_command=True)
 @click.pass_context
@@ -164,11 +187,20 @@ def cli(ctx, **kwargs):
     if ctx.invoked_subcommand is None:
         ctx.invoke(tray)
 
-def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, session_id: Optional[str] = None):
-    """Internal implementation for running the tray icon loop."""
-    from datetime import datetime, timezone, timedelta
 
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+def run_tray_loop(
+    config_path: str,
+    data_root: str,
+    is_once: bool = False,
+    session_id: Optional[str] = None,
+):
+    """Internal implementation for running the tray icon loop."""
+    from datetime import datetime, timezone
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
     if not session_id:
         session_id = str(uuid.uuid4())[:8]
@@ -181,8 +213,11 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
     if config_loader.storage_backend == "r2":
         try:
             from collect.storage import R2Storage
+
             cfg = config_loader.storage_config
-            remote_storage = R2Storage(account_id=cfg["r2_account_id"], bucket=cfg["r2_bucket"])
+            remote_storage = R2Storage(
+                account_id=cfg["r2_account_id"], bucket=cfg["r2_bucket"]
+            )
             logging.info(f"R2 upload enabled: {cfg['r2_bucket']}")
         except Exception as e:
             logging.warning(f"R2 storage init failed, continuing local-only: {e}")
@@ -190,13 +225,19 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
     # Load plan if one exists
     all_plan_timestamps = read_plan(data_root) or []
     now_utc = datetime.now(timezone.utc)
-    plan_timestamps = [t for t in all_plan_timestamps if datetime.fromisoformat(t) > now_utc]
+    plan_timestamps = [
+        t for t in all_plan_timestamps if datetime.fromisoformat(t) > now_utc
+    ]
     if all_plan_timestamps:
         logging.info(f"Loaded plan: {len(plan_timestamps)} captures remaining.")
     else:
-        logging.info(f"No plan file found. Using fixed interval ({fallback_interval}s).")
+        logging.info(
+            f"No plan file found. Using fixed interval ({fallback_interval}s)."
+        )
 
-    plan_last_capture_at = _derive_initial_last_capture_at(all_plan_timestamps, data_root, now_utc, session_id)
+    plan_last_capture_at = _derive_initial_last_capture_at(
+        all_plan_timestamps, data_root, now_utc, session_id
+    )
     plan_final_capture_at = all_plan_timestamps[-1] if all_plan_timestamps else None
 
     plan_total = len(plan_timestamps) if plan_timestamps else 0
@@ -216,7 +257,9 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
         _prior = json.loads(_prior_path.read_text())
         prior_capture_count = _prior.get("capture_count", 0)
         prior_plan_total = _prior.get("plan_total", 0)
-        logging.info(f"Prior sessions: {prior_capture_count}/{prior_plan_total} captures carried over.")
+        logging.info(
+            f"Prior sessions: {prior_capture_count}/{prior_plan_total} captures carried over."
+        )
     except Exception:
         pass
 
@@ -227,11 +270,7 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
 
     def _append_session_label(image_path: Path, is_adhoc: bool = False) -> None:
         rel = str(image_path.relative_to(Path(data_root)))
-        entry = {
-            rel: {
-                "type": "manual" if is_adhoc else "scheduled"
-            }
-        }
+        entry = {rel: {"type": "manual" if is_adhoc else "scheduled"}}
         with open(session_labels_file, "a") as f:
             yaml.dump(entry, f, default_flow_style=False)
 
@@ -250,7 +289,7 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
             wait = max(0, (target - datetime.now(timezone.utc)).total_seconds())
         else:
             wait = fallback_interval
-        
+
         logging.info(f"Next capture in {int(wait)}s.")
         end = time.monotonic() + wait
         while time.monotonic() < end:
@@ -261,30 +300,46 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
                 logging.info("Ad-hoc trigger detected!")
                 try:
                     trigger_file.unlink()
-                except Exception: pass
+                except Exception:
+                    pass
                 return True
             time.sleep(min(1, end - time.monotonic()))
         return False
 
     def capture_loop():
-        nonlocal capture_count, plan_index, last_capture_at, plan_total, plan_final_capture_at
+        nonlocal \
+            capture_count, \
+            plan_index, \
+            last_capture_at, \
+            plan_total, \
+            plan_final_capture_at
 
         while not stop_event.is_set():
             # Scheduled capture start
-            write_state(data_root, make_state(
-                session_id=session_id, status="Capturing...",
-                capture_count=capture_count,
-                plan_total=plan_total,
-                interval_seconds=fallback_interval,
-                last_capture_at=last_capture_at,
-                next_capture_at=_next_capture_at(),
-                session_labels_file=str(session_labels_file),
-                final_capture_at=plan_final_capture_at,
-                prior_capture_count=prior_capture_count,
-                prior_plan_total=prior_plan_total,
-            ))
+            write_state(
+                data_root,
+                make_state(
+                    session_id=session_id,
+                    status="Capturing...",
+                    capture_count=capture_count,
+                    plan_total=plan_total,
+                    interval_seconds=fallback_interval,
+                    last_capture_at=last_capture_at,
+                    next_capture_at=_next_capture_at(),
+                    session_labels_file=str(session_labels_file),
+                    final_capture_at=plan_final_capture_at,
+                    prior_capture_count=prior_capture_count,
+                    prior_plan_total=prior_plan_total,
+                ),
+            )
 
-            image_path = perform_capture(config_loader, weather_fetcher, data_root, session_uuid=session_id, remote_storage=remote_storage)
+            image_path = perform_capture(
+                config_loader,
+                weather_fetcher,
+                data_root,
+                session_uuid=session_id,
+                remote_storage=remote_storage,
+            )
 
             if image_path:
                 capture_count += 1
@@ -294,19 +349,22 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
             if plan_timestamps:
                 plan_index += 1
 
-            write_state(data_root, make_state(
-                session_id=session_id,
-                status="Idle" if image_path else "Error",
-                capture_count=capture_count,
-                plan_total=plan_total,
-                interval_seconds=fallback_interval,
-                last_capture_at=last_capture_at,
-                next_capture_at=_next_capture_at(),
-                session_labels_file=str(session_labels_file),
-                final_capture_at=plan_final_capture_at,
-                prior_capture_count=prior_capture_count,
-                prior_plan_total=prior_plan_total,
-            ))
+            write_state(
+                data_root,
+                make_state(
+                    session_id=session_id,
+                    status="Idle" if image_path else "Error",
+                    capture_count=capture_count,
+                    plan_total=plan_total,
+                    interval_seconds=fallback_interval,
+                    last_capture_at=last_capture_at,
+                    next_capture_at=_next_capture_at(),
+                    session_labels_file=str(session_labels_file),
+                    final_capture_at=plan_final_capture_at,
+                    prior_capture_count=prior_capture_count,
+                    prior_plan_total=prior_plan_total,
+                ),
+            )
 
             if is_once:
                 logging.info("Single capture complete.")
@@ -319,10 +377,14 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
                 try:
                     import sys as _sys
                     from datetime import timedelta as _td
+
                     _sys.path.insert(0, str(Path(config_path).resolve().parent))
                     from tools.plan import CapturePlan
+
                     planner = CapturePlan(47.6533, -122.3091)
-                    _now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+                    _now = datetime.now(timezone.utc).replace(
+                        minute=0, second=0, microsecond=0
+                    )
                     intervals = planner.generate(_now, days=30)
                     new_ts = []
                     current = _now
@@ -332,13 +394,21 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
                         current = current + _td(seconds=int(step[:-1]))
                         new_ts.append(current.isoformat())
                     write_plan(data_root, new_ts)
-                    plan_timestamps[:] = [t for t in new_ts if datetime.fromisoformat(t) > datetime.now(timezone.utc)]
+                    plan_timestamps[:] = [
+                        t
+                        for t in new_ts
+                        if datetime.fromisoformat(t) > datetime.now(timezone.utc)
+                    ]
                     plan_index = 0
                     plan_total = len(plan_timestamps)
                     plan_final_capture_at = new_ts[-1] if new_ts else None
-                    logging.info(f"New plan: {len(plan_timestamps)} captures over 30 days.")
+                    logging.info(
+                        f"New plan: {len(plan_timestamps)} captures over 30 days."
+                    )
                 except Exception:
-                    logging.exception("Failed to regenerate plan. Falling back to fixed interval.")
+                    logging.exception(
+                        "Failed to regenerate plan. Falling back to fixed interval."
+                    )
                     plan_timestamps.clear()
                     plan_index = 0
                     plan_total = 0
@@ -349,47 +419,66 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
                 if not is_adhoc:
                     # Normal scheduled wakeup
                     break
-                
+
                 # Ad-hoc capture wakeup
-                write_state(data_root, make_state(
-                    session_id=session_id, status="Capturing (Ad-hoc)...",
-                    capture_count=capture_count,
-                    plan_total=plan_total,
-                    interval_seconds=fallback_interval,
-                    last_capture_at=last_capture_at,
-                    next_capture_at=_next_capture_at(),
-                    session_labels_file=str(session_labels_file),
-                    final_capture_at=plan_final_capture_at,
-                ))
-                
-                image_path = perform_capture(config_loader, weather_fetcher, data_root, session_uuid=session_id, remote_storage=remote_storage)
+                write_state(
+                    data_root,
+                    make_state(
+                        session_id=session_id,
+                        status="Capturing (Ad-hoc)...",
+                        capture_count=capture_count,
+                        plan_total=plan_total,
+                        interval_seconds=fallback_interval,
+                        last_capture_at=last_capture_at,
+                        next_capture_at=_next_capture_at(),
+                        session_labels_file=str(session_labels_file),
+                        final_capture_at=plan_final_capture_at,
+                    ),
+                )
+
+                image_path = perform_capture(
+                    config_loader,
+                    weather_fetcher,
+                    data_root,
+                    session_uuid=session_id,
+                    remote_storage=remote_storage,
+                )
                 if image_path:
                     capture_count += 1
                     last_capture_at = datetime.now(timezone.utc).isoformat()
                     _append_session_label(image_path, is_adhoc=True)
-                
-                write_state(data_root, make_state(
-                    session_id=session_id, status="Idle",
-                    capture_count=capture_count,
-                    plan_total=plan_total,
-                    interval_seconds=fallback_interval,
-                    last_capture_at=last_capture_at,
-                    next_capture_at=_next_capture_at(),
-                    session_labels_file=str(session_labels_file),
-                    final_capture_at=plan_final_capture_at,
-                ))
+
+                write_state(
+                    data_root,
+                    make_state(
+                        session_id=session_id,
+                        status="Idle",
+                        capture_count=capture_count,
+                        plan_total=plan_total,
+                        interval_seconds=fallback_interval,
+                        last_capture_at=last_capture_at,
+                        next_capture_at=_next_capture_at(),
+                        session_labels_file=str(session_labels_file),
+                        final_capture_at=plan_final_capture_at,
+                    ),
+                )
 
     # Write initial state before starting tray so first _refresh() has data.
     # last_capture_at is derived from the plan (most recent past timestamp).
-    write_state(data_root, make_state(
-        session_id=session_id, status="Starting...",
-        capture_count=capture_count, plan_total=plan_total,
-        interval_seconds=fallback_interval,
-        last_capture_at=last_capture_at,
-        next_capture_at=_next_capture_at(),
-        session_labels_file=str(session_labels_file),
-        final_capture_at=plan_final_capture_at,
-    ))
+    write_state(
+        data_root,
+        make_state(
+            session_id=session_id,
+            status="Starting...",
+            capture_count=capture_count,
+            plan_total=plan_total,
+            interval_seconds=fallback_interval,
+            last_capture_at=last_capture_at,
+            next_capture_at=_next_capture_at(),
+            session_labels_file=str(session_labels_file),
+            final_capture_at=plan_final_capture_at,
+        ),
+    )
 
     t = threading.Thread(target=capture_loop, daemon=True)
     t.start()
@@ -404,14 +493,15 @@ def run_tray_loop(config_path: str, data_root: str, is_once: bool = False, sessi
 
 
 @cli.command()
-@click.option('--data-root', default='data', help='Root directory for data storage.')
-@click.option('--days', default=30, help='Number of days to plan ahead.')
-@click.option('--lat', default=47.6533, help='Latitude of camera location.')
-@click.option('--lon', default=-122.3091, help='Longitude of camera location.')
+@click.option("--data-root", default="data", help="Root directory for data storage.")
+@click.option("--days", default=30, help="Number of days to plan ahead.")
+@click.option("--lat", default=47.6533, help="Latitude of camera location.")
+@click.option("--lon", default=-122.3091, help="Longitude of camera location.")
 def schedule(data_root: str, days: int, lat: float, lon: float):
     """Generate a solar-aligned capture plan and save it to capture_plan.json."""
     import sys as _sys
     from datetime import datetime, timezone, timedelta as _timedelta
+
     _sys.path.insert(0, str(Path(__file__).parent.parent))
     from tools.plan import CapturePlan
 
@@ -437,27 +527,32 @@ def schedule(data_root: str, days: int, lat: float, lon: float):
 
 
 @cli.command()
-@click.option('--config', default='mountain.toml', help='Path to config file.')
-@click.option('--data-root', default='data', help='Root directory for data storage.')
-@click.option('--session-id', default=None, help='Unique ID for this session.')
+@click.option("--config", default="mountain.toml", help="Path to config file.")
+@click.option("--data-root", default="data", help="Root directory for data storage.")
+@click.option("--session-id", default=None, help="Unique ID for this session.")
 def tray(config: str, data_root: str, session_id: str):
     """Runs continuous collection with a system tray icon."""
     run_tray_loop(config, data_root, is_once=False, session_id=session_id)
 
+
 @cli.command()
-@click.option('--config', default='mountain.toml', help='Path to config file.')
-@click.option('--data-root', default='data', help='Root directory for data storage.')
-@click.option('--session-id', default=None, help='Unique ID for this session.')
+@click.option("--config", default="mountain.toml", help="Path to config file.")
+@click.option("--data-root", default="data", help="Root directory for data storage.")
+@click.option("--session-id", default=None, help="Unique ID for this session.")
 def once(config: str, data_root: str, session_id: str):
     """Performs a single capture, showing a tray icon briefly."""
     run_tray_loop(config, data_root, is_once=True, session_id=session_id)
 
+
 @cli.command()
-@click.option('--config', default='mountain.toml', help='Path to config file.')
-@click.option('--data-root', default='data', help='Root directory for data storage.')
+@click.option("--config", default="mountain.toml", help="Path to config file.")
+@click.option("--data-root", default="data", help="Root directory for data storage.")
 def live(config: str, data_root: str):
     """Runs continuous collection in the foreground (no tray icon)."""
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
     session_id = str(uuid.uuid4())[:8]
     config_loader = ConfigLoader(config)
     weather_fetcher = WeatherFetcher(config_loader.metar_station)
@@ -467,21 +562,32 @@ def live(config: str, data_root: str):
     if config_loader.storage_backend == "r2":
         try:
             from collect.storage import R2Storage
+
             cfg = config_loader.storage_config
-            remote_storage = R2Storage(account_id=cfg["r2_account_id"], bucket=cfg["r2_bucket"])
+            remote_storage = R2Storage(
+                account_id=cfg["r2_account_id"], bucket=cfg["r2_bucket"]
+            )
             logging.info(f"R2 upload enabled: {cfg['r2_bucket']}")
         except Exception as e:
             logging.warning(f"R2 storage init failed, continuing local-only: {e}")
 
-    logging.info(f"Starting live collection loop (interval: {interval}s). Press Ctrl+C to stop.")
+    logging.info(
+        f"Starting live collection loop (interval: {interval}s). Press Ctrl+C to stop."
+    )
     try:
         while True:
-            perform_capture(config_loader, weather_fetcher, data_root, session_uuid=session_id, remote_storage=remote_storage)
+            perform_capture(
+                config_loader,
+                weather_fetcher,
+                data_root,
+                session_uuid=session_id,
+                remote_storage=remote_storage,
+            )
             time.sleep(interval)
     except KeyboardInterrupt:
         logging.info("Stopping live collection.")
 
-from collect.sync import sync
+
 cli.add_command(sync)
 
 if __name__ == "__main__":

--- a/collect/notebook_helpers.py
+++ b/collect/notebook_helpers.py
@@ -1,40 +1,46 @@
 import yaml
 import json
-import os
-import subprocess
 from pathlib import Path
-from datetime import datetime, timedelta, UTC
-from IPython.display import display, Image, HTML, clear_output
+from IPython.display import display
 import ipywidgets as widgets
+
 
 def load_labels(data_root):
     """Loads the training index from labels.yaml."""
     labels_path = Path(data_root) / "labels.yaml"
     if labels_path.exists():
-        with open(labels_path, 'r') as f:
+        with open(labels_path, "r") as f:
             return yaml.safe_load(f) or {}
     return {}
+
 
 def save_labels(data_root, labels):
     """Saves the training index to labels.yaml."""
     labels_path = Path(data_root) / "labels.yaml"
-    with open(labels_path, 'w') as f:
+    with open(labels_path, "w") as f:
         yaml.safe_dump(labels, f)
 
+
 class CaptureBrowser:
-    def __init__(self, log_path='data/collection.log', data_root='data', batch_size=20):
+    def __init__(self, log_path="data/collection.log", data_root="data", batch_size=20):
         self.log_path = Path(log_path)
         self.data_root = Path(data_root)
         self.batch_size = batch_size
-        
+
         # UI Components
         self.main_container = widgets.VBox()
         self.grid_container = widgets.GridBox(
-            layout=widgets.Layout(grid_template_columns="repeat(2, 512px)", grid_gap="20px", justify_content="center")
+            layout=widgets.Layout(
+                grid_template_columns="repeat(2, 512px)",
+                grid_gap="20px",
+                justify_content="center",
+            )
         )
         self.status_label = widgets.HTML()
-        self.control_bar = widgets.HBox(layout=widgets.Layout(justify_content="center", margin="20px 0"))
-        
+        self.control_bar = widgets.HBox(
+            layout=widgets.Layout(justify_content="center", margin="20px 0")
+        )
+
         self.all_captures = []
         self.current_page = 0
 
@@ -43,64 +49,88 @@ class CaptureBrowser:
         captures = []
         if not self.log_path.exists():
             return []
-            
+
         with open(self.log_path, "r") as f:
             for line in f:
                 try:
                     entry = json.loads(line)
-                    if entry.get("event") == "CAPTURE" and entry.get("status") == "SUCCESS":
+                    if (
+                        entry.get("event") == "CAPTURE"
+                        and entry.get("status") == "SUCCESS"
+                    ):
                         meta = entry["metadata"]
-                        captures.append({
-                            "timestamp": entry["timestamp"],
-                            "image": meta["image_path"],
-                            "metar": meta.get("metar_path")
-                        })
-                except: continue
+                        captures.append(
+                            {
+                                "timestamp": entry["timestamp"],
+                                "image": meta["image_path"],
+                                "metar": meta.get("metar_path"),
+                            }
+                        )
+                except Exception:
+                    continue
         return sorted(captures, key=lambda x: x["timestamp"], reverse=True)
 
     def refresh_ui(self):
         self.all_captures = self._load_captures()
-        
+
         start = self.current_page * self.batch_size
         end = start + self.batch_size
         page_items = self.all_captures[start:end]
-        
-        self.status_label.value = f"<div style='text-align:center;'><b>Total Captures:</b> {len(self.all_captures)} | <b>Showing:</b> {start+1}-{min(end, len(self.all_captures))}</div>"
-        
+
+        self.status_label.value = f"<div style='text-align:center;'><b>Total Captures:</b> {len(self.all_captures)} | <b>Showing:</b> {start + 1}-{min(end, len(self.all_captures))}</div>"
+
         if not page_items:
-            self.grid_container.children = [widgets.HTML("<h3 style='text-align:center; width:100%;'>No captures found in log.</h3>")]
+            self.grid_container.children = [
+                widgets.HTML(
+                    "<h3 style='text-align:center; width:100%;'>No captures found in log.</h3>"
+                )
+            ]
             return
 
         grid_items = []
         for item in page_items:
-            abs_img = Path(item['image'])
-            if not abs_img.exists(): 
-                abs_img = self.data_root.parent / item['image']
-                
+            abs_img = Path(item["image"])
+            if not abs_img.exists():
+                abs_img = self.data_root.parent / item["image"]
+
             try:
                 with open(abs_img, "rb") as f:
-                    img_widget = widgets.Image(value=f.read(), format='jpg', width=512)
-                
+                    img_widget = widgets.Image(value=f.read(), format="jpg", width=512)
+
                 metar_text = "N/A"
-                if item['metar']:
-                    metar_p = Path(item['metar'])
-                    if not metar_p.exists(): metar_p = self.data_root.parent / item['metar']
+                if item["metar"]:
+                    metar_p = Path(item["metar"])
+                    if not metar_p.exists():
+                        metar_p = self.data_root.parent / item["metar"]
                     if metar_p.exists():
-                        with open(metar_p, "r") as f: metar_text = f.read().strip()
-                
-                info = widgets.HTML(f"<div style='font-size:11px; color:#666;'>{item['timestamp']}<br><code>{metar_text}</code></div>")
+                        with open(metar_p, "r") as f:
+                            metar_text = f.read().strip()
+
+                info = widgets.HTML(
+                    f"<div style='font-size:11px; color:#666;'>{item['timestamp']}<br><code>{metar_text}</code></div>"
+                )
                 grid_items.append(widgets.VBox([img_widget, info]))
-            except: continue
-        
+            except Exception:
+                continue
+
         self.grid_container.children = grid_items
-        
+
         # Pagination buttons
-        btn_prev = widgets.Button(description="⬅️ Newer", disabled=(self.current_page == 0))
-        btn_next = widgets.Button(description="Older ➡️", disabled=(end >= len(self.all_captures)))
-        
-        def go_prev(_): self.current_page -= 1; self.refresh_ui()
-        def go_next(_): self.current_page += 1; self.refresh_ui()
-        
+        btn_prev = widgets.Button(
+            description="⬅️ Newer", disabled=(self.current_page == 0)
+        )
+        btn_next = widgets.Button(
+            description="Older ➡️", disabled=(end >= len(self.all_captures))
+        )
+
+        def go_prev(_):
+            self.current_page -= 1
+            self.refresh_ui()
+
+        def go_next(_):
+            self.current_page += 1
+            self.refresh_ui()
+
         btn_prev.on_click(go_prev)
         btn_next.on_click(go_next)
         self.control_bar.children = [btn_prev, btn_next]
@@ -113,6 +143,6 @@ class CaptureBrowser:
             widgets.HTML("<hr>"),
             self.grid_container,
             widgets.HTML("<hr>"),
-            self.control_bar
+            self.control_bar,
         ]
         self.refresh_ui()

--- a/collect/simple_classifier.py
+++ b/collect/simple_classifier.py
@@ -1,11 +1,12 @@
 import http.server
 import socketserver
 import json
-import os
 import yaml
 from pathlib import Path
+from typing import Optional
 import urllib.parse
-import sys
+
+import typer
 
 # Minimal HTML for the classifier
 HTML_TEMPLATE = """
@@ -92,53 +93,53 @@ HTML_TEMPLATE = """
 </html>
 """
 
+
 class ClassifierHandler(http.server.SimpleHTTPRequestHandler):
     def log_message(self, format, *args):
-        return # Silent
+        return  # Silent
 
     def do_GET(self):
-        if self.path == '/':
+        if self.path == "/":
             self.send_response(200)
-            self.send_header('Content-type', 'text/html')
+            self.send_header("Content-type", "text/html")
             self.end_headers()
             self.wfile.write(HTML_TEMPLATE.encode())
-        
-        elif self.path == '/api/data':
+
+        elif self.path == "/api/data":
             self.send_response(200)
-            self.send_header('Content-type', 'application/json')
+            self.send_header("Content-type", "application/json")
             self.end_headers()
-            
+
             # Scan for images
             data_root = Path(self.server.data_root)
             all_imgs = []
             for img_p in sorted(data_root.rglob("*.jpg")):
                 rel = str(img_p.relative_to(data_root))
                 all_imgs.append({"path": rel})
-            
+
             # Load existing labels
             labels = {}
             labels_p = data_root / "labels.yaml"
             if labels_p.exists():
-                with open(labels_p, 'r') as f:
+                with open(labels_p, "r") as f:
                     labels = yaml.safe_load(f) or {}
-            
-            # Filter out already labeled
-            unlabeled = [img for img in all_imgs if img['path'] not in labels]
-            
-            self.wfile.write(json.dumps({
-                "images": unlabeled,
-                "labels": labels
-            }).encode())
 
-        elif self.path.startswith('/img/'):
+            # Filter out already labeled
+            unlabeled = [img for img in all_imgs if img["path"] not in labels]
+
+            self.wfile.write(
+                json.dumps({"images": unlabeled, "labels": labels}).encode()
+            )
+
+        elif self.path.startswith("/img/"):
             rel_path = urllib.parse.unquote(self.path[5:])
             abs_path = Path(self.server.data_root) / rel_path
-            
+
             if abs_path.exists():
                 self.send_response(200)
-                self.send_header('Content-type', 'image/jpeg')
+                self.send_header("Content-type", "image/jpeg")
                 self.end_headers()
-                with open(abs_path, 'rb') as f:
+                with open(abs_path, "rb") as f:
                     self.wfile.write(f.read())
             else:
                 self.send_error(404)
@@ -146,25 +147,26 @@ class ClassifierHandler(http.server.SimpleHTTPRequestHandler):
             self.send_error(404)
 
     def do_POST(self):
-        if self.path == '/api/label':
-            content_length = int(self.headers['Content-Length'])
+        if self.path == "/api/label":
+            content_length = int(self.headers["Content-Length"])
             post_data = json.loads(self.rfile.read(content_length))
-            
+
             data_root = Path(self.server.data_root)
             labels_p = data_root / "labels.yaml"
-            
+
             labels = {}
             if labels_p.exists():
-                with open(labels_p, 'r') as f:
+                with open(labels_p, "r") as f:
                     labels = yaml.safe_load(f) or {}
-            
-            labels[post_data['path']] = post_data['label']
-            
-            with open(labels_p, 'w') as f:
+
+            labels[post_data["path"]] = post_data["label"]
+
+            with open(labels_p, "w") as f:
                 yaml.safe_dump(labels, f)
-            
+
             self.send_response(200)
             self.end_headers()
+
 
 def run_classifier(data_root, port=9999):
     Handler = ClassifierHandler
@@ -176,44 +178,51 @@ def run_classifier(data_root, port=9999):
         try:
             # Auto-open browser
             import subprocess
+
             subprocess.run(["open", f"http://localhost:{port}"])
             httpd.serve_forever()
         except KeyboardInterrupt:
             print("\nStopping...")
             httpd.shutdown()
 
-import typer
-from typing import Optional
 
 cli = typer.Typer()
+
 
 def get_folder_via_picker(title="Select Data Root"):
     import tkinter as tk
     from tkinter import filedialog
+
     root = tk.Tk()
     root.withdraw()
     root.attributes("-topmost", True)
     root.focus_force()
     print("Opening folder picker...")
-    selected_dir = filedialog.askdirectory(title=title, initialdir=str(Path.cwd() / "data"))
+    selected_dir = filedialog.askdirectory(
+        title=title, initialdir=str(Path.cwd() / "data")
+    )
     root.destroy()
     return selected_dir
+
 
 @cli.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
     folder: Optional[str] = typer.Argument(None),
     port: int = 9999,
-    f: Optional[str] = typer.Option(None, "-f")
+    f: Optional[str] = typer.Option(None, "-f"),
 ):
-    if ctx.invoked_subcommand: return
-    
+    if ctx.invoked_subcommand:
+        return
+
     data_root = folder or f
     if not data_root:
         data_root = get_folder_via_picker()
-        if not data_root: return
-    
+        if not data_root:
+            return
+
     run_classifier(data_root, port)
+
 
 if __name__ == "__main__":
     cli()

--- a/collect/state.py
+++ b/collect/state.py
@@ -5,6 +5,7 @@ The state file lives at {data_root}/collector_state.json and can be
 updated by any process that has access to the data directory, independently
 of whether the capture service is running.
 """
+
 import json
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
@@ -12,26 +13,28 @@ from pathlib import Path
 from typing import Dict, Optional
 
 STATE_FILENAME = "collector_state.json"
-PLAN_FILENAME  = "capture_plan.json"
+PLAN_FILENAME = "capture_plan.json"
+
 
 def _get_state_path(data_root: str | Path, session_id: str) -> Path:
     return Path(data_root) / f"collector_state_{session_id}.json"
 
+
 @dataclass
 class CollectorState:
     session_id: str
-    status: str                          # "Idle", "Capturing...", "Error"
+    status: str  # "Idle", "Capturing...", "Error"
     capture_count: int
-    plan_total: int                      # total planned captures (0 = unknown)
+    plan_total: int  # total planned captures (0 = unknown)
     interval_seconds: int
-    last_capture_at: Optional[str]       # ISO-8601 UTC
-    next_capture_at: Optional[str]       # ISO-8601 UTC
-    label_counts: Dict[str, int]         # {"0": N, "1": N, "2": N}
-    updated_at: str                      # ISO-8601 UTC
+    last_capture_at: Optional[str]  # ISO-8601 UTC
+    next_capture_at: Optional[str]  # ISO-8601 UTC
+    label_counts: Dict[str, int]  # {"0": N, "1": N, "2": N}
+    updated_at: str  # ISO-8601 UTC
     session_labels_file: Optional[str] = None  # path to labels.{uuid}.yaml
-    final_capture_at: Optional[str] = None      # ISO-8601 UTC of last planned capture
-    prior_capture_count: int = 0                 # captures from previous sessions toward same goal
-    prior_plan_total: int = 0                    # plan_total from previous sessions toward same goal
+    final_capture_at: Optional[str] = None  # ISO-8601 UTC of last planned capture
+    prior_capture_count: int = 0  # captures from previous sessions toward same goal
+    prior_plan_total: int = 0  # plan_total from previous sessions toward same goal
 
     @property
     def pct_complete(self) -> int:
@@ -62,17 +65,20 @@ def read_state(data_root: str | Path, session_id: str) -> Optional[CollectorStat
         return None
 
 
-
-
 def write_plan(data_root: str | Path, timestamps: list[str]) -> Path:
     """Save a list of ISO-8601 UTC capture timestamps to capture_plan.json."""
     path = Path(data_root) / PLAN_FILENAME
     tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps({
-        "generated_at": _now_iso(),
-        "total": len(timestamps),
-        "captures": timestamps,
-    }, indent=2))
+    tmp.write_text(
+        json.dumps(
+            {
+                "generated_at": _now_iso(),
+                "total": len(timestamps),
+                "captures": timestamps,
+            },
+            indent=2,
+        )
+    )
     tmp.replace(path)
     return path
 
@@ -94,6 +100,7 @@ def read_label_counts(data_root: str | Path) -> Dict[str, int]:
         return {}
     try:
         import yaml
+
         with open(labels_path) as f:
             labels = yaml.safe_load(f) or {}
         counts: Dict[str, int] = {}

--- a/collect/storage.py
+++ b/collect/storage.py
@@ -6,7 +6,6 @@ Provides a Protocol-based abstraction with three implementations:
 - CachedR2Storage: R2 with batched local disk cache for training
 """
 
-import io
 import logging
 import os
 import shutil
@@ -57,9 +56,7 @@ class LocalStorage:
         if not base.exists():
             return []
         return sorted(
-            str(p.relative_to(self.root))
-            for p in base.rglob("*")
-            if p.is_file()
+            str(p.relative_to(self.root)) for p in base.rglob("*") if p.is_file()
         )
 
     def exists(self, key: str) -> bool:
@@ -91,7 +88,8 @@ class R2Storage:
             "s3",
             endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
             aws_access_key_id=access_key_id or os.environ["R2_ACCESS_KEY_ID"],
-            aws_secret_access_key=secret_access_key or os.environ["R2_SECRET_ACCESS_KEY"],
+            aws_secret_access_key=secret_access_key
+            or os.environ["R2_SECRET_ACCESS_KEY"],
             config=BotoConfig(
                 retries={"max_attempts": 3, "mode": "adaptive"},
                 signature_version="s3v4",
@@ -203,7 +201,9 @@ class CachedR2Storage:
         if not to_fetch:
             logger.info("Cache is warm — nothing to prefetch.")
             return
-        logger.info(f"Prefetching {len(to_fetch)} files from R2 ({len(keys) - len(to_fetch)} already cached)...")
+        logger.info(
+            f"Prefetching {len(to_fetch)} files from R2 ({len(keys) - len(to_fetch)} already cached)..."
+        )
 
         def _download(key: str) -> str | None:
             try:
@@ -224,7 +224,10 @@ class CachedR2Storage:
                     errors.append(err)
 
         if errors:
-            logger.warning(f"Prefetch completed with {len(errors)} errors:\n  " + "\n  ".join(errors[:10]))
+            logger.warning(
+                f"Prefetch completed with {len(errors)} errors:\n  "
+                + "\n  ".join(errors[:10])
+            )
         else:
             logger.info(f"Prefetch complete: {len(to_fetch)} files downloaded.")
 

--- a/collect/streamlit_classifier.py
+++ b/collect/streamlit_classifier.py
@@ -3,21 +3,21 @@ import os
 import yaml
 import json
 from pathlib import Path
-from PIL import Image
 
 # 1. Load config
 GLOBAL_CONFIG = "/tmp/is_the_mountain_out_config.json"
 if os.path.exists(GLOBAL_CONFIG):
-    with open(GLOBAL_CONFIG, 'r') as f:
+    with open(GLOBAL_CONFIG, "r") as f:
         config = json.load(f)
-    data_root = Path(config['data_root'])
+    data_root = Path(config["data_root"])
 else:
     data_root = Path("data")
 
 st.set_page_config(page_title="Mountain Classifier", layout="wide")
 
 # Custom CSS for iOS-style selection
-st.markdown("""
+st.markdown(
+    """
     <style>
     .stCheckbox {
         position: absolute;
@@ -35,18 +35,21 @@ st.markdown("""
         transition: all 0.2s;
     }
     </style>
-""", unsafe_allow_html=True)
+""",
+    unsafe_allow_html=True,
+)
 
 st.title("🏔️ Batch Mountain Classifier")
 
 # 2. Efficient Label Loading
 labels_p = data_root / "labels.yaml"
-if 'labels' not in st.session_state:
+if "labels" not in st.session_state:
     if labels_p.exists():
-        with open(labels_p, 'r') as f:
+        with open(labels_p, "r") as f:
             st.session_state.labels = yaml.safe_load(f) or {}
     else:
         st.session_state.labels = {}
+
 
 # 3. Incremental Scanning (Efficiency)
 def get_unlabeled_batch(root, limit=50):
@@ -64,16 +67,20 @@ def get_unlabeled_batch(root, limit=50):
                         return batch
     return batch
 
+
 # 4. Batch Actions
 def apply_batch_label(image_paths, label):
     for p in image_paths:
         rel = str(p.relative_to(data_root))
         st.session_state.labels[rel] = label
-    
-    with open(labels_p, 'w') as f:
+
+    with open(labels_p, "w") as f:
         yaml.safe_dump(st.session_state.labels, f)
-    st.toast(f"Tagged {len(image_paths)} images as {'OUT' if label==1 else 'NOT OUT'}")
+    st.toast(
+        f"Tagged {len(image_paths)} images as {'OUT' if label == 1 else 'NOT OUT'}"
+    )
     st.rerun()
+
 
 # 5. UI Layout
 current_batch = get_unlabeled_batch(data_root)
@@ -90,7 +97,7 @@ st.sidebar.metric("Mountain Out", out_count)
 st.sidebar.metric("Not Out", not_count)
 
 # Floating Action Bar for batch operations
-if 'selected' not in st.session_state:
+if "selected" not in st.session_state:
     st.session_state.selected = set()
 
 # Clean up selected set if paths are no longer in current batch
@@ -100,18 +107,20 @@ cols = st.columns(5)
 for i, img_path in enumerate(current_batch):
     with cols[i % 5]:
         is_selected = img_path in st.session_state.selected
-        
+
         # Approximate iOS selection: Checkbox overlay + border highlight
-        selected = st.checkbox("Select", key=f"cb_{i}", label_visibility="collapsed", value=is_selected)
+        selected = st.checkbox(
+            "Select", key=f"cb_{i}", label_visibility="collapsed", value=is_selected
+        )
         if selected:
             st.session_state.selected.add(img_path)
         else:
             st.session_state.selected.discard(img_path)
-            
+
         css_class = "img-selected" if selected else ""
         st.markdown(f'<div class="img-container {css_class}">', unsafe_allow_html=True)
         st.image(str(img_path))
-        st.markdown('</div>', unsafe_allow_html=True)
+        st.markdown("</div>", unsafe_allow_html=True)
         st.caption(f"{img_path.parent.name}")
 
 st.divider()
@@ -119,12 +128,21 @@ st.divider()
 # Footer Controls
 sticky_cols = st.columns([1, 1, 1, 2])
 with sticky_cols[0]:
-    if st.button("🏔️ ALL OUT (1)", type="primary", use_container_width=True, disabled=not st.session_state.selected):
+    if st.button(
+        "🏔️ ALL OUT (1)",
+        type="primary",
+        use_container_width=True,
+        disabled=not st.session_state.selected,
+    ):
         apply_batch_label(list(st.session_state.selected), 1)
         st.session_state.selected = set()
 
 with sticky_cols[1]:
-    if st.button("☁️ ALL NOT OUT (0)", use_container_width=True, disabled=not st.session_state.selected):
+    if st.button(
+        "☁️ ALL NOT OUT (0)",
+        use_container_width=True,
+        disabled=not st.session_state.selected,
+    ):
         apply_batch_label(list(st.session_state.selected), 0)
         st.session_state.selected = set()
 
@@ -134,4 +152,6 @@ with sticky_cols[2]:
         st.rerun()
 
 with sticky_cols[3]:
-    st.info(f"💡 Selected {len(st.session_state.selected)} images. Select images in the grid above to bulk-label them.")
+    st.info(
+        f"💡 Selected {len(st.session_state.selected)} images. Select images in the grid above to bulk-label them."
+    )

--- a/collect/sync.py
+++ b/collect/sync.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 def _get_r2(config_path: str) -> R2Storage:
     config = ConfigLoader(config_path)
     if config.storage_backend != "r2":
-        raise click.ClickException("R2 storage is not configured. Add [storage] section to mountain.toml.")
+        raise click.ClickException(
+            "R2 storage is not configured. Add [storage] section to mountain.toml."
+        )
     cfg = config.storage_config
     return R2Storage(account_id=cfg["r2_account_id"], bucket=cfg["r2_bucket"])
 
@@ -36,7 +38,9 @@ def push(config: str, data_root: str):
 
     all_keys = local.list_keys()
     # Filter to capture data only (images + metar), skip state/config files
-    capture_keys = [k for k in all_keys if "/" in k and (k.endswith(".jpg") or k.endswith(".txt"))]
+    capture_keys = [
+        k for k in all_keys if "/" in k and (k.endswith(".jpg") or k.endswith(".txt"))
+    ]
 
     uploaded = 0
     skipped = 0
@@ -51,7 +55,9 @@ def push(config: str, data_root: str):
         except Exception as e:
             logger.warning(f"Failed to upload {key}: {e}")
 
-    click.echo(f"Push complete: {uploaded} uploaded, {skipped} skipped (already in R2).")
+    click.echo(
+        f"Push complete: {uploaded} uploaded, {skipped} skipped (already in R2)."
+    )
 
 
 @sync.command()
@@ -65,7 +71,9 @@ def pull(config: str, data_root: str):
 
     all_keys = r2.list_keys()
     # Filter to capture data only
-    capture_keys = [k for k in all_keys if "/" in k and (k.endswith(".jpg") or k.endswith(".txt"))]
+    capture_keys = [
+        k for k in all_keys if "/" in k and (k.endswith(".jpg") or k.endswith(".txt"))
+    ]
 
     downloaded = 0
     skipped = 0
@@ -80,7 +88,9 @@ def pull(config: str, data_root: str):
         except Exception as e:
             logger.warning(f"Failed to download {key}: {e}")
 
-    click.echo(f"Pull complete: {downloaded} downloaded, {skipped} skipped (already local).")
+    click.echo(
+        f"Pull complete: {downloaded} downloaded, {skipped} skipped (already local)."
+    )
 
 
 @sync.group()
@@ -115,7 +125,9 @@ def labels_push(config: str, data_root: str):
     r2.put_text("labels.yaml", yaml.safe_dump(merged))
 
     added = len(merged) - len(remote_labels)
-    click.echo(f"Labels pushed: {len(merged)} total ({added} new, {len(local_labels)} from local).")
+    click.echo(
+        f"Labels pushed: {len(merged)} total ({added} new, {len(local_labels)} from local)."
+    )
 
 
 @labels.command("pull")

--- a/collect/tests/conftest.py
+++ b/collect/tests/conftest.py
@@ -2,6 +2,7 @@ import sys
 import types
 from unittest.mock import MagicMock
 
+
 def _make_rumps_stub():
     rumps_mod = types.ModuleType("rumps")
 
@@ -14,15 +15,21 @@ def _make_rumps_stub():
         def __init__(self, callback, interval):
             self.callback = callback
             self.interval = interval
-        def start(self): pass
-        def stop(self): pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
 
     class App:
         def __init__(self, name, title="", quit_button=None):
             self.name = name
             self.title = title
             self.menu = []
-        def run(self): pass
+
+        def run(self):
+            pass
 
     rumps_mod.App = App
     rumps_mod.MenuItem = MenuItem
@@ -30,6 +37,7 @@ def _make_rumps_stub():
     rumps_mod.separator = "---"
     rumps_mod.quit_application = MagicMock()
     return rumps_mod
+
 
 # Apply mock globally for collect tests
 if "rumps" not in sys.modules:

--- a/collect/tests/test_collector.py
+++ b/collect/tests/test_collector.py
@@ -1,56 +1,66 @@
-import pytest
 from unittest.mock import MagicMock, patch
-import sys
 from click.testing import CliRunner
 from collect.collector import once, live
-from pathlib import Path
-import os
-import shutil
 from datetime import datetime, UTC
-import threading
+
 
 def run_sync_thread(target, daemon=True):
     """Mocks threading.Thread to run the target synchronously."""
     mock_thread = MagicMock()
+
     def start_mock():
         target()
+
     mock_thread.start = start_mock
     return mock_thread
 
-@patch('collect.collector.ConfigLoader')
-@patch('collect.collector.WebcamStream')
-@patch('collect.collector.WeatherFetcher')
-@patch('threading.Thread', side_effect=run_sync_thread)
-def test_once_execution_utc_structure(mock_thread, mock_weather_cls, mock_webcam, mock_config, tmp_path):
+
+@patch("collect.collector.ConfigLoader")
+@patch("collect.collector.WebcamStream")
+@patch("collect.collector.WeatherFetcher")
+@patch("threading.Thread", side_effect=run_sync_thread)
+def test_once_execution_utc_structure(
+    mock_thread, mock_weather_cls, mock_webcam, mock_config, tmp_path
+):
     """Verify that once function uses the new UTC-based directory structure."""
-    mock_config.return_value.webcam_url = 'Cam_JPG'
-    mock_config.return_value.metar_station = 'KSEA'
+    mock_config.return_value.webcam_url = "Cam_JPG"
+    mock_config.return_value.metar_station = "KSEA"
     mock_config.return_value.collection_seconds = 600
-    
+
     mock_weather = MagicMock()
     mock_weather.fetch_latest_metar.return_value = "METAR KSEA 211953Z CLR 10/05"
     mock_weather_cls.return_value = mock_weather
-    
+
     mock_stream = MagicMock()
     mock_stream.capture_raw.return_value = MagicMock()
     mock_webcam.return_value = mock_stream
-    
+
     runner = CliRunner()
     # We also need to mock rumps.App.run to not block
-    with patch('rumps.App.run') as mock_run:
-        with patch('cv2.imwrite') as mock_imwrite:
+    with patch("rumps.App.run"):
+        with patch("cv2.imwrite") as mock_imwrite:
             # Use CliRunner to call the command with arguments
-            result = runner.invoke(once, ['--config', 'mountain.toml', '--data-root', str(tmp_path), '--session-id', 'test-once'])
-            
+            result = runner.invoke(
+                once,
+                [
+                    "--config",
+                    "mountain.toml",
+                    "--data-root",
+                    str(tmp_path),
+                    "--session-id",
+                    "test-once",
+                ],
+            )
+
             assert result.exit_code == 0
-            
+
             # Structure: data/YYYYMMDD/HHMMSS_UTC/
             now_utc = datetime.now(UTC)
             date_str = now_utc.strftime("%Y%m%d")
-            
+
             date_dir = tmp_path / date_str
             assert date_dir.exists()
-            
+
             time_dirs = list(date_dir.iterdir())
             assert len(time_dirs) > 0
             time_dir = time_dirs[0]
@@ -60,29 +70,32 @@ def test_once_execution_utc_structure(mock_thread, mock_weather_cls, mock_webcam
             assert (time_dir / "metar" / "metar.txt").exists()
             assert mock_imwrite.called
 
-@patch('collect.collector.ConfigLoader')
-@patch('collect.collector.WebcamStream')
-@patch('collect.collector.WeatherFetcher')
-@patch('time.sleep', side_effect=KeyboardInterrupt)
-def test_live_collection_loop(mock_sleep, mock_weather_cls, mock_webcam, mock_config, tmp_path):
+
+@patch("collect.collector.ConfigLoader")
+@patch("collect.collector.WebcamStream")
+@patch("collect.collector.WeatherFetcher")
+@patch("time.sleep", side_effect=KeyboardInterrupt)
+def test_live_collection_loop(
+    mock_sleep, mock_weather_cls, mock_webcam, mock_config, tmp_path
+):
     """Verify that live command runs a loop and stops on KeyboardInterrupt."""
-    mock_config.return_value.webcam_url = 'Cam_JPG'
-    mock_config.return_value.metar_station = 'KSEA'
+    mock_config.return_value.webcam_url = "Cam_JPG"
+    mock_config.return_value.metar_station = "KSEA"
     mock_config.return_value.collection_seconds = 1
-    
+
     mock_weather = MagicMock()
     mock_weather.fetch_latest_metar.return_value = "METAR KSEA"
     mock_weather_cls.return_value = mock_weather
-    
+
     mock_stream = MagicMock()
     mock_stream.capture_raw.return_value = MagicMock()
     mock_webcam.return_value = mock_stream
-    
+
     runner = CliRunner()
-    with patch('cv2.imwrite'):
+    with patch("cv2.imwrite"):
         # This will run one iteration and then 'sleep' will raise KeyboardInterrupt
-        result = runner.invoke(live, ['--config', 'mountain.toml', '--data-root', str(tmp_path)])
-        
+        runner.invoke(live, ["--config", "mountain.toml", "--data-root", str(tmp_path)])
+
         # Check if directories were created for the first run
         now_utc = datetime.now(UTC)
         date_str = now_utc.strftime("%Y%m%d")

--- a/collect/tests/test_notebook_helpers.py
+++ b/collect/tests/test_notebook_helpers.py
@@ -1,17 +1,24 @@
 import json
 import pytest
-from pathlib import Path
-from datetime import datetime, UTC
-from unittest.mock import MagicMock, patch
-from collect.notebook_helpers import get_job_captures, get_job_status, CaptureBrowser, get_directory_captures, get_upcoming_schedule
+from unittest.mock import patch
+from collect.notebook_helpers import (
+    get_job_captures,
+    get_job_status,
+    CaptureBrowser,
+    get_directory_captures,
+    get_upcoming_schedule,
+)
+
 
 @pytest.fixture
 def temp_log(tmp_path):
     log_file = tmp_path / "collection.log"
     return log_file
 
+
 def test_get_job_captures_empty(temp_log):
     assert get_job_captures(temp_log) == []
+
 
 def test_get_job_captures_valid(temp_log):
     entry = {
@@ -21,30 +28,33 @@ def test_get_job_captures_valid(temp_log):
         "metadata": {
             "image_path": "data/test.jpg",
             "step_index": 1,
-            "metar_path": "data/metar.txt"
-        }
+            "metar_path": "data/metar.txt",
+        },
     }
     temp_log.write_text(json.dumps(entry) + "\n")
-    
+
     captures = get_job_captures(temp_log)
     assert len(captures) == 1
-    assert captures[0]['step'] == 1
-    assert captures[0]['path'] == "data/test.jpg"
+    assert captures[0]["step"] == 1
+    assert captures[0]["path"] == "data/test.jpg"
+
 
 def test_get_job_status_valid(temp_log):
     entry = {
         "event": "PROGRESS",
         "status": "STATUS",
-        "metadata": {"progress": 5, "total": 10, "percentage": 50.0}
+        "metadata": {"progress": 5, "total": 10, "percentage": 50.0},
     }
     temp_log.write_text(json.dumps(entry) + "\n")
-    
+
     status = get_job_status(temp_log)
-    assert status['progress'] == 5
-    assert status['total'] == 10
+    assert status["progress"] == 5
+    assert status["total"] == 10
+
 
 def test_get_job_status_missing(temp_log):
     assert get_job_status(temp_log) is None
+
 
 def test_get_directory_captures(tmp_path):
     # Create mock structure
@@ -55,26 +65,28 @@ def test_get_directory_captures(tmp_path):
     img_dir = cap_dir / "images"
     img_dir.mkdir()
     (img_dir / "test.jpg").write_text("fake image")
-    
+
     metar_dir = cap_dir / "metar"
     metar_dir.mkdir()
     (metar_dir / "metar.txt").write_text("KSEA 231200Z")
-    
+
     caps = get_directory_captures(tmp_path)
     assert len(caps) == 1
-    assert caps[0]['metar'] is not None
-    assert "test" in caps[0]['path']
+    assert caps[0]["metar"] is not None
+    assert "test" in caps[0]["path"]
 
-@patch('collect.notebook_helpers.widgets')
-@patch('collect.notebook_helpers.display')
+
+@patch("collect.notebook_helpers.widgets")
+@patch("collect.notebook_helpers.display")
 def test_capture_browser_init(mock_display, mock_widgets, temp_log):
     browser = CaptureBrowser(log_path=str(temp_log))
     assert browser.log_path == str(temp_log)
     assert browser.all_captures == []
 
-@patch('collect.notebook_helpers.widgets')
-@patch('collect.notebook_helpers.display')
-@patch('collect.notebook_helpers.plt')
+
+@patch("collect.notebook_helpers.widgets")
+@patch("collect.notebook_helpers.display")
+@patch("collect.notebook_helpers.plt")
 def test_render_control_panel(mock_plt, mock_display, mock_widgets, temp_log):
     browser = CaptureBrowser(log_path=str(temp_log))
     browser.render_control_panel()
@@ -82,7 +94,8 @@ def test_render_control_panel(mock_plt, mock_display, mock_widgets, temp_log):
     # It now sets children instead of calling display
     assert browser.control_container.children != []
 
-@patch('pathlib.Path.exists')
+
+@patch("pathlib.Path.exists")
 def test_get_upcoming_schedule_missing(mock_exists):
     # Mock files as NOT existing
     mock_exists.return_value = False

--- a/collect/tests/test_storage.py
+++ b/collect/tests/test_storage.py
@@ -1,8 +1,6 @@
 """Tests for collect.storage backends."""
 
-import pytest
-from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from collect.storage import LocalStorage, R2Storage, CachedR2Storage
 
@@ -52,9 +50,13 @@ class TestLocalStorage:
 
 
 class TestR2Storage:
-    @patch.dict("sys.modules", {"boto3": MagicMock(), "botocore": MagicMock(), "botocore.config": MagicMock()})
+    @patch.dict(
+        "sys.modules",
+        {"boto3": MagicMock(), "botocore": MagicMock(), "botocore.config": MagicMock()},
+    )
     def test_init_from_env(self, monkeypatch):
         import sys
+
         mock_boto3 = sys.modules["boto3"]
         monkeypatch.setenv("R2_ACCESS_KEY_ID", "test-key-id")
         monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test-secret")
@@ -62,12 +64,15 @@ class TestR2Storage:
         # Re-import to pick up mocked boto3
         import importlib
         import collect.storage
+
         importlib.reload(collect.storage)
 
         store = collect.storage.R2Storage(account_id="abc123", bucket="my-bucket")
         mock_boto3.client.assert_called_once()
         call_kwargs = mock_boto3.client.call_args
-        assert call_kwargs[1]["endpoint_url"] == "https://abc123.r2.cloudflarestorage.com"
+        assert (
+            call_kwargs[1]["endpoint_url"] == "https://abc123.r2.cloudflarestorage.com"
+        )
         assert call_kwargs[1]["aws_access_key_id"] == "test-key-id"
         assert store.bucket == "my-bucket"
 
@@ -78,11 +83,15 @@ class TestR2Storage:
         store._client = mock_client
 
         store.put("key.jpg", b"data")
-        mock_client.put_object.assert_called_once_with(Bucket="b", Key="key.jpg", Body=b"data")
+        mock_client.put_object.assert_called_once_with(
+            Bucket="b", Key="key.jpg", Body=b"data"
+        )
 
     def test_get(self):
         mock_client = MagicMock()
-        mock_client.get_object.return_value = {"Body": MagicMock(read=lambda: b"img-data")}
+        mock_client.get_object.return_value = {
+            "Body": MagicMock(read=lambda: b"img-data")
+        }
         store = R2Storage.__new__(R2Storage)
         store.bucket = "b"
         store._client = mock_client
@@ -96,7 +105,9 @@ class TestR2Storage:
         store._client = mock_client
 
         store.put_text("metar.txt", "KSEA 221153Z")
-        mock_client.put_object.assert_called_once_with(Bucket="b", Key="metar.txt", Body=b"KSEA 221153Z")
+        mock_client.put_object.assert_called_once_with(
+            Bucket="b", Key="metar.txt", Body=b"KSEA 221153Z"
+        )
 
     def test_presign(self):
         mock_client = MagicMock()

--- a/collect/tests/test_tray.py
+++ b/collect/tests/test_tray.py
@@ -1,23 +1,26 @@
 """Tests for MountainTray — mocks rumps so no GUI event loop is needed."""
-import sys
-from unittest.mock import MagicMock
+
 import pytest
 
 from collect.state import CollectorState, write_state, read_state, make_state
 from collect.tray import MountainTray, _fmt_time  # noqa: E402
+from collect.collector import _derive_initial_last_capture_at
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture()
 def data_root(tmp_path):
     return tmp_path
 
+
 @pytest.fixture()
 def tray(data_root):
     return MountainTray(data_root=str(data_root), session_id="abc123")
+
 
 @pytest.fixture()
 def base_state():
@@ -38,6 +41,7 @@ def base_state():
 # Identity
 # ---------------------------------------------------------------------------
 
+
 def test_initial_title_is_mountain_emoji(tray):
     assert tray.title == "🗻"
 
@@ -49,6 +53,7 @@ def test_initial_status_placeholder(tray):
 # ---------------------------------------------------------------------------
 # State file read/write round-trip
 # ---------------------------------------------------------------------------
+
 
 def test_write_and_read_state_roundtrip(data_root, base_state):
     write_state(data_root, base_state)
@@ -73,6 +78,7 @@ def test_write_is_atomic(data_root, base_state):
 # Rendering
 # ---------------------------------------------------------------------------
 
+
 def test_render_populates_status(tray, base_state):
     tray._render(base_state)
     assert "Idle" in tray.status_item.title
@@ -81,7 +87,7 @@ def test_render_populates_status(tray, base_state):
 def test_render_populates_progress(tray, base_state):
     tray._render(base_state)
     assert "10/628" in tray.progress_item.title
-    assert "1%" in tray.progress_item.title   # 10/628 = 1%
+    assert "1%" in tray.progress_item.title  # 10/628 = 1%
 
 
 def test_render_populates_next_capture(tray, base_state):
@@ -95,7 +101,6 @@ def test_render_populates_session(tray, base_state):
     assert "abc123" in tray.session_item.title
 
 
-
 def test_render_shows_placeholder_when_next_is_none(tray, base_state):
     base_state.next_capture_at = None
     tray._render(base_state)
@@ -104,16 +109,17 @@ def test_render_shows_placeholder_when_next_is_none(tray, base_state):
 
 def test_render_spinner_cycles(tray, base_state):
     from collect.tray import SPINNER
+
     base_state.status = "capturing"
-    
+
     # First frame
     tray._render(base_state)
     assert tray.title == f"🗻{SPINNER[0]}"
-    
+
     # Second frame
     tray._render(base_state)
     assert tray.title == f"🗻{SPINNER[1]}"
-    
+
     # Wrap around (after len(SPINNER) calls)
     tray._spinner_idx = len(SPINNER) - 1
     tray._render(base_state)
@@ -125,6 +131,7 @@ def test_render_spinner_cycles(tray, base_state):
 # ---------------------------------------------------------------------------
 # _refresh reads from state file
 # ---------------------------------------------------------------------------
+
 
 def test_refresh_reads_state_file(tray, data_root, base_state):
     write_state(data_root, base_state)
@@ -143,13 +150,14 @@ def test_refresh_skips_rerender_when_state_unchanged(tray, data_root, base_state
     tray._refresh()
     # Mutate a menu item directly — a re-render would reset it
     tray.status_item.title = "SENTINEL"
-    tray._refresh()   # same state object, should skip
+    tray._refresh()  # same state object, should skip
     assert tray.status_item.title == "SENTINEL"
 
 
 # ---------------------------------------------------------------------------
 # pct_complete
 # ---------------------------------------------------------------------------
+
 
 def test_pct_complete_normal():
     s = make_state("s", "Idle", capture_count=314, interval_seconds=600, plan_total=628)
@@ -174,6 +182,7 @@ def test_pct_complete_unknown_plan():
 # ---------------------------------------------------------------------------
 # _fmt_time helper
 # ---------------------------------------------------------------------------
+
 
 def test_fmt_time_past_date_includes_month_and_day():
     # A date in the past — should show "Mar 15 HH:MM" style
@@ -202,18 +211,13 @@ def test_fmt_time_invalid():
 # last_capture_at preservation through capture loop state writes
 # ---------------------------------------------------------------------------
 
-import sys as _sys
-import types as _types
-from unittest.mock import patch, MagicMock as _MagicMock
-from collect.state import write_plan, read_state, make_state, write_state
-from collect.collector import _derive_initial_last_capture_at
-
 
 def test_derive_initial_last_capture_at_from_plan_past(tmp_path):
     """Returns most recent past plan timestamp when one exists."""
     past = "2026-03-14T20:00:00+00:00"
     future = "2026-03-15T20:00:00+00:00"
     from datetime import datetime, timezone
+
     now = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
     result = _derive_initial_last_capture_at([past, future], str(tmp_path), now, "sess")
     assert result == past
@@ -222,11 +226,20 @@ def test_derive_initial_last_capture_at_from_plan_past(tmp_path):
 def test_derive_initial_last_capture_at_falls_back_to_state_file(tmp_path):
     """When plan has no past timestamps, uses previous state file's last_capture_at."""
     past_time = "2026-03-14T20:00:00+00:00"
-    write_state(tmp_path, make_state("prev", "Idle", capture_count=5,
-                                     interval_seconds=600, plan_total=636,
-                                     last_capture_at=past_time))
+    write_state(
+        tmp_path,
+        make_state(
+            "prev",
+            "Idle",
+            capture_count=5,
+            interval_seconds=600,
+            plan_total=636,
+            last_capture_at=past_time,
+        ),
+    )
     future = "2026-03-15T20:00:00+00:00"
     from datetime import datetime, timezone
+
     now = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
     result = _derive_initial_last_capture_at([future], str(tmp_path), now, "prev")
     assert result == past_time
@@ -235,10 +248,19 @@ def test_derive_initial_last_capture_at_falls_back_to_state_file(tmp_path):
 def test_derive_initial_last_capture_at_ignores_future_state(tmp_path):
     """Does not use previous state's last_capture_at if it's in the future."""
     future_time = "2026-03-16T20:00:00+00:00"
-    write_state(tmp_path, make_state("prev", "Idle", capture_count=5,
-                                     interval_seconds=600, plan_total=636,
-                                     last_capture_at=future_time))
+    write_state(
+        tmp_path,
+        make_state(
+            "prev",
+            "Idle",
+            capture_count=5,
+            interval_seconds=600,
+            plan_total=636,
+            last_capture_at=future_time,
+        ),
+    )
     from datetime import datetime, timezone
+
     now = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
     result = _derive_initial_last_capture_at([], str(tmp_path), now, "prev")
     assert result is None
@@ -246,13 +268,16 @@ def test_derive_initial_last_capture_at_ignores_future_state(tmp_path):
 
 def test_derive_initial_last_capture_at_no_plan_no_state(tmp_path):
     from datetime import datetime, timezone
+
     now = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
     assert _derive_initial_last_capture_at([], str(tmp_path), now, "any") is None
 
 
 def test_make_state_resets_last_capture_at_when_omitted(tmp_path):
     """Regression guard: make_state without last_capture_at yields None — callers must pass it."""
-    state = make_state("sess1", "Capturing...", capture_count=0, interval_seconds=600, plan_total=5)
+    state = make_state(
+        "sess1", "Capturing...", capture_count=0, interval_seconds=600, plan_total=5
+    )
     assert state.last_capture_at is None  # documenting the footgun the loop must avoid
 
 
@@ -260,8 +285,16 @@ def test_capturing_state_preserves_last_capture_at(tmp_path):
     """The capture loop must pass last_capture_at to EVERY write_state call, including Capturing."""
     past_time = "2026-03-14T20:00:00+00:00"
     # Simulate the fixed loop: Capturing... write includes last_capture_at explicitly
-    write_state(tmp_path, make_state("sess1", "Capturing...", capture_count=0,
-                                     interval_seconds=600, plan_total=5,
-                                     last_capture_at=past_time))
+    write_state(
+        tmp_path,
+        make_state(
+            "sess1",
+            "Capturing...",
+            capture_count=0,
+            interval_seconds=600,
+            plan_total=5,
+            last_capture_at=past_time,
+        ),
+    )
     state = read_state(tmp_path, "sess1")
     assert state.last_capture_at == past_time

--- a/collect/tray.py
+++ b/collect/tray.py
@@ -5,6 +5,7 @@ Reads collector_state.json via a rumps.Timer; entirely decoupled from
 the capture loop. Any process can update the state file and the menu
 will reflect it within REFRESH_INTERVAL seconds.
 """
+
 import logging
 import subprocess
 import sys
@@ -25,11 +26,16 @@ REFRESH_INTERVAL = 10  # seconds between state file reads
 
 SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
+
 class MountainTray(rumps.App if rumps else object):
     def __init__(self, data_root: str = "data", session_id: Optional[str] = None):
         self.session_id = session_id or "persistent"
         if rumps:
-            name = f"Mountain Collector ({self.session_id})" if self.session_id != "persistent" else "Mountain Collector"
+            name = (
+                f"Mountain Collector ({self.session_id})"
+                if self.session_id != "persistent"
+                else "Mountain Collector"
+            )
             super().__init__(name, title="🗻", quit_button=None)
         self.data_root = Path(data_root).absolute()
         self._last_state: Optional[CollectorState] = None
@@ -40,14 +46,18 @@ class MountainTray(rumps.App if rumps else object):
 
         # --- Static menu skeleton ---
         self.progress_bar_item = rumps.MenuItem("—")
-        self.status_item       = rumps.MenuItem("Status: —")
-        self.progress_item     = rumps.MenuItem("Progress: —")
+        self.status_item = rumps.MenuItem("Status: —")
+        self.progress_item = rumps.MenuItem("Progress: —")
         self.last_capture_item = rumps.MenuItem("Last Capture: —")
-        self.next_item         = rumps.MenuItem("Next Capture: —")
-        self.final_item        = rumps.MenuItem("Final Capture: —")
-        self.session_item      = rumps.MenuItem("Session: —")
-        self.open_item         = rumps.MenuItem("Open Index File", callback=self._on_open_folder)
-        self.ad_hoc_item       = rumps.MenuItem("Capture additional image", callback=self._on_capture_additional)
+        self.next_item = rumps.MenuItem("Next Capture: —")
+        self.final_item = rumps.MenuItem("Final Capture: —")
+        self.session_item = rumps.MenuItem("Session: —")
+        self.open_item = rumps.MenuItem(
+            "Open Index File", callback=self._on_open_folder
+        )
+        self.ad_hoc_item = rumps.MenuItem(
+            "Capture additional image", callback=self._on_capture_additional
+        )
         self.menu = [
             self.progress_bar_item,
             rumps.separator,
@@ -77,13 +87,13 @@ class MountainTray(rumps.App if rumps else object):
         if state is None:
             self.status_item.title = "Status: No state found"
             return
-        
+
         # Compare essential fields to decide if we need a rerender
         if self._last_state:
             is_same = (
-                state.capture_count == self._last_state.capture_count and
-                state.status == self._last_state.status and
-                state.next_capture_at == self._last_state.next_capture_at
+                state.capture_count == self._last_state.capture_count
+                and state.status == self._last_state.status
+                and state.next_capture_at == self._last_state.next_capture_at
             )
             if is_same:
                 return
@@ -106,7 +116,7 @@ class MountainTray(rumps.App if rumps else object):
         bar = "█" * filled_len + "░" * (bar_len - filled_len)
         self.progress_bar_item.title = f"[{bar}] {state.pct_complete}%"
 
-        self.status_item.title   = f"Status: {state.status}"
+        self.status_item.title = f"Status: {state.status}"
         total_str = str(state.plan_total) if state.plan_total > 0 else "?"
         self.progress_item.title = (
             f"Progress: {state.capture_count}/{total_str} ({state.pct_complete}%)"
@@ -114,9 +124,9 @@ class MountainTray(rumps.App if rumps else object):
         last_str = _fmt_time(state.last_capture_at) or "—"
         self.last_capture_item.title = f"Last Capture: {last_str}"
         next_str = _fmt_time(state.next_capture_at) or "—"
-        self.next_item.title         = f"Next Capture: {next_str}"
+        self.next_item.title = f"Next Capture: {next_str}"
         final_str = _fmt_time(state.final_capture_at) or "—"
-        self.final_item.title        = f"Final Capture: {final_str}"
+        self.final_item.title = f"Final Capture: {final_str}"
         self.session_item.title = f"Session: {state.session_id}"
         if state.session_labels_file:
             self.open_item.title = f"Open {state.session_labels_file}"
@@ -128,7 +138,11 @@ class MountainTray(rumps.App if rumps else object):
     # ------------------------------------------------------------------
 
     def _on_open_folder(self, _):
-        target = self._last_state.session_labels_file if self._last_state and self._last_state.session_labels_file else None
+        target = (
+            self._last_state.session_labels_file
+            if self._last_state and self._last_state.session_labels_file
+            else None
+        )
         if sys.platform == "darwin":
             if target and Path(target).exists():
                 subprocess.Popen(["open", "-R", target])  # reveal file in Finder
@@ -155,7 +169,7 @@ class MountainTray(rumps.App if rumps else object):
     # ------------------------------------------------------------------
 
     def run(self):
-        self._refresh()          # populate immediately on startup
+        self._refresh()  # populate immediately on startup
         self._timer.start()
         super().run()
 
@@ -164,12 +178,14 @@ class MountainTray(rumps.App if rumps else object):
 # Helpers
 # ------------------------------------------------------------------
 
+
 def _fmt_time(iso: Optional[str]) -> Optional[str]:
     """Format an ISO-8601 UTC string as local 'Mar 15 06:38' or 'Today 06:38', or None."""
     if not iso:
         return None
     try:
-        from datetime import datetime, timezone
+        from datetime import datetime
+
         dt = datetime.fromisoformat(iso).astimezone()
         today = datetime.now(dt.tzinfo).date()
         if dt.date() == today:

--- a/inference/server.py
+++ b/inference/server.py
@@ -6,6 +6,7 @@ result back to a public R2 bucket; this process is pure inference.
 Checkpoint is pulled from R2 on first /predict call (cached on local FS for
 subsequent calls within the container's lifetime).
 """
+
 import os
 import sys
 from pathlib import Path

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -8,18 +8,16 @@ os.environ["HF_HUB_OFFLINE"] = "0"
 os.environ["PYTHONWARNINGS"] = "ignore"
 os.environ["HF_HUB_DISABLE_SYMLINKS_WARNING"] = "1"
 # Ensure no GUI windows
-os.environ["QT_QPA_PLATFORM"] = "offscreen" 
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 import matplotlib
-matplotlib.use('Agg') # Force non-interactive backend
 
-import json
+matplotlib.use("Agg")  # Force non-interactive backend
+
 import yaml
 import torch
-import torch.nn as nn
 import torch.optim as optim
 from pathlib import Path
-from PIL import Image
 import cv2
 import numpy as np
 from torchvision import transforms
@@ -32,6 +30,7 @@ import pandas as pd
 sys.path.append(str(Path.cwd()))
 from train.model import ConvNextLoRAModel
 from train.config_loader import ConfigLoader
+
 
 def get_metar_vector(storage, img_key: str):
     img_rel = Path(img_key)
@@ -46,138 +45,164 @@ def get_metar_vector(storage, img_key: str):
             metar_text = storage.get_text(c).strip()
             break
 
-    vis, ceil = 0.0, 1.0 # Default bad
+    vis, ceil = 0.0, 1.0  # Default bad
     if metar_text:
         try:
             obs = Metar.Metar(metar_text)
-            if obs.vis: vis = min(obs.vis.value('SM'), 10.0) / 10.0
+            if obs.vis:
+                vis = min(obs.vis.value("SM"), 10.0) / 10.0
             if obs.sky:
-                layers = [l for l in obs.sky if l[0] in ['BKN', 'OVC']]
-                ceil = min(layers[0][1].value('FT'), 10000.0) / 10000.0 if layers else 1.0
-        except: pass
+                layers = [layer for layer in obs.sky if layer[0] in ["BKN", "OVC"]]
+                ceil = (
+                    min(layers[0][1].value("FT"), 10000.0) / 10000.0 if layers else 1.0
+                )
+        except Exception:
+            pass
     return [vis, ceil]
+
 
 def run_experiment(variant_name, data_list, storage, folds=3):
     print(f"\n🚀 Starting Experiment: {variant_name}", flush=True)
-    
+
     kf = StratifiedKFold(n_splits=folds, shuffle=True, random_state=42)
-    
-    paths = [d['path'] for d in data_list]
-    labels = [d['label'] for d in data_list]
-    
+
+    paths = [d["path"] for d in data_list]
+    labels = [d["label"] for d in data_list]
+
     all_metrics = []
-    
-    transform = transforms.Compose([
-        transforms.ToPILImage(),
-        transforms.Resize(224),
-        transforms.CenterCrop(224),
-        transforms.ToTensor(),
-        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-    ])
+
+    transform = transforms.Compose(
+        [
+            transforms.ToPILImage(),
+            transforms.Resize(224),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
 
     device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
     print(f"  Using device: {device}", flush=True)
 
     for fold, (train_idx, val_idx) in enumerate(kf.split(paths, labels)):
-        print(f"  Fold {fold+1}/{folds}...", flush=True)
-        
+        print(f"  Fold {fold + 1}/{folds}...", flush=True)
+
         # Fresh model for each fold
         model = ConvNextLoRAModel().to(device)
         optimizer = optim.Adam(model.model_dict.parameters(), lr=0.0001)
-        
+
         # Prepare training data with oversampling
         train_data = [data_list[i] for i in train_idx]
-        train_out = [d for d in train_data if d['label'] == 1]
-        train_partial = [d for d in train_data if d['label'] == 2]
-        train_not = [d for d in train_data if d['label'] == 0]
-        
+        train_out = [d for d in train_data if d["label"] == 1]
+        train_partial = [d for d in train_data if d["label"] == 2]
+        train_not = [d for d in train_data if d["label"] == 0]
+
         # Balance the batch
-        oversample_factor_out = max(1, len(train_not) // (len(train_out) * 2)) if train_out else 1
-        oversample_factor_partial = max(1, len(train_not) // (len(train_partial) * 2)) if train_partial else 1
-        
-        balanced_train = train_not + (train_out * oversample_factor_out) + (train_partial * oversample_factor_partial)
+        oversample_factor_out = (
+            max(1, len(train_not) // (len(train_out) * 2)) if train_out else 1
+        )
+        oversample_factor_partial = (
+            max(1, len(train_not) // (len(train_partial) * 2)) if train_partial else 1
+        )
+
+        balanced_train = (
+            train_not
+            + (train_out * oversample_factor_out)
+            + (train_partial * oversample_factor_partial)
+        )
         import random
+
         random.shuffle(balanced_train)
-        
+
         # Training loop (Mini-version: 3 epochs)
         model.train()
         for epoch in range(3):
             batch_count = 0
             for i in range(0, len(balanced_train), 16):
-                batch = balanced_train[i:i+16]
-                if not batch: continue
-                
+                batch = balanced_train[i : i + 16]
+                if not batch:
+                    continue
+
                 imgs, weathers, lbls = [], [], []
                 for item in batch:
                     try:
-                        img_bytes = storage.get(item['path'])
+                        img_bytes = storage.get(item["path"])
                     except Exception:
                         continue
-                    img = cv2.imdecode(np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR)
-                    if img is None: continue
+                    img = cv2.imdecode(
+                        np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR
+                    )
+                    if img is None:
+                        continue
                     img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
                     imgs.append(transform(img))
-                    
-                    w = item['weather']
+
+                    w = item["weather"]
                     if variant_name == "Vision Only":
                         w = [0.0, 0.0]
                     weathers.append(torch.tensor(w))
-                    lbls.append(item['label'])
-                
-                if not imgs: continue
-                
+                    lbls.append(item["label"])
+
+                if not imgs:
+                    continue
+
                 model.train_step(
-                    torch.stack(imgs), 
-                    torch.stack(weathers), 
-                    torch.tensor(lbls).long(), 
-                    optimizer
+                    torch.stack(imgs),
+                    torch.stack(weathers),
+                    torch.tensor(lbls).long(),
+                    optimizer,
                 )
                 batch_count += 1
-            print(f"    Epoch {epoch+1} finished ({batch_count} batches).", flush=True)
+            print(
+                f"    Epoch {epoch + 1} finished ({batch_count} batches).", flush=True
+            )
 
         # Evaluation
         model.eval()
         preds, true = [], []
-        print(f"    Starting evaluation...", flush=True)
+        print("    Starting evaluation...", flush=True)
         with torch.no_grad():
             for i in val_idx:
                 item = data_list[i]
                 try:
-                    img_bytes = storage.get(item['path'])
+                    img_bytes = storage.get(item["path"])
                 except Exception:
                     continue
                 img = cv2.imdecode(np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR)
-                if img is None: continue
+                if img is None:
+                    continue
                 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
                 img_tensor = transform(img).unsqueeze(0).to(device)
-                
-                w = item['weather']
-                if variant_name == "Vision Only": w = [0.0, 0.0]
-                
+
+                w = item["weather"]
+                if variant_name == "Vision Only":
+                    w = [0.0, 0.0]
+
                 weather_tensor = torch.tensor([w], dtype=torch.float32).to(device)
-                
+
                 output = model(img_tensor, weather_tensor)
                 pred = torch.argmax(output, dim=1).item()
                 preds.append(pred)
-                true.append(item['label'])
-        
-        f1 = f1_score(true, preds, average='weighted')
-        prec = precision_score(true, preds, zero_division=0, average='weighted')
-        rec = recall_score(true, preds, zero_division=0, average='weighted')
-        
-        all_metrics.append({'f1': f1, 'precision': prec, 'recall': rec})
+                true.append(item["label"])
+
+        f1 = f1_score(true, preds, average="weighted")
+        prec = precision_score(true, preds, zero_division=0, average="weighted")
+        rec = recall_score(true, preds, zero_division=0, average="weighted")
+
+        all_metrics.append({"f1": f1, "precision": prec, "recall": rec})
         print(f"    F1: {f1:.4f} | Prec: {prec:.4f} | Rec: {rec:.4f}", flush=True)
 
-    avg_f1 = np.mean([m['f1'] for m in all_metrics])
-    avg_prec = np.mean([m['precision'] for m in all_metrics])
-    avg_rec = np.mean([m['recall'] for m in all_metrics])
-    
+    avg_f1 = np.mean([m["f1"] for m in all_metrics])
+    avg_prec = np.mean([m["precision"] for m in all_metrics])
+    avg_rec = np.mean([m["recall"] for m in all_metrics])
+
     return {
-        'Variant': variant_name,
-        'F1-Score': avg_f1,
-        'Precision': avg_prec,
-        'Recall': avg_rec
+        "Variant": variant_name,
+        "F1-Score": avg_f1,
+        "Precision": avg_prec,
+        "Recall": avg_rec,
     }
+
 
 if __name__ == "__main__":
     data_root = Path("data")
@@ -189,32 +214,31 @@ if __name__ == "__main__":
     print(f"Loading and pre-processing {len(labels_map)} images...")
     processed_data = []
     for rel_path, label in labels_map.items():
-        if not storage.exists(rel_path): continue
+        if not storage.exists(rel_path):
+            continue
 
         weather = get_metar_vector(storage, rel_path)
-        processed_data.append({
-            'path': rel_path,
-            'label': label,
-            'weather': weather
-        })
+        processed_data.append({"path": rel_path, "label": label, "weather": weather})
 
     # Run full experiment
     # processed_data = processed_data[:50]
-    print(f"Running experiment on all {len(processed_data)} labeled images...", flush=True)
+    print(
+        f"Running experiment on all {len(processed_data)} labeled images...", flush=True
+    )
 
     # Map every image to the most recent UNIQUE weather vector that preceded it
     # This perfectly models our new collector deduplication logic
     unique_weather_history = []
     sparse_data = []
-    
-    current_weather = [0.0, 1.0] # Default
+
+    current_weather = [0.0, 1.0]  # Default
     for item in processed_data:
-        actual_weather = item['weather']
+        actual_weather = item["weather"]
         if actual_weather != current_weather:
             current_weather = actual_weather
-        
+
         new_item = item.copy()
-        new_item['weather'] = current_weather
+        new_item["weather"] = current_weather
         sparse_data.append(new_item)
 
     results = []
@@ -225,17 +249,33 @@ if __name__ == "__main__":
     df = pd.DataFrame(results)
     print("\n📊 --- A/B TEST RESULTS ---")
     print(df.to_markdown(index=False))
-    
-    best = df.loc[df['F1-Score'].idxmax()]
+
+    best = df.loc[df["F1-Score"].idxmax()]
     print(f"\n✅ CONCLUSION: The '{best['Variant']}' model performed best.")
-    
-    if best['Variant'] == "Vision Only":
-        print("💡 METAR data is redundant. Vision backbone captures enough atmospheric cues.")
+
+    if best["Variant"] == "Vision Only":
+        print(
+            "💡 METAR data is redundant. Vision backbone captures enough atmospheric cues."
+        )
     else:
-        gain = (best['F1-Score'] - df[df['Variant']=='Vision Only']['F1-Score'].values[0]) / df[df['Variant']=='Vision Only']['F1-Score'].values[0] * 100
+        gain = (
+            (
+                best["F1-Score"]
+                - df[df["Variant"] == "Vision Only"]["F1-Score"].values[0]
+            )
+            / df[df["Variant"] == "Vision Only"]["F1-Score"].values[0]
+            * 100
+        )
         print(f"💡 METAR data improves F1-Score by {gain:.1f}%.")
-        
-    if df[df['Variant']=='Full METAR']['F1-Score'].values[0] > df[df['Variant']=='Sparse METAR']['F1-Score'].values[0] * 1.05:
-        print("💡 High-frequency METAR is SIGNIFICANT. Hourly updates catch rapid clearing events.")
+
+    if (
+        df[df["Variant"] == "Full METAR"]["F1-Score"].values[0]
+        > df[df["Variant"] == "Sparse METAR"]["F1-Score"].values[0] * 1.05
+    ):
+        print(
+            "💡 High-frequency METAR is SIGNIFICANT. Hourly updates catch rapid clearing events."
+        )
     else:
-        print("💡 Sparse METAR (Once a Day) is SUFFICIENT. Seasonal trends dominate the weather signal.")
+        print(
+            "💡 Sparse METAR (Once a Day) is SUFFICIENT. Seasonal trends dominate the weather signal."
+        )

--- a/tools/capture_now.py
+++ b/tools/capture_now.py
@@ -5,52 +5,52 @@ import argparse
 import uuid
 from pathlib import Path
 
+
 def trigger_capture(session_id=None):
     """Triggers a single capture by running a unique Nomad batch job."""
     hcl_path = Path("nomad/once.hcl")
     if not hcl_path.exists():
         # Check relative to script location
         hcl_path = Path(__file__).parent.parent / "nomad" / "once.hcl"
-        
+
     if not hcl_path.exists():
         print(f"Error: {hcl_path} not found.")
         sys.exit(1)
 
     unique_id = str(uuid.uuid4())[:8]
     job_name = f"adhoc-{unique_id}"
-    
+
     # Read HCL and replace job name
     hcl_content = hcl_path.read_text()
-    hcl_content = hcl_content.replace('job "mountain-capture-single"', f'job "{job_name}"')
+    hcl_content = hcl_content.replace(
+        'job "mountain-capture-single"', f'job "{job_name}"'
+    )
 
     cmd = ["nomad", "job", "run"]
     if session_id:
         cmd.extend(["-var", f"session_id={session_id}"])
-    cmd.append("-") # Read from stdin
+    cmd.append("-")  # Read from stdin
 
     print(f"Submitting Nomad job {job_name}...")
     try:
         # Run nomad job run and capture output
         result = subprocess.run(
-            cmd,
-            input=hcl_content,
-            capture_output=True,
-            text=True,
-            check=True
+            cmd, input=hcl_content, capture_output=True, text=True, check=True
         )
         print(f"Nomad job {job_name} submitted successfully.")
-        
+
         # Extract the Eval ID from output
         for line in result.stdout.splitlines():
             if "Monitoring evaluation" in line:
                 eval_id = line.split()[-1].strip('"')
                 print(f"Evaluation ID: {eval_id}")
                 break
-        
+
         print("Capture in progress via Nomad (batch job)...")
     except subprocess.CalledProcessError as e:
         print(f"Error submitting Nomad job:\n{e.stderr}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/tools/capture_out.py
+++ b/tools/capture_out.py
@@ -1,43 +1,50 @@
 import time
 import random
 import subprocess
-import os
 from datetime import datetime, UTC
+
 
 def run_capture(session_id: str):
     print(f"[{datetime.now(UTC).isoformat()}] Running capture...")
     # Using 'uv run collect once' to leverage existing logic for a single capture
     cmd = [
-        "uv", "run", "collect", "once",
-        "--config", "mountain.toml",
-        "--data-root", "data/out_captures",
-        "--session-id", session_id
+        "uv",
+        "run",
+        "collect",
+        "once",
+        "--config",
+        "mountain.toml",
+        "--data-root",
+        "data/out_captures",
+        "--session-id",
+        session_id,
     ]
     subprocess.run(cmd, check=True)
+
 
 if __name__ == "__main__":
     session_id = f"out_{int(time.time())}"
     print(f"Starting 'Out' capture job (Session: {session_id})...")
-    
+
     # 10 captures over 3600 seconds (1 hour)
     total_duration = 3600
     num_captures = 10
-    
+
     # Generate 10 random delay points in the 1 hour window
     delays = sorted([random.randint(0, total_duration) for _ in range(num_captures)])
-    
+
     current_time = 0
     for i, delay in enumerate(delays):
         wait_time = delay - current_time
         if wait_time > 0:
-            print(f"Waiting {wait_time}s for capture {i+1}/10...")
+            print(f"Waiting {wait_time}s for capture {i + 1}/10...")
             time.sleep(wait_time)
-        
+
         try:
             run_capture(session_id)
         except Exception as e:
             print(f"Capture failed: {e}")
-        
+
         current_time = delay
 
     print("All captures completed.")

--- a/tools/classifier_server.py
+++ b/tools/classifier_server.py
@@ -1,14 +1,13 @@
 import os
 import logging
+import requests
 import yaml
-import json
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from datetime import datetime, UTC
 
 from train.config_loader import ConfigLoader
 
@@ -31,15 +30,19 @@ try:
     _config = ConfigLoader(os.environ.get("MOUNTAIN_CONFIG", "mountain.toml"))
     if _config.storage_backend == "r2":
         from collect.storage import R2Storage
+
         _cfg = _config.storage_config
-        _r2_storage = R2Storage(account_id=_cfg["r2_account_id"], bucket=_cfg["r2_bucket"])
+        _r2_storage = R2Storage(
+            account_id=_cfg["r2_account_id"], bucket=_cfg["r2_bucket"]
+        )
         logging.info(f"Classifier server: R2 storage enabled ({_cfg['r2_bucket']})")
 except Exception as e:
     logging.info(f"Classifier server: R2 not configured, using local only ({e})")
 
 
 class LabelBatch(BaseModel):
-    labels: Dict[str, int] # path -> label
+    labels: Dict[str, int]  # path -> label
+
 
 def load_labels():
     # Pull from R2 if available (R2 is source of truth)
@@ -58,6 +61,7 @@ def load_labels():
             return yaml.safe_load(f) or {}
     return {}
 
+
 def save_labels(labels):
     with open(LABELS_PATH, "w") as f:
         yaml.safe_dump(labels, f)
@@ -75,6 +79,7 @@ def save_labels(labels):
         except Exception as e:
             logging.warning(f"Failed to push labels to R2: {e}")
 
+
 @app.get("/api/jobs")
 def get_jobs():
     """Proxy Nomad jobs for the UI."""
@@ -83,9 +88,10 @@ def get_jobs():
         response = requests.get(f"{nomad_url}/v1/jobs", timeout=2)
         response.raise_for_status()
         return response.json()
-    except Exception as e:
+    except Exception:
         # Fallback if Nomad is unreachable
         return []
+
 
 @app.get("/api/images")
 def get_images(batch_size: int = 20, offset: int = 0):
@@ -93,28 +99,32 @@ def get_images(batch_size: int = 20, offset: int = 0):
     if _r2_storage is not None:
         all_images = sorted(k for k in _r2_storage.list_keys() if k.endswith(".jpg"))
     else:
-        all_images = sorted(str(p.relative_to(DATA_ROOT)) for p in DATA_ROOT.rglob("*.jpg"))
+        all_images = sorted(
+            str(p.relative_to(DATA_ROOT)) for p in DATA_ROOT.rglob("*.jpg")
+        )
 
     unlabeled = [img for img in all_images if img not in labels]
 
     return {
         "images": unlabeled[:batch_size],
         "total_unlabeled": len(unlabeled),
-        "total_images": len(all_images)
+        "total_images": len(all_images),
     }
+
 
 @app.get("/api/stats")
 def get_stats():
     labels = load_labels()
     counts = {0: 0, 1: 0, 2: 0}
-    for l in labels.values():
-        counts[l] = counts.get(l, 0) + 1
-        
+    for label in labels.values():
+        counts[label] = counts.get(label, 0) + 1
+
     return {
         "labeled": len(labels),
         "counts": counts,
-        "labels_path": str(LABELS_PATH.absolute())
+        "labels_path": str(LABELS_PATH.absolute()),
     }
+
 
 @app.post("/api/label")
 def post_labels(batch: LabelBatch):
@@ -122,6 +132,7 @@ def post_labels(batch: LabelBatch):
     labels.update(batch.labels)
     save_labels(labels)
     return {"status": "success", "new_count": len(labels)}
+
 
 @app.get("/api/image-url/{path:path}")
 def get_image_url(path: str):
@@ -134,13 +145,17 @@ def get_image_url(path: str):
             url = _r2_storage.presign(path, expires=3600)
             return {"url": url, "source": "r2"}
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Failed to generate pre-signed URL: {e}")
+            raise HTTPException(
+                status_code=500, detail=f"Failed to generate pre-signed URL: {e}"
+            )
     return {"url": f"/data/{path}", "source": "local"}
+
 
 @app.get("/api/storage-mode")
 def get_storage_mode():
     """Report whether the server is using R2 or local storage."""
     return {"backend": "r2" if _r2_storage is not None else "local"}
+
 
 # Serve the actual data directory for image access
 # Access via /data/YYYYMMDD/...
@@ -152,18 +167,18 @@ if __name__ == "__main__":
 
     def is_port_in_use(port):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            return s.connect_ex(('localhost', port)) == 0
+            return s.connect_ex(("localhost", port)) == 0
 
     port = int(os.environ.get("MOUNTAIN_API_PORT", 8000))
     if is_port_in_use(port):
         # Find a free port
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(('', 0))
+            s.bind(("", 0))
             port = s.getsockname()[1]
-    
+
     # Write the actual port being used to a file so the UI or other tools can find it
     port_file = DATA_ROOT / "classifier_server.port"
     port_file.write_text(str(port))
-    
+
     print(f"📡 API Server starting on port {port}")
     uvicorn.run(app, host="0.0.0.0", port=port)

--- a/tools/evaluate.py
+++ b/tools/evaluate.py
@@ -19,6 +19,7 @@ sys.path.append(str(Path.cwd()))
 from train.model import ConvNextLoRAModel
 from train.config_loader import ConfigLoader
 
+
 def get_metar_vector(storage, img_key: str):
     img_rel = Path(img_key)
     candidates = [
@@ -32,16 +33,21 @@ def get_metar_vector(storage, img_key: str):
             metar_text = storage.get_text(c).strip()
             break
 
-    vis, ceil = 0.0, 1.0 # Default bad
+    vis, ceil = 0.0, 1.0  # Default bad
     if metar_text:
         try:
             obs = Metar.Metar(metar_text)
-            if obs.vis: vis = min(obs.vis.value('SM'), 10.0) / 10.0
+            if obs.vis:
+                vis = min(obs.vis.value("SM"), 10.0) / 10.0
             if obs.sky:
-                layers = [l for l in obs.sky if l[0] in ['BKN', 'OVC']]
-                ceil = min(layers[0][1].value('FT'), 10000.0) / 10000.0 if layers else 1.0
-        except: pass
+                layers = [layer for layer in obs.sky if layer[0] in ["BKN", "OVC"]]
+                ceil = (
+                    min(layers[0][1].value("FT"), 10000.0) / 10000.0 if layers else 1.0
+                )
+        except Exception:
+            pass
     return [vis, ceil]
+
 
 def evaluate(checkpoint_dir: str, labels_file: str):
     device = "mps" if torch.backends.mps.is_available() else "cpu"
@@ -49,9 +55,7 @@ def evaluate(checkpoint_dir: str, labels_file: str):
     print(f"Using device: {device}")
 
     model = ConvNextLoRAModel(
-        num_classes=3,
-        checkpoint_dir=checkpoint_dir,
-        device=device
+        num_classes=3, checkpoint_dir=checkpoint_dir, device=device
     )
     model.model_dict.eval()
 
@@ -64,13 +68,15 @@ def evaluate(checkpoint_dir: str, labels_file: str):
 
     print(f"Found {len(labels_map)} labels in {labels_file}")
 
-    transform = transforms.Compose([
-        transforms.ToPILImage(),
-        transforms.Resize(224),
-        transforms.CenterCrop(224),
-        transforms.ToTensor(),
-        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-    ])
+    transform = transforms.Compose(
+        [
+            transforms.ToPILImage(),
+            transforms.Resize(224),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
 
     true_labels = []
     pred_labels = []
@@ -104,22 +110,40 @@ def evaluate(checkpoint_dir: str, labels_file: str):
     if not true_labels:
         print("No valid images found for evaluation.")
         return
-        
+
     print("\n--- Evaluation Results ---")
     target_names = ["Not Out (0)", "Full (1)", "Partial (2)"]
     # Handle cases where some classes might not be present in the true labels
     present_classes = sorted(list(set(true_labels) | set(pred_labels)))
     present_target_names = [target_names[i] for i in present_classes]
-    
-    print(classification_report(true_labels, pred_labels, labels=present_classes, target_names=present_target_names, zero_division=0))
-    
+
+    print(
+        classification_report(
+            true_labels,
+            pred_labels,
+            labels=present_classes,
+            target_names=present_target_names,
+            zero_division=0,
+        )
+    )
+
     print("\nConfusion Matrix:")
     print(confusion_matrix(true_labels, pred_labels, labels=present_classes))
-    
+
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Evaluate a trained model checkpoint on a labeled dataset.")
-    parser.add_argument("--checkpoint", type=str, default="train/checkpoints", help="Path to checkpoint directory")
-    parser.add_argument("--labels", type=str, required=True, help="Path to labels.yaml file")
-    
+    parser = argparse.ArgumentParser(
+        description="Evaluate a trained model checkpoint on a labeled dataset."
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        default="train/checkpoints",
+        help="Path to checkpoint directory",
+    )
+    parser.add_argument(
+        "--labels", type=str, required=True, help="Path to labels.yaml file"
+    )
+
     args = parser.parse_args()
     evaluate(args.checkpoint, args.labels)

--- a/tools/generate_map.py
+++ b/tools/generate_map.py
@@ -2,47 +2,48 @@ import requests
 import tomllib
 from pathlib import Path
 
+
 def generate_map():
     # Load config
     with open("mountain.toml", "rb") as f:
         config = tomllib.load(f)
-    
+
     # Load key
     with open("mapbox.key", "r") as f:
         token = f.read().strip()
-    
+
     # Coordinates
-    mtn = config['mountain']
-    cam = config['webcam']
-    weather = config['weather']
-    
+    mtn = config["mountain"]
+    cam = config["webcam"]
+    weather = config["weather"]
+
     # Marker colors: Rainier (Red), Webcam (Blue), Weather (Green)
     # Using Maki icons as reliable high-quality substitutes for the requested emojis
     # mountain -> 🏔️, cinema -> 🎥, airport -> 🛬
     markers = [
         f"pin-s-mountain+f44336({mtn['longitude']},{mtn['latitude']})",
         f"pin-s-cinema+2196f3({cam['longitude']},{cam['latitude']})",
-        f"pin-s-airport+4caf50({weather['longitude']},{weather['latitude']})"
+        f"pin-s-airport+4caf50({weather['longitude']},{weather['latitude']})",
     ]
-    
+
     overlay = ",".join(markers)
     style = "mapbox/outdoors-v12"
     width, height = 800, 600
-    
+
     # Calculate bounds to add padding (Mapbox 'auto' is often too tight)
     # Center is approximately halfway between the furthest points
-    avg_lon = (mtn['longitude'] + cam['longitude']) / 2
-    avg_lat = (mtn['latitude'] + cam['latitude']) / 2
-    
+    avg_lon = (mtn["longitude"] + cam["longitude"]) / 2
+    avg_lat = (mtn["latitude"] + cam["latitude"]) / 2
+
     # Zoom 8 provides a better balance for the Puget Sound region coverage
     zoom = 8
-    
+
     url = f"https://api.mapbox.com/styles/v1/{style}/static/{overlay}/{avg_lon},{avg_lat},{zoom}/{width}x{height}@2x?access_token={token}"
-    
+
     print(f"Requesting map from Mapbox (Zoom: {zoom})...")
     headers = {"Referer": "https://tommyroar.github.io"}
     response = requests.get(url, headers=headers)
-    
+
     if response.status_code == 200:
         Path("assets").mkdir(exist_ok=True)
         with open("assets/map.png", "wb") as f:
@@ -51,6 +52,7 @@ def generate_map():
     else:
         print(f"Error: {response.status_code}")
         print(response.text)
+
 
 if __name__ == "__main__":
     generate_map()

--- a/tools/plan.py
+++ b/tools/plan.py
@@ -1,9 +1,9 @@
 import sys
 import random
-import json
 import argparse
-from datetime import datetime, timedelta, date, UTC
-from typing import List, Dict, Optional
+from datetime import datetime, timedelta, UTC
+from typing import List
+
 try:
     from astral import LocationInfo
     from astral.sun import sun
@@ -11,82 +11,118 @@ except ImportError:
     print("Error: 'astral' library not found. Run with 'uv pip install astral'")
     sys.exit(1)
 
+
 class CapturePlan:
     def __init__(self, lat: float, lon: float, name: str = "Mount Rainier"):
         self.location = LocationInfo(name, "USA", "UTC", lat, lon)
 
-    def generate(self, start_time: datetime, days: int = 30, jitter: int = 300) -> List[str]:
+    def generate(
+        self, start_time: datetime, days: int = 30, jitter: int = 300
+    ) -> List[str]:
         intervals = []
         current = start_time
-        
+
         for d_offset in range(days + 1):
             day = start_time.date() + timedelta(days=d_offset)
             s = sun(self.location.observer, date=day)
-            
+
             # Key segments for each day
             # 1. Early Night (if day starts before sunrise)
             # 2. Dawn Golden Hour (Sunrise +/- 45m)
             # 3. Standard Day (Dawn end to Dusk start)
             # 4. Dusk Golden Hour (Sunset +/- 45m)
             # 5. Night (Sunset + 45m to next Dawn start)
-            
+
             segments = [
-                {"name": "GOLDEN", "start": s["sunrise"] - timedelta(minutes=45), "end": s["sunrise"] + timedelta(minutes=45), "gap": 600},
-                {"name": "DAY",    "start": s["sunrise"] + timedelta(minutes=46), "end": s["sunset"] - timedelta(minutes=46), "gap": 1800},
-                {"name": "GOLDEN", "start": s["sunset"] - timedelta(minutes=45),  "end": s["sunset"] + timedelta(minutes=45),  "gap": 600},
-                {"name": "NIGHT",  "start": s["sunset"] + timedelta(minutes=46),  "end": s["sunset"] + timedelta(hours=8),    "gap": 28800} # One anchor at night
+                {
+                    "name": "GOLDEN",
+                    "start": s["sunrise"] - timedelta(minutes=45),
+                    "end": s["sunrise"] + timedelta(minutes=45),
+                    "gap": 600,
+                },
+                {
+                    "name": "DAY",
+                    "start": s["sunrise"] + timedelta(minutes=46),
+                    "end": s["sunset"] - timedelta(minutes=46),
+                    "gap": 1800,
+                },
+                {
+                    "name": "GOLDEN",
+                    "start": s["sunset"] - timedelta(minutes=45),
+                    "end": s["sunset"] + timedelta(minutes=45),
+                    "gap": 600,
+                },
+                {
+                    "name": "NIGHT",
+                    "start": s["sunset"] + timedelta(minutes=46),
+                    "end": s["sunset"] + timedelta(hours=8),
+                    "gap": 28800,
+                },  # One anchor at night
             ]
-            
+
             for seg in sorted(segments, key=lambda x: x["start"]):
-                if seg["end"] < current: continue
-                
+                if seg["end"] < current:
+                    continue
+
                 # Move 'current' to start of segment if we are before it
                 if current < seg["start"]:
                     wait = int((seg["start"] - current).total_seconds())
                     if wait > 0:
                         intervals.append(f"{wait}s")
                         current = seg["start"]
-                
+
                 # Fill segment
                 while current < seg["end"]:
                     wait = seg["gap"] + random.randint(-jitter, jitter)
                     # Don't overshoot segment too much
-                    if current + timedelta(seconds=wait) > seg["end"] + timedelta(minutes=5):
+                    if current + timedelta(seconds=wait) > seg["end"] + timedelta(
+                        minutes=5
+                    ):
                         break
                     intervals.append(f"{wait}s")
                     current += timedelta(seconds=wait)
-                    
+
             if current > start_time + timedelta(days=days):
                 break
-                
+
         intervals.append("stop")
         return intervals
 
     def simulate(self, start_time: datetime, intervals: List[str]):
-        print(f"\n📈 PLAN SIMULATION (Start: {start_time.strftime('%Y-%m-%d %H:%M')} UTC)")
+        print(
+            f"\n📈 PLAN SIMULATION (Start: {start_time.strftime('%Y-%m-%d %H:%M')} UTC)"
+        )
         print("-" * 80)
         current = start_time
-        
+
         for i, step in enumerate(intervals):
-            if step == "stop": break
+            if step == "stop":
+                break
             wait_sec = int(step[:-1])
-            if i % 100 == 0 or i < 10: 
-                print(f"Capture {i+1:<4} | {current.strftime('%Y-%m-%d %H:%M'):<20} | Next: {step}")
+            if i % 100 == 0 or i < 10:
+                print(
+                    f"Capture {i + 1:<4} | {current.strftime('%Y-%m-%d %H:%M'):<20} | Next: {step}"
+                )
             current += timedelta(seconds=wait_sec)
-            
+
         print("-" * 80)
-        print(f"Total captures: {len(intervals)-1} over {(current-start_time).days} days")
+        print(
+            f"Total captures: {len(intervals) - 1} over {(current - start_time).days} days"
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--days", type=int, default=30)
     parser.add_argument("--simulate", action="store_true")
     args = parser.parse_args()
-    
+
     planner = CapturePlan(47.6533, -122.3091)
     # Start at a clean hour
     now = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
     steps = planner.generate(now, days=args.days)
-    
-    if args.simulate: planner.simulate(now, steps)
-    else: print(" ".join([f"--plan-steps {s}" for s in steps]))
+
+    if args.simulate:
+        planner.simulate(now, steps)
+    else:
+        print(" ".join([f"--plan-steps {s}" for s in steps]))

--- a/tools/predict_state.py
+++ b/tools/predict_state.py
@@ -2,6 +2,7 @@
 
 Used by `.github/workflows/update.yml` on a 15-minute schedule.
 """
+
 import argparse
 import io
 import json
@@ -27,12 +28,14 @@ from train.model import ConvNextLoRAModel  # noqa: E402
 
 CLASS_NAMES = ["not_out", "full", "partial"]
 
-IMAGE_TRANSFORM = transforms.Compose([
-    transforms.Resize(224),
-    transforms.CenterCrop(224),
-    transforms.ToTensor(),
-    transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-])
+IMAGE_TRANSFORM = transforms.Compose(
+    [
+        transforms.Resize(224),
+        transforms.CenterCrop(224),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+    ]
+)
 
 
 def fetch_webcam_tensor(url: str, timeout: float = 20.0) -> torch.Tensor:
@@ -89,7 +92,9 @@ def git_short_sha() -> str | None:
 
 
 def predict(checkpoint_dir: str, webcam_url: str, station: str, storage=None) -> dict:
-    model = ConvNextLoRAModel(num_classes=3, checkpoint_dir=checkpoint_dir, device="cpu", storage=storage)
+    model = ConvNextLoRAModel(
+        num_classes=3, checkpoint_dir=checkpoint_dir, device="cpu", storage=storage
+    )
     model.model_dict.eval()
 
     image_tensor = fetch_webcam_tensor(webcam_url)
@@ -101,7 +106,9 @@ def predict(checkpoint_dir: str, webcam_url: str, station: str, storage=None) ->
     idx = int(max(range(3), key=lambda i: probs[i]))
 
     return {
-        "timestamp_utc": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "timestamp_utc": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
         "class_index": idx,
         "class_name": CLASS_NAMES[idx],
         "is_out": idx in (1, 2),
@@ -123,7 +130,9 @@ def _append_log(log_path: Path, record: dict) -> None:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run a single visibility prediction and write state.json.")
+    parser = argparse.ArgumentParser(
+        description="Run a single visibility prediction and write state.json."
+    )
     parser.add_argument("--config", default="mountain.toml")
     parser.add_argument("--out", default="web/public/state.json")
     parser.add_argument(
@@ -172,7 +181,9 @@ def main() -> int:
     finally:
         finished_at = datetime.now(timezone.utc)
         record["finished_at"] = _iso_utc(finished_at)
-        record["duration_seconds"] = round((finished_at - started_at).total_seconds(), 3)
+        record["duration_seconds"] = round(
+            (finished_at - started_at).total_seconds(), 3
+        )
         _append_log(Path(args.log), record)
 
     return exit_code

--- a/tools/prune_data.py
+++ b/tools/prune_data.py
@@ -14,7 +14,7 @@ from train.config_loader import ConfigLoader
 def load_labels(data_root):
     labels_path = Path(data_root) / "labels.yaml"
     if labels_path.exists():
-        with open(labels_path, 'r') as f:
+        with open(labels_path, "r") as f:
             return yaml.safe_load(f) or {}
     return {}
 
@@ -25,7 +25,7 @@ def save_labels(data_root, labels, storage):
     labels_path = Path(data_root) / "labels.yaml"
     labels_path.parent.mkdir(parents=True, exist_ok=True)
     text = yaml.safe_dump(labels)
-    with open(labels_path, 'w') as f:
+    with open(labels_path, "w") as f:
         f.write(text)
     storage.put_text("labels.yaml", text)
 
@@ -58,19 +58,32 @@ def _mtime_from_key(img_key: str) -> float:
     parts = Path(img_key).parts
     date_str, time_str = parts[0], parts[1]  # 20260222, 220834_724181_UTC
     hhmmss = time_str[:6]
-    return datetime.strptime(f"{date_str} {hhmmss}", "%Y%m%d %H%M%S").replace(tzinfo=UTC).timestamp()
+    return (
+        datetime.strptime(f"{date_str} {hhmmss}", "%Y%m%d %H%M%S")
+        .replace(tzinfo=UTC)
+        .timestamp()
+    )
 
 
 def _open_pil(storage, img_key: str):
     return Image.open(io.BytesIO(storage.get(img_key)))
 
 
-def prune_dataset(data_root="data", min_seconds=300, dark_thresh=10.0, diff_thresh=2.0,
-                  dry_run=True, force_keep_hourly=True, auto_label_metar=True):
+def prune_dataset(
+    data_root="data",
+    min_seconds=300,
+    dark_thresh=10.0,
+    diff_thresh=2.0,
+    dry_run=True,
+    force_keep_hourly=True,
+    auto_label_metar=True,
+):
     storage = ConfigLoader().get_storage(data_root)
     labels = load_labels(data_root)
 
-    image_keys = [k for k in storage.list_keys("") if k.endswith(".jpg") and k not in labels]
+    image_keys = [
+        k for k in storage.list_keys("") if k.endswith(".jpg") and k not in labels
+    ]
     image_keys.sort()  # Lexicographic == chronological for our key layout
     images = [(_mtime_from_key(k), k) for k in image_keys]
 
@@ -92,11 +105,14 @@ def prune_dataset(data_root="data", min_seconds=300, dark_thresh=10.0, diff_thre
             if metar_text:
                 try:
                     obs = Metar.Metar(metar_text)
-                    vis = obs.vis.value('SM') if obs.vis else 10.0
+                    vis = obs.vis.value("SM") if obs.vis else 10.0
                     ceil = 10000.0
                     if obs.sky:
-                        layers = [l for l in obs.sky if l[0] in ['BKN', 'OVC']]
-                        if layers: ceil = layers[0][1].value('FT')
+                        layers = [
+                            layer for layer in obs.sky if layer[0] in ["BKN", "OVC"]
+                        ]
+                        if layers:
+                            ceil = layers[0][1].value("FT")
 
                     # Vis crap OR ceiling below Rainier's peak area (~8000ft)
                     if vis < 3.0 or ceil < 6000:
@@ -104,7 +120,8 @@ def prune_dataset(data_root="data", min_seconds=300, dark_thresh=10.0, diff_thre
                             labels[img_key] = 0
                         reasons["metar_auto"] += 1
                         continue  # Auto-label, do not delete
-                except: pass
+                except Exception:
+                    pass
 
         # 2. Force Keep Logic (1 per hour for darkness baseline)
         dt = datetime.fromtimestamp(mtime, UTC)
@@ -116,7 +133,8 @@ def prune_dataset(data_root="data", min_seconds=300, dark_thresh=10.0, diff_thre
                 with _open_pil(storage, img_key) as img:
                     last_kept_img = img.convert("L").copy()
                 continue
-            except: pass
+            except Exception:
+                pass
 
         # 3. Temporal Pruning
         if mtime - last_kept_time < min_seconds:
@@ -191,5 +209,9 @@ if __name__ == "__main__":
     parser.add_argument("--diff", type=float, default=2.0)
     args = parser.parse_args()
 
-    prune_dataset(dry_run=not args.execute, min_seconds=args.min_sec,
-                  dark_thresh=args.dark, diff_thresh=args.diff)
+    prune_dataset(
+        dry_run=not args.execute,
+        min_seconds=args.min_sec,
+        dark_thresh=args.dark,
+        diff_thresh=args.diff,
+    )

--- a/train/config_loader.py
+++ b/train/config_loader.py
@@ -1,5 +1,6 @@
 import tomli
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
+
 
 class ConfigLoader:
     def __init__(self, config_path: str = "mountain.toml"):
@@ -9,67 +10,67 @@ class ConfigLoader:
         self._validate_config()
 
     def _load_toml_config(self, path: str) -> Dict[str, Any]:
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             return tomli.load(f)
 
     def _validate_config(self):
         # Basic config validation
-        required_sections = ['mountain', 'webcam', 'weather', 'training', 'collection']
+        required_sections = ["mountain", "webcam", "weather", "training", "collection"]
         for section in required_sections:
             if section not in self.data:
                 raise ValueError(f"Missing required config section: {section}")
 
     @property
     def webcam_url(self) -> str:
-        return self.data['webcam'].get('url', "")
+        return self.data["webcam"].get("url", "")
 
     @property
     def schedule_seconds(self) -> int:
-        return self.data['training'].get('schedule_seconds', 1800)
+        return self.data["training"].get("schedule_seconds", 1800)
 
     @property
     def collection_seconds(self) -> int:
-        return self.data['collection'].get('collection_seconds', 600)
+        return self.data["collection"].get("collection_seconds", 600)
 
     @property
     def collection_schedule(self) -> Optional[Dict[str, int]]:
-        return self.data['collection'].get('schedule')
+        return self.data["collection"].get("schedule")
 
     @property
     def capture_interval_seconds(self) -> int:
-        return self.data['training'].get('capture_interval_seconds', 300)
+        return self.data["training"].get("capture_interval_seconds", 300)
 
     @property
     def gradient_accumulation_steps(self) -> int:
-        return self.data['training'].get('gradient_accumulation_steps', 4)
+        return self.data["training"].get("gradient_accumulation_steps", 4)
 
     @property
     def lora_settings(self) -> Dict[str, Any]:
-        return self.data['training'].get('lora', {})
+        return self.data["training"].get("lora", {})
 
     @property
     def checkpoint_dir(self) -> str:
-        return self.data['training'].get('checkpoint_dir', "train/checkpoints")
+        return self.data["training"].get("checkpoint_dir", "train/checkpoints")
 
     @property
     def metar_station(self) -> str:
-        return self.data['weather'].get('station_id', 'KSEA')
+        return self.data["weather"].get("station_id", "KSEA")
 
     @property
     def mountain_data(self) -> Dict[str, Any]:
-        return self.data.get('mountain', {})
+        return self.data.get("mountain", {})
 
     # -- Optional storage backend (R2) --
 
     @property
     def storage_backend(self) -> str:
         """Return 'local' or 'r2'. Defaults to 'local' when [storage] is absent."""
-        return self.data.get('storage', {}).get('backend', 'local')
+        return self.data.get("storage", {}).get("backend", "local")
 
     @property
     def storage_config(self) -> Dict[str, Any]:
         """Return the raw [storage] section, or empty dict."""
-        return self.data.get('storage', {})
+        return self.data.get("storage", {})
 
     def get_storage(self, data_root: str = "data"):
         """Factory: return the appropriate StorageBackend based on config.
@@ -89,4 +90,3 @@ class ConfigLoader:
         )
         cache_dir = cfg.get("cache_dir", ".r2cache")
         return CachedR2Storage(r2, cache_dir=cache_dir)
-

--- a/train/model.py
+++ b/train/model.py
@@ -5,77 +5,95 @@ from peft import LoraConfig, get_peft_model
 from typing import List, Optional
 import os
 
+
 class ConvNextLoRAModel(nn.Module):
-    def __init__(self, num_classes: int = 3, rank: int = 8, alpha: int = 16,
-                 target_modules: List[str] = ["fc1", "fc2"], device: str = "mps",
-                 checkpoint_dir: Optional[str] = None, storage=None):
+    def __init__(
+        self,
+        num_classes: int = 3,
+        rank: int = 8,
+        alpha: int = 16,
+        target_modules: List[str] = ["fc1", "fc2"],
+        device: str = "mps",
+        checkpoint_dir: Optional[str] = None,
+        storage=None,
+    ):
         super().__init__()
         self.device = device if torch.backends.mps.is_available() else "cpu"
-        
+
         # Load pretrained model
-        self.base_model = timm.create_model('convnext_tiny', pretrained=True, num_classes=0, global_pool='avg')
-        
+        self.base_model = timm.create_model(
+            "convnext_tiny", pretrained=True, num_classes=0, global_pool="avg"
+        )
+
         # LoRA Configuration
         self.lora_config = LoraConfig(
             r=rank,
             lora_alpha=alpha,
             target_modules=target_modules,
             lora_dropout=0.1,
-            bias="none"
+            bias="none",
         )
-        
+
         # Wrap the backbone with LoRA
         self.backbone = get_peft_model(self.base_model, self.lora_config)
-        
+
         # Custom head for dual input (image features + weather vector)
         self.weather_dim = 2
         self.classifier = nn.Sequential(
             nn.Linear(768 + self.weather_dim, 256),
             nn.ReLU(),
             nn.Dropout(0.1),
-            nn.Linear(256, num_classes)
+            nn.Linear(256, num_classes),
         )
-        
-        self.model_dict = nn.ModuleDict({
-            'backbone': self.backbone,
-            'classifier': self.classifier
-        })
+
+        self.model_dict = nn.ModuleDict(
+            {"backbone": self.backbone, "classifier": self.classifier}
+        )
         self.model_dict.to(self.device)
 
         if checkpoint_dir:
             self.load_checkpoint(checkpoint_dir, storage=storage)
 
     def forward(self, image_batch: torch.Tensor, weather_batch: torch.Tensor):
-        features = self.model_dict['backbone'](image_batch)
+        features = self.model_dict["backbone"](image_batch)
         combined_input = torch.cat((features, weather_batch), dim=1)
-        return self.model_dict['classifier'](combined_input)
+        return self.model_dict["classifier"](combined_input)
 
-    def train_step(self, image_batch: torch.Tensor, weather_batch: torch.Tensor, 
-                   label_batch: torch.Tensor, optimizer: torch.optim.Optimizer,
-                   class_weights: Optional[torch.Tensor] = None):
+    def train_step(
+        self,
+        image_batch: torch.Tensor,
+        weather_batch: torch.Tensor,
+        label_batch: torch.Tensor,
+        optimizer: torch.optim.Optimizer,
+        class_weights: Optional[torch.Tensor] = None,
+    ):
         self.model_dict.train()
         optimizer.zero_grad()
-        
+
         image_batch = image_batch.to(self.device)
         weather_batch = weather_batch.to(self.device)
         label_batch = label_batch.to(self.device)
         if class_weights is not None:
             class_weights = class_weights.to(self.device)
-        
+
         outputs = self.forward(image_batch, weather_batch)
-        
-        loss = torch.nn.functional.cross_entropy(outputs, label_batch, weight=class_weights)
+
+        loss = torch.nn.functional.cross_entropy(
+            outputs, label_batch, weight=class_weights
+        )
         loss.backward()
         optimizer.step()
-        
+
         loss_val = loss.item()
         del loss, outputs, label_batch
         if self.device == "mps":
             torch.mps.empty_cache()
-            
+
         return loss_val
 
-    def predict(self, image_batch: torch.Tensor, weather_batch: torch.Tensor) -> torch.Tensor:
+    def predict(
+        self, image_batch: torch.Tensor, weather_batch: torch.Tensor
+    ) -> torch.Tensor:
         self.model_dict.eval()
         with torch.no_grad():
             outputs = self.forward(image_batch, weather_batch)
@@ -85,8 +103,11 @@ class ConvNextLoRAModel(nn.Module):
     def save_checkpoint(self, checkpoint_dir: str, storage=None):
         """Saves LoRA adapters and classifier head locally, then uploads to R2 if storage is provided."""
         os.makedirs(checkpoint_dir, exist_ok=True)
-        self.model_dict['backbone'].save_pretrained(checkpoint_dir)
-        torch.save(self.model_dict['classifier'].state_dict(), os.path.join(checkpoint_dir, "classifier.pt"))
+        self.model_dict["backbone"].save_pretrained(checkpoint_dir)
+        torch.save(
+            self.model_dict["classifier"].state_dict(),
+            os.path.join(checkpoint_dir, "classifier.pt"),
+        )
         print(f"Checkpoint saved to {checkpoint_dir}")
 
         if storage is not None:
@@ -95,7 +116,12 @@ class ConvNextLoRAModel(nn.Module):
     def _upload_checkpoint(self, checkpoint_dir: str, storage):
         """Upload checkpoint files to remote storage under checkpoints/ prefix."""
         import logging
-        checkpoint_files = ["adapter_config.json", "adapter_model.safetensors", "classifier.pt"]
+
+        checkpoint_files = [
+            "adapter_config.json",
+            "adapter_model.safetensors",
+            "classifier.pt",
+        ]
         for fname in checkpoint_files:
             local_path = os.path.join(checkpoint_dir, fname)
             if os.path.exists(local_path):
@@ -115,8 +141,10 @@ class ConvNextLoRAModel(nn.Module):
             self._download_checkpoint(checkpoint_dir, storage)
 
         if os.path.exists(checkpoint_dir) and os.path.exists(classifier_path):
-            self.model_dict['backbone'].load_adapter(checkpoint_dir, "default")
-            self.model_dict['classifier'].load_state_dict(torch.load(classifier_path, map_location=self.device))
+            self.model_dict["backbone"].load_adapter(checkpoint_dir, "default")
+            self.model_dict["classifier"].load_state_dict(
+                torch.load(classifier_path, map_location=self.device)
+            )
             print(f"Checkpoint loaded from {checkpoint_dir}")
             return True
         return False
@@ -124,8 +152,13 @@ class ConvNextLoRAModel(nn.Module):
     def _download_checkpoint(self, checkpoint_dir: str, storage):
         """Download checkpoint files from remote storage if available."""
         import logging
+
         os.makedirs(checkpoint_dir, exist_ok=True)
-        checkpoint_files = ["adapter_config.json", "adapter_model.safetensors", "classifier.pt"]
+        checkpoint_files = [
+            "adapter_config.json",
+            "adapter_model.safetensors",
+            "classifier.pt",
+        ]
         for fname in checkpoint_files:
             try:
                 data = storage.get(f"checkpoints/{fname}")

--- a/train/scheduler.py
+++ b/train/scheduler.py
@@ -2,9 +2,8 @@ import time
 import torch
 import torch.optim as optim
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional
 import typer
-import os
 from pathlib import Path
 import subprocess
 
@@ -14,6 +13,7 @@ from train.model import ConvNextLoRAModel
 
 app = typer.Typer()
 
+
 class Trainer:
     def __init__(self, config_path: str = "mountain.toml", fresh: bool = False):
         self.config_loader = ConfigLoader(config_path)
@@ -22,24 +22,26 @@ class Trainer:
         # Initialize components
         self.model_wrapper = ConvNextLoRAModel(
             num_classes=3,
-            rank=self.config_loader.lora_settings['rank'],
-            alpha=self.config_loader.lora_settings['alpha'],
-            target_modules=self.config_loader.lora_settings['target_modules'],
-            device=self.device
+            rank=self.config_loader.lora_settings["rank"],
+            alpha=self.config_loader.lora_settings["alpha"],
+            target_modules=self.config_loader.lora_settings["target_modules"],
+            device=self.device,
         )
 
         # Attempt to load checkpoint (skip if fresh training requested)
         if not fresh:
             self.model_wrapper.load_checkpoint(self.config_loader.checkpoint_dir)
-        
+
         # Lower learning rate for fine-tuning stability
-        self.optimizer = optim.Adam(self.model_wrapper.model_dict.parameters(), lr=0.0001)
+        self.optimizer = optim.Adam(
+            self.model_wrapper.model_dict.parameters(), lr=0.0001
+        )
         self.weather_fetcher = WeatherFetcher(self.config_loader.metar_station)
 
     def run_single_cycle(self, label: int = 1):
         print(f"[{datetime.now()}] Starting single training cycle...")
         weather_vector = self.weather_fetcher.get_weather_vector()
-        
+
         source = self.config_loader.webcam_url
         stream = WebcamStream(source, device=self.device)
         try:
@@ -49,8 +51,10 @@ class Trainer:
                 image_batch = tensor
                 weather_batch = weather_vector.unsqueeze(0)
                 label_batch = torch.tensor([label]).to(self.device)
-                
-                loss = self.model_wrapper.train_step(image_batch, weather_batch, label_batch, self.optimizer)
+
+                loss = self.model_wrapper.train_step(
+                    image_batch, weather_batch, label_batch, self.optimizer
+                )
                 print(f"[{datetime.now()}] Cycle Complete: Loss = {loss:.4f}")
                 self.model_wrapper.save_checkpoint(self.config_loader.checkpoint_dir)
             else:
@@ -63,7 +67,7 @@ class Trainer:
         image_list = []
         weather_list = []
         label_list = []
-        
+
         source = self.config_loader.webcam_url
         try:
             while True:
@@ -80,23 +84,32 @@ class Trainer:
                         print(f"  Source {source}: Capture failed.")
                 finally:
                     stream.release()
-                
+
                 if image_list:
                     current_accum = len(image_list)
-                    print(f"  Accumulation step {current_accum}/{self.config_loader.gradient_accumulation_steps}")
-                    
+                    print(
+                        f"  Accumulation step {current_accum}/{self.config_loader.gradient_accumulation_steps}"
+                    )
+
                     if current_accum >= self.config_loader.gradient_accumulation_steps:
                         image_batch = torch.stack(image_list)
                         weather_batch = torch.stack(weather_list)
                         label_batch = torch.stack(label_list)
-                        loss = self.model_wrapper.train_step(image_batch, weather_batch, label_batch, self.optimizer)
-                        print(f"[{datetime.now()}] Batch Training Complete: Loss = {loss:.4f}")
-                        self.model_wrapper.save_checkpoint(self.config_loader.checkpoint_dir)
+                        loss = self.model_wrapper.train_step(
+                            image_batch, weather_batch, label_batch, self.optimizer
+                        )
+                        print(
+                            f"[{datetime.now()}] Batch Training Complete: Loss = {loss:.4f}"
+                        )
+                        self.model_wrapper.save_checkpoint(
+                            self.config_loader.checkpoint_dir
+                        )
                         image_list, weather_list, label_list = [], [], []
-                
+
                 time.sleep(self.config_loader.capture_interval_seconds)
         except (KeyboardInterrupt, SystemExit):
             print("\nExiting live training loop.")
+
 
 @app.command()
 def once(config: str = "mountain.toml"):
@@ -104,11 +117,13 @@ def once(config: str = "mountain.toml"):
     trainer = Trainer(config)
     trainer.run_single_cycle()
 
+
 @app.command()
 def live(config: str = "mountain.toml"):
     """Runs a continuous loop capturing images and weather data to train the model."""
     trainer = Trainer(config)
     trainer.live_training_loop()
+
 
 @app.command()
 def batch(
@@ -117,7 +132,9 @@ def batch(
     config: str = "mountain.toml",
     epochs: int = 5,
     fresh: bool = False,
-    labels: Optional[str] = typer.Option(None, "--labels", help="Path to labels.yaml (overrides folder/labels.yaml)"),
+    labels: Optional[str] = typer.Option(
+        None, "--labels", help="Path to labels.yaml (overrides folder/labels.yaml)"
+    ),
 ):
     """Runs training using a labels index. Pass --labels path/to/labels.yaml or a folder containing labels.yaml."""
     trainer = Trainer(config, fresh=fresh)
@@ -131,7 +148,7 @@ def batch(
     else:
         typer.echo("Error: provide a --labels file or a folder argument.", err=True)
         raise typer.Exit(1)
-    
+
     import yaml
     import cv2
     import numpy as np
@@ -144,16 +161,18 @@ def batch(
     # Strategy: Use labels.yaml if exists, otherwise fallback to folder-wide label
     labels_map = {}
     if labels_file.exists():
-        with open(labels_file, 'r') as f:
+        with open(labels_file, "r") as f:
             labels_map = yaml.safe_load(f) or {}
         print(f"Loaded {len(labels_map)} labels from {labels_file}")
-    
+
     # Strategy: Oversample minority classes (Full = 1, Partial = 2)
     labels_full = {path: label for path, label in labels_map.items() if label == 1}
     labels_partial = {path: label for path, label in labels_map.items() if label == 2}
     labels_not_out = {path: label for path, label in labels_map.items() if label == 0}
 
-    print(f"Dataset stats: {len(labels_not_out)} Not Out, {len(labels_full)} Full, {len(labels_partial)} Partial")
+    print(
+        f"Dataset stats: {len(labels_not_out)} Not Out, {len(labels_full)} Full, {len(labels_partial)} Partial"
+    )
 
     # We want a reasonable representation of all visible mountain frames
     # Target: 1:2:2 ratio (NotOut : Full : Partial) or similar
@@ -161,39 +180,43 @@ def batch(
 
     final_training_list = []
     # Add all 'Not Out' once
-    for p, l in labels_not_out.items():
-        final_training_list.append((p, l))
+    for p, label in labels_not_out.items():
+        final_training_list.append((p, label))
 
     # Oversample 'Full'
     if labels_full:
         full_factor = max(1, max_not_out // (len(labels_full) * 2))
-        for p, l in labels_full.items():
+        for p, label in labels_full.items():
             for _ in range(full_factor):
-                final_training_list.append((p, l))
+                final_training_list.append((p, label))
         print(f"  Oversampling 'Full' by {full_factor}x")
 
     # Oversample 'Partial'
     if labels_partial:
         partial_factor = max(1, max_not_out // (len(labels_partial) * 2))
-        for p, l in labels_partial.items():
+        for p, label in labels_partial.items():
             for _ in range(partial_factor):
-                final_training_list.append((p, l))
+                final_training_list.append((p, label))
         print(f"  Oversampling 'Partial' by {partial_factor}x")
 
     import random
+
     random.shuffle(final_training_list)
 
     print(f"Final training set size: {len(final_training_list)} samples.")
 
     # Prefetch all needed files from R2 into local cache (no-op for LocalStorage)
     from collect.storage import CachedR2Storage
+
     if isinstance(storage, CachedR2Storage):
         prefetch_keys = []
         for rel_path, _ in final_training_list:
             prefetch_keys.append(rel_path)
             # Also add METAR file keys (try all fallback patterns)
             img_p = Path(rel_path)
-            prefetch_keys.append(str(img_p.parent.parent / "metar" / f"{img_p.stem}.txt"))
+            prefetch_keys.append(
+                str(img_p.parent.parent / "metar" / f"{img_p.stem}.txt")
+            )
             prefetch_keys.append(str(img_p.parent.parent / "metar" / "metar.txt"))
             prefetch_keys.append(str(img_p.parent / f"{img_p.stem}.txt"))
         storage.prefetch(prefetch_keys)
@@ -202,6 +225,7 @@ def batch(
 
     # Stratified train/val split (85/15)
     from collections import defaultdict
+
     by_class = defaultdict(list)
     for item in final_training_list:
         by_class[item[1]].append(item)
@@ -219,36 +243,49 @@ def batch(
 
     # Class weights (inverse frequency) for loss function
     from collections import Counter
-    class_counts = Counter(l for _, l in train_list)
+
+    class_counts = Counter(label for _, label in train_list)
     total_samples = sum(class_counts.values())
     n_classes = 3
     class_weights = torch.tensor(
-        [total_samples / (n_classes * class_counts.get(c, 1)) for c in range(n_classes)],
-        dtype=torch.float32
+        [
+            total_samples / (n_classes * class_counts.get(c, 1))
+            for c in range(n_classes)
+        ],
+        dtype=torch.float32,
     )
     print(f"Class weights: {class_weights.tolist()}")
 
-    from torchvision import transforms
-    train_transform = transforms.Compose([
-        transforms.ToPILImage(),
-        transforms.Resize(224),
-        transforms.CenterCrop(224),
-        transforms.RandomHorizontalFlip(),
-        transforms.ColorJitter(brightness=0.3, contrast=0.3, saturation=0.2),
-        transforms.RandomAffine(degrees=10, translate=(0.05, 0.05)),
-        transforms.ToTensor(),
-        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-    ])
-    val_transform = transforms.Compose([
-        transforms.ToPILImage(),
-        transforms.Resize(224),
-        transforms.CenterCrop(224),
-        transforms.ToTensor(),
-        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-    ])
+    train_transform = transforms.Compose(
+        [
+            transforms.ToPILImage(),
+            transforms.Resize(224),
+            transforms.CenterCrop(224),
+            transforms.RandomHorizontalFlip(),
+            transforms.ColorJitter(brightness=0.3, contrast=0.3, saturation=0.2),
+            transforms.RandomAffine(degrees=10, translate=(0.05, 0.05)),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+    val_transform = transforms.Compose(
+        [
+            transforms.ToPILImage(),
+            transforms.Resize(224),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
 
     import json
-    from rich.progress import Progress, TextColumn, BarColumn, TaskProgressColumn, TimeRemainingColumn
+    from rich.progress import (
+        Progress,
+        TextColumn,
+        BarColumn,
+        TaskProgressColumn,
+        TimeRemainingColumn,
+    )
 
     state_file = Path("data/training_state.json")
     state_file.parent.mkdir(parents=True, exist_ok=True)
@@ -262,14 +299,16 @@ def batch(
             str(img_rel.parent / f"{img_rel.stem}.txt"),
         ]
         metar_key = next((c for c in metar_candidates if storage.exists(c)), None)
-        if metar_key is None: return None
+        if metar_key is None:
+            return None
 
         try:
             img_bytes = storage.get(rel_path)
         except Exception:
             return None
         frame = cv2.imdecode(np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR)
-        if frame is None: return None
+        if frame is None:
+            return None
         frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         tensor = transform_fn(frame_rgb)  # CPU
 
@@ -277,13 +316,21 @@ def batch(
         vis, ceil = 0.0, 1.0
         try:
             obs = Metar.Metar(metar_text)
-            if obs.vis: vis = min(obs.vis.value('SM'), 10.0) / 10.0
+            if obs.vis:
+                vis = min(obs.vis.value("SM"), 10.0) / 10.0
             if obs.sky:
-                layers = [l for l in obs.sky if l[0] in ['BKN', 'OVC']]
-                ceil = min(layers[0][1].value('FT'), 10000.0) / 10000.0 if layers else 1.0
-        except: pass
+                layers = [layer for layer in obs.sky if layer[0] in ["BKN", "OVC"]]
+                ceil = (
+                    min(layers[0][1].value("FT"), 10000.0) / 10000.0 if layers else 1.0
+                )
+        except Exception:
+            pass
 
-        return tensor, torch.tensor([vis, ceil], dtype=torch.float32), torch.tensor(img_label)
+        return (
+            tensor,
+            torch.tensor([vis, ceil], dtype=torch.float32),
+            torch.tensor(img_label),
+        )
 
     def _run_validation():
         """Run validation pass batch-by-batch, return average loss and accuracy."""
@@ -294,31 +341,38 @@ def batch(
 
         def _flush():
             nonlocal total_loss, correct, total
-            if not buf_img: return
+            if not buf_img:
+                return
             ib = torch.stack(buf_img).to(trainer.device)
             wb = torch.stack(buf_w).to(trainer.device)
             lb = torch.stack(buf_l).to(trainer.device)
             outputs = trainer.model_wrapper(ib, wb)
-            total_loss += torch.nn.functional.cross_entropy(outputs, lb, weight=cw).item() * lb.size(0)
+            total_loss += torch.nn.functional.cross_entropy(
+                outputs, lb, weight=cw
+            ).item() * lb.size(0)
             correct += (outputs.argmax(1) == lb).sum().item()
             total += lb.size(0)
             del ib, wb, lb, outputs
-            if trainer.device == "mps": torch.mps.empty_cache()
+            if trainer.device == "mps":
+                torch.mps.empty_cache()
 
         with torch.no_grad():
             for rel_path, img_label in val_list:
                 item = _load_one(rel_path, img_label, val_transform)
-                if item is None: continue
-                buf_img.append(item[0]); buf_w.append(item[1]); buf_l.append(item[2])
+                if item is None:
+                    continue
+                buf_img.append(item[0])
+                buf_w.append(item[1])
+                buf_l.append(item[2])
                 if len(buf_img) >= batch_size:
                     _flush()
                     buf_img, buf_w, buf_l = [], [], []
             _flush()
         if total == 0:
-            return float('nan'), 0.0
+            return float("nan"), 0.0
         return total_loss / total, correct / total
 
-    best_val_loss = float('inf')
+    best_val_loss = float("inf")
 
     with Progress(
         TextColumn("[progress.description]{task.description}"),
@@ -330,7 +384,9 @@ def batch(
 
         for epoch in range(epochs):
             random.shuffle(train_list)
-            batch_task = progress.add_task(f"[cyan]Epoch {epoch+1}/{epochs}...", total=total_batches)
+            batch_task = progress.add_task(
+                f"[cyan]Epoch {epoch + 1}/{epochs}...", total=total_batches
+            )
 
             image_list, weather_list, label_list = [], [], []
             epoch_losses = []
@@ -344,7 +400,9 @@ def batch(
                     str(img_rel.parent.parent / "metar" / "metar.txt"),
                     str(img_rel.parent / f"{img_rel.stem}.txt"),
                 ]
-                metar_key = next((c for c in metar_candidates if storage.exists(c)), None)
+                metar_key = next(
+                    (c for c in metar_candidates if storage.exists(c)), None
+                )
                 if metar_key is None:
                     continue
 
@@ -352,8 +410,11 @@ def batch(
                     img_bytes = storage.get(rel_path)
                 except Exception:
                     continue
-                frame = cv2.imdecode(np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR)
-                if frame is None: continue
+                frame = cv2.imdecode(
+                    np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR
+                )
+                if frame is None:
+                    continue
                 frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                 tensor = train_transform(frame_rgb).to(trainer.device)
 
@@ -361,11 +422,19 @@ def batch(
                 vis, ceil = 0.0, 1.0
                 try:
                     obs = Metar.Metar(metar_text)
-                    if obs.vis: vis = min(obs.vis.value('SM'), 10.0) / 10.0
+                    if obs.vis:
+                        vis = min(obs.vis.value("SM"), 10.0) / 10.0
                     if obs.sky:
-                        layers = [l for l in obs.sky if l[0] in ['BKN', 'OVC']]
-                        ceil = min(layers[0][1].value('FT'), 10000.0) / 10000.0 if layers else 1.0
-                except: pass
+                        layers = [
+                            layer for layer in obs.sky if layer[0] in ["BKN", "OVC"]
+                        ]
+                        ceil = (
+                            min(layers[0][1].value("FT"), 10000.0) / 10000.0
+                            if layers
+                            else 1.0
+                        )
+                except Exception:
+                    pass
 
                 image_list.append(tensor)
                 weather_list.append(torch.tensor([vis, ceil], dtype=torch.float32))
@@ -373,8 +442,10 @@ def batch(
 
                 if len(image_list) >= batch_size:
                     loss = trainer.model_wrapper.train_step(
-                        torch.stack(image_list), torch.stack(weather_list),
-                        torch.stack(label_list), trainer.optimizer,
+                        torch.stack(image_list),
+                        torch.stack(weather_list),
+                        torch.stack(label_list),
+                        trainer.optimizer,
                         class_weights=class_weights,
                     )
                     epoch_losses.append(loss)
@@ -384,7 +455,10 @@ def batch(
                     progress.update(batch_task, advance=1)
 
                     avg_loss = sum(epoch_losses) / len(epoch_losses)
-                    progress.update(batch_task, description=f"[cyan]Epoch {epoch+1}/{epochs} (Loss: {avg_loss:.4f})")
+                    progress.update(
+                        batch_task,
+                        description=f"[cyan]Epoch {epoch + 1}/{epochs} (Loss: {avg_loss:.4f})",
+                    )
 
                     state = {
                         "status": "running",
@@ -392,7 +466,7 @@ def batch(
                         "total_epochs": epochs,
                         "batches_complete": batches_complete,
                         "total_batches": total_batches,
-                        "current_loss": avg_loss
+                        "current_loss": avg_loss,
                     }
                     tmp_state = state_file.with_suffix(".tmp")
                     with open(tmp_state, "w") as f:
@@ -401,29 +475,44 @@ def batch(
 
             if image_list:
                 loss = trainer.model_wrapper.train_step(
-                    torch.stack(image_list), torch.stack(weather_list),
-                    torch.stack(label_list), trainer.optimizer,
+                    torch.stack(image_list),
+                    torch.stack(weather_list),
+                    torch.stack(label_list),
+                    trainer.optimizer,
                     class_weights=class_weights,
                 )
                 epoch_losses.append(loss)
                 batches_complete += 1
                 progress.update(batch_task, advance=1)
                 avg_loss = sum(epoch_losses) / len(epoch_losses)
-                progress.update(batch_task, description=f"[cyan]Epoch {epoch+1}/{epochs} (Loss: {avg_loss:.4f})")
+                progress.update(
+                    batch_task,
+                    description=f"[cyan]Epoch {epoch + 1}/{epochs} (Loss: {avg_loss:.4f})",
+                )
 
-            avg_loss = sum(epoch_losses) / len(epoch_losses) if epoch_losses else float('nan')
+            avg_loss = (
+                sum(epoch_losses) / len(epoch_losses) if epoch_losses else float("nan")
+            )
 
             # Validation
             val_loss, val_acc = _run_validation()
             progress.remove_task(batch_task)
-            progress.update(epoch_task, advance=1, description=f"[green]Epoch {epoch+1}: train={avg_loss:.4f} val={val_loss:.4f} acc={val_acc:.1%}")
-            print(f"  Epoch {epoch+1}: train_loss={avg_loss:.4f}  val_loss={val_loss:.4f}  val_acc={val_acc:.1%}")
+            progress.update(
+                epoch_task,
+                advance=1,
+                description=f"[green]Epoch {epoch + 1}: train={avg_loss:.4f} val={val_loss:.4f} acc={val_acc:.1%}",
+            )
+            print(
+                f"  Epoch {epoch + 1}: train_loss={avg_loss:.4f}  val_loss={val_loss:.4f}  val_acc={val_acc:.1%}"
+            )
 
             if val_loss < best_val_loss:
                 best_val_loss = val_loss
-                trainer.model_wrapper.save_checkpoint(trainer.config_loader.checkpoint_dir, storage=storage)
+                trainer.model_wrapper.save_checkpoint(
+                    trainer.config_loader.checkpoint_dir, storage=storage
+                )
                 print(f"  ↳ Best model saved (val_loss={val_loss:.4f})")
-            
+
     if state_file.exists():
         state = {
             "status": "complete",
@@ -431,24 +520,31 @@ def batch(
             "total_epochs": epochs,
             "batches_complete": total_batches,
             "total_batches": total_batches,
-            "current_loss": avg_loss if 'avg_loss' in locals() else 0.0
+            "current_loss": avg_loss if "avg_loss" in locals() else 0.0,
         }
         with open(state_file.with_suffix(".tmp"), "w") as f:
             json.dump(state, f)
         state_file.with_suffix(".tmp").rename(state_file)
-    
+
     # Reload the best checkpoint (saved during training) for evaluation
-    trainer.model_wrapper.load_checkpoint(trainer.config_loader.checkpoint_dir, storage=storage)
+    trainer.model_wrapper.load_checkpoint(
+        trainer.config_loader.checkpoint_dir, storage=storage
+    )
 
     # Clean up R2 cache if used
     if isinstance(storage, CachedR2Storage):
         storage.clear_cache()
 
-    print(f"\nTraining complete (best val_loss={best_val_loss:.4f}). Running final evaluation...")
+    print(
+        f"\nTraining complete (best val_loss={best_val_loss:.4f}). Running final evaluation..."
+    )
     import sys
+
     sys.path.append(str(Path.cwd()))
     from tools.evaluate import evaluate
+
     evaluate(trainer.config_loader.checkpoint_dir, str(labels_file))
+
 
 @app.command()
 def schedule(config: str = "mountain.toml"):
@@ -458,7 +554,7 @@ def schedule(config: str = "mountain.toml"):
     current_dir = Path.cwd().absolute()
     executable = subprocess.check_output(["which", "uv"], text=True).strip()
     plist_path = Path.home() / "Library" / "LaunchAgents" / "com.mountain.trainer.plist"
-    
+
     plist_content = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -485,10 +581,14 @@ def schedule(config: str = "mountain.toml"):
 </dict>
 </plist>
 """
-    with open(plist_path, "w") as f: f.write(plist_content)
+    with open(plist_path, "w") as f:
+        f.write(plist_content)
     subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
     subprocess.run(["launchctl", "load", str(plist_path)])
-    print(f"Service installed at {plist_path}. Interval: {config_loader.schedule_seconds}s")
+    print(
+        f"Service installed at {plist_path}. Interval: {config_loader.schedule_seconds}s"
+    )
+
 
 @app.command()
 def unschedule():
@@ -497,8 +597,10 @@ def unschedule():
     if plist_path.exists():
         subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
         plist_path.unlink()
-        print(f"Service removed.")
-    else: print("Service not found.")
+        print("Service removed.")
+    else:
+        print("Service not found.")
+
 
 if __name__ == "__main__":
     app()

--- a/train/scheduler.py
+++ b/train/scheduler.py
@@ -107,7 +107,8 @@ class Trainer:
                         image_list, weather_list, label_list = [], [], []
 
                 time.sleep(self.config_loader.capture_interval_seconds)
-        except (KeyboardInterrupt, SystemExit):
+        # Keep the parens 3.13-compatible; ruff's py314 style would strip them.
+        except (KeyboardInterrupt, SystemExit):  # fmt: skip
             print("\nExiting live training loop.")
 
 

--- a/train/tests/test_config_loader.py
+++ b/train/tests/test_config_loader.py
@@ -1,34 +1,31 @@
-import pytest
 import tomli_w
-import os
 from train.config_loader import ConfigLoader
+
 
 def test_config_loader(tmp_path):
     # Consolidated mountain.toml
     config_file = tmp_path / "mountain.toml"
     config_data = {
-        'mountain': {'name': 'Mount Rainier', 'height': 14411},
-        'webcam': {'url': 'http://rainier-webcam.jpg', 'name': 'Rainier View'},
-        'weather': {'station_id': 'KTCM'},
-        'training': {
-            'schedule_seconds': 1800,
-            'capture_interval_seconds': 300,
-            'gradient_accumulation_steps': 4,
-            'checkpoint_dir': 'checkpoints',
-            'lora': {'rank': 4, 'alpha': 8, 'target_modules': ['fc1']}
+        "mountain": {"name": "Mount Rainier", "height": 14411},
+        "webcam": {"url": "http://rainier-webcam.jpg", "name": "Rainier View"},
+        "weather": {"station_id": "KTCM"},
+        "training": {
+            "schedule_seconds": 1800,
+            "capture_interval_seconds": 300,
+            "gradient_accumulation_steps": 4,
+            "checkpoint_dir": "checkpoints",
+            "lora": {"rank": 4, "alpha": 8, "target_modules": ["fc1"]},
         },
-        'collection': {
-            'collection_seconds': 600
-        }
+        "collection": {"collection_seconds": 600},
     }
-    with open(config_file, 'wb') as f:
+    with open(config_file, "wb") as f:
         f.write(tomli_w.dumps(config_data).encode())
-    
+
     loader = ConfigLoader(str(config_file))
-    
-    assert loader.webcam_url == 'http://rainier-webcam.jpg'
-    assert loader.metar_station == 'KTCM'
-    assert loader.mountain_data['name'] == 'Mount Rainier'
+
+    assert loader.webcam_url == "http://rainier-webcam.jpg"
+    assert loader.metar_station == "KTCM"
+    assert loader.mountain_data["name"] == "Mount Rainier"
     assert loader.schedule_seconds == 1800
     assert loader.collection_seconds == 600
-    assert loader.lora_settings['rank'] == 4
+    assert loader.lora_settings["rank"] == 4

--- a/train/tests/test_config_r2.py
+++ b/train/tests/test_config_r2.py
@@ -1,6 +1,5 @@
 """Tests for ConfigLoader storage properties and get_storage() factory."""
 
-import pytest
 import tomli_w
 from unittest.mock import patch, MagicMock
 from train.config_loader import ConfigLoader
@@ -63,7 +62,10 @@ class TestGetStorageFactory:
         storage = loader.get_storage(str(tmp_path / "data"))
         assert isinstance(storage, LocalStorage)
 
-    @patch.dict("sys.modules", {"boto3": MagicMock(), "botocore": MagicMock(), "botocore.config": MagicMock()})
+    @patch.dict(
+        "sys.modules",
+        {"boto3": MagicMock(), "botocore": MagicMock(), "botocore.config": MagicMock()},
+    )
     def test_r2_returns_cached(self, tmp_path, monkeypatch):
         monkeypatch.setenv("R2_ACCESS_KEY_ID", "k")
         monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "s")
@@ -71,6 +73,7 @@ class TestGetStorageFactory:
         # Reload storage module so it picks up the mocked boto3
         import importlib
         import collect.storage
+
         importlib.reload(collect.storage)
         from collect.storage import CachedR2Storage
 

--- a/train/tests/test_model.py
+++ b/train/tests/test_model.py
@@ -1,29 +1,29 @@
-import pytest
 import torch
 import torch.optim as optim
-import os
-import shutil
 from train.model import ConvNextLoRAModel
+
 
 def test_lora_initialization():
     """Verify ConvNextLoRAModel initializes with correct device."""
     model_wrapper = ConvNextLoRAModel(num_classes=2)
-    
+
     if torch.backends.mps.is_available():
         assert str(model_wrapper.device) == "mps"
     else:
         assert str(model_wrapper.device) == "cpu"
-    
+
     # Check if peft wrapped the backbone
     from peft import PeftModel
-    assert isinstance(model_wrapper.model_dict['backbone'], PeftModel)
+
+    assert isinstance(model_wrapper.model_dict["backbone"], PeftModel)
+
 
 def test_dual_input_batch_parameter_update():
     """Verify LoRA weights and classifier update after a batch training step."""
     model_wrapper = ConvNextLoRAModel(num_classes=2)
     device = model_wrapper.device
     batch_size = 4
-    
+
     # Get initial parameters
     initial_params = {}
     for name, param in model_wrapper.model_dict.named_parameters():
@@ -34,50 +34,58 @@ def test_dual_input_batch_parameter_update():
     weather_batch = torch.randn(batch_size, 2).to(device)
     label_batch = torch.randint(0, 2, (batch_size,)).to(device)
     optimizer = optim.Adam(model_wrapper.model_dict.parameters(), lr=0.001)
-    
+
     # Perform training step
     model_wrapper.train_step(image_batch, weather_batch, label_batch, optimizer)
-    
+
     # Check if parameters updated
     updated_lora = False
     updated_classifier = False
-    
+
     for name, param in model_wrapper.model_dict.named_parameters():
-        if 'lora_' in name:
+        if "lora_" in name:
             if not torch.equal(initial_params[name], param):
                 updated_lora = True
-        elif 'classifier' in name:
+        elif "classifier" in name:
             if not torch.equal(initial_params[name], param):
                 updated_classifier = True
-    
-    assert updated_lora, "LoRA parameters in backbone did not change after a batch training step"
-    assert updated_classifier, "Classifier head parameters did not change after a batch training step"
+
+    assert updated_lora, (
+        "LoRA parameters in backbone did not change after a batch training step"
+    )
+    assert updated_classifier, (
+        "Classifier head parameters did not change after a batch training step"
+    )
+
 
 def test_checkpoint_save_load(tmp_path):
     """Verify that model can save and load checkpoints correctly."""
     checkpoint_dir = str(tmp_path / "test_ckpt")
     model1 = ConvNextLoRAModel(num_classes=2)
-    
+
     # Save initial state of model1
     model1.save_checkpoint(checkpoint_dir)
-    
+
     # Create model2 and load model1's checkpoint
     model2 = ConvNextLoRAModel(num_classes=2)
     model2.load_checkpoint(checkpoint_dir)
-    
+
     # Verify parameters match
-    for (n1, p1), (n2, p2) in zip(model1.model_dict.named_parameters(), model2.model_dict.named_parameters()):
-        if 'lora_' in n1 or 'classifier' in n1:
+    for (n1, p1), (n2, p2) in zip(
+        model1.model_dict.named_parameters(), model2.model_dict.named_parameters()
+    ):
+        if "lora_" in n1 or "classifier" in n1:
             assert torch.equal(p1, p2), f"Parameter {n1} does not match after loading"
+
 
 def test_predict_batch():
     """Verify prediction works with a batch of dual inputs."""
     model_wrapper = ConvNextLoRAModel(num_classes=2)
     device = model_wrapper.device
     batch_size = 4
-    
+
     image_batch = torch.randn(batch_size, 3, 224, 224).to(device)
     weather_batch = torch.randn(batch_size, 2).to(device)
-    
+
     predictions = model_wrapper.predict(image_batch, weather_batch)
     assert predictions.shape == (batch_size,)

--- a/train/tests/test_regression.py
+++ b/train/tests/test_regression.py
@@ -6,35 +6,48 @@ from torchvision import transforms
 from train.model import ConvNextLoRAModel
 from train.config_loader import ConfigLoader
 
+
 class RegressionTester:
     def __init__(self, config_path="mountain.toml"):
         self.config = ConfigLoader(config_path)
-        self.device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
-        self.model = ConvNextLoRAModel(checkpoint_dir=self.config.checkpoint_dir).to(self.device)
+        self.device = torch.device(
+            "mps" if torch.backends.mps.is_available() else "cpu"
+        )
+        self.model = ConvNextLoRAModel(checkpoint_dir=self.config.checkpoint_dir).to(
+            self.device
+        )
         self.model.eval()
-        
-        self.transform = transforms.Compose([
-            transforms.ToPILImage(),
-            transforms.Resize(224),
-            transforms.CenterCrop(224),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-        ])
+
+        self.transform = transforms.Compose(
+            [
+                transforms.ToPILImage(),
+                transforms.Resize(224),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
 
     def predict(self, img_path, vis=1.0, ceil=1.0):
         img = cv2.imread(str(img_path))
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         img_tensor = self.transform(img).unsqueeze(0).to(self.device)
-        weather_tensor = torch.tensor([[vis, ceil]], dtype=torch.float32).to(self.device)
-        
+        weather_tensor = torch.tensor([[vis, ceil]], dtype=torch.float32).to(
+            self.device
+        )
+
         with torch.no_grad():
             output = self.model(img_tensor, weather_tensor)
             prediction = torch.argmax(output, dim=1).item()
         return prediction
 
+
 @pytest.fixture(scope="module")
 def tester():
     return RegressionTester()
+
 
 def test_dark_frame_prediction(tester):
     """
@@ -43,11 +56,14 @@ def test_dark_frame_prediction(tester):
     Source: assets/regression_samples/dark_sample.jpg
     """
     img_path = Path("assets/regression_samples/dark_sample.jpg")
-    # Low visibility/ceiling usually accompanies dark frames if weather is bad, 
+    # Low visibility/ceiling usually accompanies dark frames if weather is bad,
     # but for a 'pure darkness' test we keep weather neutral to test vision bias.
     prediction = tester.predict(img_path, vis=1.0, ceil=1.0)
-    
-    assert prediction == 0, f"Model failed to identify dark frame as 'Not Out'. Predicted: {prediction}"
+
+    assert prediction == 0, (
+        f"Model failed to identify dark frame as 'Not Out'. Predicted: {prediction}"
+    )
+
 
 def test_known_out_frame(tester):
     """
@@ -57,5 +73,7 @@ def test_known_out_frame(tester):
     """
     img_path = Path("assets/regression_samples/mountain_out_sample.jpg")
     prediction = tester.predict(img_path, vis=1.0, ceil=1.0)
-    
-    assert prediction == 1, f"Model failed to identify known mountain-out frame. Predicted: {prediction}"
+
+    assert prediction == 1, (
+        f"Model failed to identify known mountain-out frame. Predicted: {prediction}"
+    )

--- a/train/tests/test_scheduler.py
+++ b/train/tests/test_scheduler.py
@@ -1,61 +1,68 @@
 import pytest
 import torch
-import torch.optim as optim
 from unittest.mock import MagicMock, patch
 from train.scheduler import Trainer
 
-@patch('train.scheduler.ConfigLoader')
-@patch('train.scheduler.ConvNextLoRAModel')
-@patch('train.scheduler.WeatherFetcher')
+
+@patch("train.scheduler.ConfigLoader")
+@patch("train.scheduler.ConvNextLoRAModel")
+@patch("train.scheduler.WeatherFetcher")
 def test_trainer_initialization(mock_weather, mock_model_cls, mock_config):
     """Verify that the trainer initializes correctly."""
-    mock_config.return_value.metar_station = 'KSEA'
+    mock_config.return_value.metar_station = "KSEA"
     mock_config.return_value.lora_settings = {
-        'rank': 8, 'alpha': 16, 'target_modules': ['fc1']
+        "rank": 8,
+        "alpha": 16,
+        "target_modules": ["fc1"],
     }
-    mock_config.return_value.checkpoint_dir = 'checkpoints'
-    
+    mock_config.return_value.checkpoint_dir = "checkpoints"
+
     mock_model = MagicMock()
     mock_model.model_dict.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
     mock_model_cls.return_value = mock_model
-    
-    trainer = Trainer('mountain.toml')
-    
+
+    Trainer("mountain.toml")
+
     assert mock_model_cls.called
     assert mock_weather.called
 
-@patch('train.scheduler.WebcamStream')
-@patch('train.scheduler.WeatherFetcher')
+
+@patch("train.scheduler.WebcamStream")
+@patch("train.scheduler.WeatherFetcher")
 def test_run_single_cycle_execution(mock_weather_cls, mock_webcam):
     """Verify that run_single_cycle captures from single source and performs a training step."""
-    with patch('train.scheduler.ConfigLoader') as mock_config:
-        mock_config.return_value.webcam_url = 'http://cam.jpg'
-        mock_config.return_value.metar_station = 'KSEA'
+    with patch("train.scheduler.ConfigLoader") as mock_config:
+        mock_config.return_value.webcam_url = "http://cam.jpg"
+        mock_config.return_value.metar_station = "KSEA"
         mock_config.return_value.lora_settings = {
-            'rank': 8, 'alpha': 16, 'target_modules': ['fc1']
+            "rank": 8,
+            "alpha": 16,
+            "target_modules": ["fc1"],
         }
-        mock_config.return_value.checkpoint_dir = 'checkpoints'
-        
-        with patch('train.scheduler.ConvNextLoRAModel') as mock_model_cls:
+        mock_config.return_value.checkpoint_dir = "checkpoints"
+
+        with patch("train.scheduler.ConvNextLoRAModel") as mock_model_cls:
             mock_model = MagicMock()
-            mock_model.model_dict.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
+            mock_model.model_dict.parameters.return_value = [
+                torch.nn.Parameter(torch.randn(1))
+            ]
             mock_model.train_step.return_value = 0.5
-            mock_model_cls.return_value = mock_model            
+            mock_model_cls.return_value = mock_model
             mock_weather = MagicMock()
             mock_weather_vector = torch.tensor([0.8, 0.9])
             mock_weather.get_weather_vector.return_value = mock_weather_vector
             mock_weather_cls.return_value = mock_weather
-            
-            trainer = Trainer('mountain.toml')
+
+            trainer = Trainer("mountain.toml")
             trainer.optimizer = MagicMock()
-            
+
             mock_stream = MagicMock()
             mock_tensor = torch.randn(1, 3, 224, 224)
             mock_stream.capture_to_tensor.return_value = mock_tensor
             mock_webcam.return_value = mock_stream
-            
+
             trainer.run_single_cycle(label=1)
-            
+
             assert mock_stream.capture_to_tensor.call_count == 1
             args, _ = mock_model.train_step.call_args
             image_batch, weather_batch, label_batch, _ = args
@@ -63,40 +70,45 @@ def test_run_single_cycle_execution(mock_weather_cls, mock_webcam):
             assert weather_batch.shape == (1, 2)
             assert label_batch.shape == (1,)
 
-@patch('train.scheduler.WebcamStream')
-@patch('train.scheduler.WeatherFetcher')
-@patch('time.sleep', side_effect=InterruptedError) 
+
+@patch("train.scheduler.WebcamStream")
+@patch("train.scheduler.WeatherFetcher")
+@patch("time.sleep", side_effect=InterruptedError)
 def test_live_training_loop_cycle(mock_sleep, mock_weather_cls, mock_webcam):
     """Verify that live_training_loop captures and performs training."""
-    with patch('train.scheduler.ConfigLoader') as mock_config:
-        mock_config.return_value.webcam_url = 'http://cam.jpg'
-        mock_config.return_value.metar_station = 'KSEA'
+    with patch("train.scheduler.ConfigLoader") as mock_config:
+        mock_config.return_value.webcam_url = "http://cam.jpg"
+        mock_config.return_value.metar_station = "KSEA"
         mock_config.return_value.lora_settings = {
-            'rank': 8, 'alpha': 16, 'target_modules': ['fc1']
+            "rank": 8,
+            "alpha": 16,
+            "target_modules": ["fc1"],
         }
         mock_config.return_value.capture_interval_seconds = 0
         mock_config.return_value.gradient_accumulation_steps = 1
-        mock_config.return_value.checkpoint_dir = 'checkpoints'
-        
-        with patch('train.scheduler.ConvNextLoRAModel') as mock_model_cls:
+        mock_config.return_value.checkpoint_dir = "checkpoints"
+
+        with patch("train.scheduler.ConvNextLoRAModel") as mock_model_cls:
             mock_model = MagicMock()
-            mock_model.model_dict.parameters.return_value = [torch.nn.Parameter(torch.randn(1))]
+            mock_model.model_dict.parameters.return_value = [
+                torch.nn.Parameter(torch.randn(1))
+            ]
             mock_model.train_step.return_value = 0.5
-            mock_model_cls.return_value = mock_model            
+            mock_model_cls.return_value = mock_model
             mock_weather = MagicMock()
             mock_weather_vector = torch.tensor([0.8, 0.9])
             mock_weather.get_weather_vector.return_value = mock_weather_vector
             mock_weather_cls.return_value = mock_weather
-            
-            trainer = Trainer('mountain.toml')
+
+            trainer = Trainer("mountain.toml")
             trainer.optimizer = MagicMock()
-            
+
             mock_stream = MagicMock()
             mock_tensor = torch.randn(1, 3, 224, 224)
             mock_stream.capture_to_tensor.return_value = mock_tensor
             mock_webcam.return_value = mock_stream
-            
+
             with pytest.raises(InterruptedError):
                 trainer.live_training_loop(label=1)
-            
+
             assert mock_stream.capture_to_tensor.call_count == 1

--- a/train/tests/test_webcam.py
+++ b/train/tests/test_webcam.py
@@ -1,9 +1,8 @@
-import pytest
 import torch
 import numpy as np
-import cv2
 from unittest.mock import MagicMock, patch
 from train.utils import WebcamStream
+
 
 def test_mps_availability():
     """Verify code identifies if MPS is available or defaults to CPU."""
@@ -13,10 +12,11 @@ def test_mps_availability():
     else:
         assert stream.device == "cpu"
 
-@patch('cv2.VideoCapture')
+
+@patch("cv2.VideoCapture")
 def test_no_disk_usage(mock_video_capture):
     """
-    Mock OpenCV frame capture and verify that the resulting tensor 
+    Mock OpenCV frame capture and verify that the resulting tensor
     is on the correct device and matches expected dimensions.
     """
     mock_cap = MagicMock()
@@ -24,14 +24,14 @@ def test_no_disk_usage(mock_video_capture):
     frame = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
     mock_cap.read.return_value = (True, frame)
     mock_video_capture.return_value = mock_cap
-    
+
     stream = WebcamStream(0)
-    
+
     # Track calls to cv2.imwrite to ensure no disk usage
-    with patch('cv2.imwrite') as mock_imwrite:
+    with patch("cv2.imwrite") as mock_imwrite:
         tensor = stream.capture_to_tensor()
         mock_imwrite.assert_not_called()
-    
+
     assert tensor is not None
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (1, 3, 224, 224)
@@ -39,13 +39,14 @@ def test_no_disk_usage(mock_video_capture):
     if torch.backends.mps.is_available():
         assert tensor.device.type == "mps"
 
-@patch('cv2.VideoCapture')
+
+@patch("cv2.VideoCapture")
 def test_capture_failure(mock_video_capture):
     """Verify behavior when frame capture fails."""
     mock_cap = MagicMock()
     mock_cap.read.return_value = (False, None)
     mock_video_capture.return_value = mock_cap
-    
+
     stream = WebcamStream(0)
     tensor = stream.capture_to_tensor()
     assert tensor is None

--- a/train/tray.py
+++ b/train/tray.py
@@ -3,8 +3,8 @@ TrainingTray — rumps menu bar app for monitoring Nomad training jobs.
 
 Reads data/training_state.json via a rumps.Timer.
 """
+
 import logging
-import sys
 import json
 from pathlib import Path
 from typing import Optional, Dict, Any
@@ -18,6 +18,7 @@ REFRESH_INTERVAL = 10  # seconds between state file reads
 
 SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
+
 class TrainingTray(rumps.App):
     def __init__(self, data_root: str = "data"):
         super().__init__("Mountain Training", title="🗻", quit_button=None)
@@ -28,11 +29,11 @@ class TrainingTray(rumps.App):
 
         # --- Static menu skeleton ---
         self.progress_bar_item = rumps.MenuItem("—")
-        self.status_item       = rumps.MenuItem("Status: —")
-        self.epoch_item        = rumps.MenuItem("Epoch: —")
-        self.batch_item        = rumps.MenuItem("Batch: —")
-        self.loss_item         = rumps.MenuItem("Loss: —")
-        
+        self.status_item = rumps.MenuItem("Status: —")
+        self.epoch_item = rumps.MenuItem("Epoch: —")
+        self.batch_item = rumps.MenuItem("Batch: —")
+        self.loss_item = rumps.MenuItem("Loss: —")
+
         self.menu = [
             self.progress_bar_item,
             rumps.separator,
@@ -51,7 +52,7 @@ class TrainingTray(rumps.App):
         if not self.state_file.exists():
             return None
         try:
-            with open(self.state_file, 'r') as f:
+            with open(self.state_file, "r") as f:
                 return json.load(f)
         except Exception as e:
             logger.error(f"Failed to read state file: {e}")
@@ -63,17 +64,17 @@ class TrainingTray(rumps.App):
             self.status_item.title = "Status: No training state found"
             self.title = "🗻"
             return
-            
+
         # Check if state changed (or if it's running, we just update to spin the icon if needed)
-        if state == self._last_state and state.get('status') != 'running':
+        if state == self._last_state and state.get("status") != "running":
             return
-            
+
         self._last_state = state
         self._render(state)
 
     def _render(self, state: Dict[str, Any]) -> None:
         status = state.get("status", "unknown")
-        
+
         if status == "running":
             # Simple spinner logic by cycling through braille frames
             spinner = SPINNER[self._spinner_idx % len(SPINNER)]
@@ -89,9 +90,9 @@ class TrainingTray(rumps.App):
 
         # Progress bar (based on batches)
         batches = state.get("batches_complete", 0)
-        total_batches = state.get("total_batches", 1) # Avoid div zero
+        total_batches = state.get("total_batches", 1)  # Avoid div zero
         pct = int(100 * batches / total_batches) if total_batches > 0 else 0
-        
+
         bar_len = 20
         filled_len = int(round(bar_len * pct / 100))
         bar = "█" * filled_len + "░" * (bar_len - filled_len)
@@ -101,10 +102,10 @@ class TrainingTray(rumps.App):
         epoch = state.get("epoch", 0)
         total_epochs = state.get("total_epochs", 0)
         self.epoch_item.title = f"Epoch: {epoch}/{total_epochs}"
-        
+
         # Batches
         self.batch_item.title = f"Batch: {batches}/{total_batches}"
-        
+
         # Loss
         loss = state.get("current_loss", 0.0)
         self.loss_item.title = f"Loss: {loss:.4f}"
@@ -118,9 +119,11 @@ class TrainingTray(rumps.App):
         self._timer.start()
         super().run()
 
+
 def cli():
     logging.basicConfig(level=logging.INFO)
     TrainingTray().run()
+
 
 if __name__ == "__main__":
     cli()

--- a/train/utils.py
+++ b/train/utils.py
@@ -2,28 +2,33 @@ import cv2
 import torch
 import numpy as np
 from torchvision import transforms
-from typing import Optional, Union, Any
+from typing import Optional, Union
 import requests
 from metar import Metar
-from datetime import datetime
+
 
 class WebcamStream:
     def __init__(self, source: Union[int, str], device: str = "mps"):
         self.source = source
         self.device = device if torch.backends.mps.is_available() else "cpu"
         self.cap = cv2.VideoCapture(source)
-        
-        self.transform = transforms.Compose([
-            transforms.ToPILImage(),
-            transforms.Resize(224),
-            transforms.CenterCrop(224),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-        ])
+
+        self.transform = transforms.Compose(
+            [
+                transforms.ToPILImage(),
+                transforms.Resize(224),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
 
     def capture_to_tensor(self) -> Optional[torch.Tensor]:
         ret, frame = self.cap.read()
-        if not ret: return None
+        if not ret:
+            return None
         frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         tensor = self.transform(frame_rgb).to(self.device)
         return tensor.unsqueeze(0)
@@ -39,6 +44,7 @@ class WebcamStream:
     def __del__(self):
         self.release()
 
+
 class WeatherFetcher:
     def __init__(self, station_id: str = "KSEA"):
         self.station_id = station_id
@@ -48,7 +54,7 @@ class WeatherFetcher:
         try:
             response = requests.get(self.base_url, timeout=10)
             if response.status_code == 200:
-                lines = response.text.strip().split('\n')
+                lines = response.text.strip().split("\n")
                 return lines[-1] if lines else None
         except Exception as e:
             print(f"Error fetching METAR: {e}")
@@ -59,11 +65,17 @@ class WeatherFetcher:
         if metar_text:
             try:
                 obs = Metar.Metar(metar_text)
-                if obs.vis: vis = min(obs.vis.value('SM'), 10.0) / 10.0
+                if obs.vis:
+                    vis = min(obs.vis.value("SM"), 10.0) / 10.0
                 if obs.sky:
-                    layers = [l for l in obs.sky if l[0] in ['BKN', 'OVC']]
-                    ceil = min(layers[0][1].value('FT'), 10000.0) / 10000.0 if layers else 1.0
-            except: pass
+                    layers = [layer for layer in obs.sky if layer[0] in ["BKN", "OVC"]]
+                    ceil = (
+                        min(layers[0][1].value("FT"), 10000.0) / 10000.0
+                        if layers
+                        else 1.0
+                    )
+            except Exception:
+                pass
         return torch.tensor([vis, ceil], dtype=torch.float32)
 
     def get_weather_vector(self) -> torch.Tensor:


### PR DESCRIPTION
`REPO` — **LINT DISPATCH**

# The lint sweep that woke up the Nomad proxy

> _Clearing 157 ruff findings surfaced a real bug: `tools/classifier_server.py` calls `requests` without ever importing it, so the `/api/jobs` Nomad proxy has silently returned `[]` on every request since the day it shipped._

> [!NOTE]
> **repo-wide** · chore · risk: low

Main went red on 2026-07-02 when the standardization merge pointed this repo at the canonical two-step Lint workflow (`ruff check`, then `ruff format --check`): 157 findings across `collect/`, `tools/` and `train/`, plus 36 files of format debt. All of it is fixed here — and one finding turned out to be load-bearing: F821, undefined name `requests`.

## The bug: a NameError swallowed whole
- `get_jobs()` calls `requests.get(f"{nomad_url}/v1/jobs")` inside `try/except Exception: return []`.
- The module never imported `requests` — every call raised `NameError`, the except ate it, and the UI saw an empty jobs list, indistinguishable from "Nomad is down."
- Fix: `import requests` (already a declared dependency). The proxy now actually proxies.

> _"The except-Exception fallback made a missing import look exactly like an unreachable Nomad."_

## How it flows
```mermaid
flowchart TD
  A[GET /api/jobs] --> B{import requests present?}
  B -->|before: NameError| C[except Exception]
  C --> D[return empty list — always]
  B -->|after: fixed| E[requests.get Nomad /v1/jobs]
  E -->|ok| F[real job list]
  E -->|Nomad unreachable| C
```

## The other 156, all mechanical
- 75 safe autofixes via `ruff check --fix`: 68 unused imports, 4 shadowed redefinitions (F811), 2 placeholder-free f-strings (F541).
- 12 bare `except:` → `except Exception:` (E722) — they no longer swallow `KeyboardInterrupt`/`SystemExit`.
- 11 ambiguous `l` renamed to `layer`/`label` (E741) in the METAR sky-layer parsing and label loops.
- 4 late module-level imports moved to the top (E402) in `collector.py`, `simple_classifier.py`, `test_tray.py`; checked first that `collect/sync.py` has no import cycle back into `collector.py`.
- 3 unused test locals dropped (F841) — the invocations they bound stay put.
- `ruff format` over 36 files + `captures.ipynb`, which also cleared all 47 E701/E702 one-liners.

## Verification
- `uvx ruff check .` and `uvx ruff format --check .` from the repo root → clean, on both current ruff (0.15.20, what CI resolves) and the pre-commit-pinned 0.12.0.
- One subtlety this PR surfaced: `requires-python = ">=3.14"` makes current ruff's formatter prefer PEP 758's unparenthesized `except A, B:` — syntax ruff 0.12.0 doesn't produce and pre-3.14 interpreters can't parse. A single `# fmt: skip` keeps the 3.13-compatible parens in `train/scheduler.py` and keeps CI and pre-commit in agreement.
- All 40 `.py` files re-parsed with CPython's `ast` module — no syntax drift.
- The pytest suite was not run locally (torch/timm/rumps not installed on this machine); the three test edits only drop unused bindings.

## Risk & rollout
- **Two intentional behavior deltas:** `/api/jobs` now returns real Nomad data when Nomad is reachable (was: always `[]`), and the 12 tightened excepts let `KeyboardInterrupt`/`SystemExit` propagate — correct for interactive tools, worth remembering if any loop relied on a bare except to survive Ctrl-C.
- Everything else is whitespace, renames, and dead-code removal. Single commit; rollback is one `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
