### PR TITLE
fix: the labeler bot must never merge labels from a stale cache

### DIFF
--- a/bot/labeler.py
+++ b/bot/labeler.py
@@ -247,6 +247,17 @@ def build_capture_embed(
 # ---------- Label recording ----------
 
 
+def uncached_storage(storage):
+    """Unwrap CachedR2Storage to its raw R2 client for the bot's use.
+
+    The training cache serves stale reads by design; a label merge that starts
+    from a stale labels.yaml would silently drop labels other surfaces added to
+    R2 since the cache was warmed. The bot never benefits from cached reads, so
+    it always talks to the raw backend (same StorageBackend interface).
+    """
+    return getattr(storage, "r2", storage)
+
+
 def load_labels(storage, labels_key: str = LABELS_KEY) -> dict:
     """Current labels from storage; empty dict when absent/unreadable."""
     try:

--- a/bot/main.py
+++ b/bot/main.py
@@ -50,7 +50,9 @@ class MountainBot(discord.Client):
         self.config_loader = config_loader
         self.data_root = data_root
         self.post_once = post_once
-        self.storage = config_loader.get_storage(data_root)
+        # Raw backend, never the training cache — a stale cached labels.yaml
+        # as a merge base would drop labels added to R2 by other surfaces.
+        self.storage = labeler.uncached_storage(config_loader.get_storage(data_root))
         self.weather = WeatherFetcher(config_loader.metar_station)
         self._last_post: datetime | None = None
         self._swept = False

--- a/bot/tests/test_labeler.py
+++ b/bot/tests/test_labeler.py
@@ -294,6 +294,14 @@ class TestRecordLabel:
     def test_load_labels_missing_file(self, tmp_path):
         assert labeler.load_labels(LocalStorage(str(tmp_path))) == {}
 
+    def test_uncached_storage_unwraps_cache(self, tmp_path):
+        class FakeCached:
+            r2 = "raw-backend"
+
+        assert labeler.uncached_storage(FakeCached()) == "raw-backend"
+        local = LocalStorage(str(tmp_path))
+        assert labeler.uncached_storage(local) is local
+
 
 # ---------- Reaction resolution ----------
 


### PR DESCRIPTION
`BOT` — **HOTFIX**

# The labeler bot must never merge labels from a stale cache

> _First live label on the mini merged against an April-era cached labels.yaml — writes went to R2, but a stale merge base can silently drop labels other surfaces add._

> [!NOTE]
> **bot** · fix · risk: low

`get_storage()` returns `CachedR2Storage` for the r2 backend; its cache-first reads are right for training prefetch and wrong for label read-merge-write. New `labeler.uncached_storage()` unwraps to the raw `R2Storage` and the bot uses it for all storage ops (labels, existence gates, uploads — which already passed through). Unit test covers the unwrap. Verified: 58 bot tests green; live label from today's post confirmed in R2 truth (2001 labels).

No flow change beyond which client the same calls go through.