### PR TITLE
chore: rename github URLs tommyroar → robogeosociety

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,6 @@
 name: Claude PR Assistant
 
-# Canonical @claude responder — source of truth: tommyroar/.github.
+# Canonical @claude responder — source of truth: robogeosociety/.github.
 # Synced into every owned repo by scripts/sync.sh. Also selectable one-click
 # from the Actions "New workflow" UI. Auth: CLAUDE_CODE_OAUTH_TOKEN (Max sub).
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Canonical pre-commit config — source of truth: tommyroar/.github, synced by scripts/sync.sh.
+# Canonical pre-commit config — source of truth: robogeosociety/.github, synced by scripts/sync.sh.
 # One-time per clone:   uv tool install pre-commit && pre-commit install
 # Ruff version here is kept in lockstep with the ruff run in CI.
 minimum_pre_commit_version: "3.5.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,5 +93,5 @@ PR descriptions follow the **newspaper / information-pyramid** format: one self-
 front page (kicker → headline → dek → masthead → why → what → mermaid flow → screens →
 verification → risk) that reads top-to-bottom on an iPad-mini portrait display (1–2 pages;
 up to 4 for very complex *code* changes). Rebuild from the **full** diff, never append.
-Full rules: <https://github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md>. CI validates
-the body via the `pr-newspaper` workflow (the reusable gate in `tommyroar/pr-newspaper`).
+Full rules: <https://github.com/robogeosociety/.github/blob/main/PR_FRAMEWORK.md>. CI validates
+the body via the `pr-newspaper` workflow (the reusable gate in `robogeosociety/pr-newspaper`).

--- a/scripts/deploy-inference.sh
+++ b/scripts/deploy-inference.sh
@@ -26,7 +26,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TERRAFORM_DIR="$REPO_ROOT/terraform"
 WORKER_DIR="$REPO_ROOT/worker"
 
-GH_OWNER="tommyroar"
+GH_OWNER="robogeosociety"
 GH_REPO="is-the-mountain-out"
 IMAGE_REPO="ghcr.io/$GH_OWNER/$GH_REPO/inference"
 

--- a/scripts/deploy-worker.sh
+++ b/scripts/deploy-worker.sh
@@ -17,12 +17,12 @@
 # Env overrides:
 #   DEPLOY_ENV   GitHub Deployment environment      (default: production)
 #   WORKER_URL   live URL recorded on the status    (default: the workers.dev URL)
-#   GH_REPO      owner/repo                          (default: tommyroar/is-the-mountain-out)
+#   GH_REPO      owner/repo                          (default: robogeosociety/is-the-mountain-out)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKER_DIR="$REPO_ROOT/worker"
-GH_REPO="${GH_REPO:-tommyroar/is-the-mountain-out}"
+GH_REPO="${GH_REPO:-robogeosociety/is-the-mountain-out}"
 DEPLOY_ENV="${DEPLOY_ENV:-production}"
 WORKER_URL="${WORKER_URL:-https://mountain-inference.tommy-b-doerr.workers.dev}"
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -134,7 +134,7 @@ function App() {
         Mount Rainier · UW ATG webcam · METAR {state?.weather?.station ?? '—'} ·{' '}
         <a
           className="underline hover:opacity-100"
-          href="https://github.com/tommyroar/is-the-mountain-out"
+          href="https://github.com/robogeosociety/is-the-mountain-out"
         >
           source
         </a>

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -8,7 +8,7 @@ crons = ["*/15 * * * *"]
 
 # Container binding. Cloudflare Containers can only pull from its own managed
 # registry (not GHCR), so the image is pushed to registry.cloudflare.com:
-#   docker pull ghcr.io/tommyroar/is-the-mountain-out/inference:latest
+#   docker pull ghcr.io/robogeosociety/is-the-mountain-out/inference:latest
 #   docker tag  ... mountain-inference:latest
 #   wrangler containers push mountain-inference:latest
 # See .github/workflows/build-inference-image.yml for the upstream GHCR build.


### PR DESCRIPTION
`fleet` — **ORG RENAME**

Mechanical URL sweep after the tommyroar → robogeosociety org migration — CLAUDE.md PR-framework links, the App.tsx footer repo link, deploy-worker.sh `GH_REPO` default, deploy-inference.sh `GH_OWNER` (ghcr image path — CI already publishes via `ghcr.io/${{ github.repository }}`, i.e. under the org), the wrangler.toml ghcr pull comment, and the pre-commit + claude.yml source-of-truth comments. Old github.com URLs redirect, so this is canonical cleanup, not a fix; no Pages project URLs (the kind that hard-404) live in this repo.

## Verification
- `grep -rn tommyroar` — remaining hits: 1, a protected form (tools/generate_map.py bare `https://tommyroar.github.io` Mapbox Referer — user-site root, unmoved, matches the pk token's URL restriction)
- CI checks expected: lint.yml on this PR

## Risk & rollout
- Comment/doc/URL-only plus the deploy-script ghcr owner defaults; `ghcr.io/robogeosociety/is-the-mountain-out/inference` materializes on the next main image build (pre-migration tags live under the old user namespace). Redirects cover the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
