### PR TITLE
feat: label telemetry on the post + live prediction context

### DIFF
--- a/BOT.md
+++ b/BOT.md
@@ -28,7 +28,12 @@ the Gateway, which is why the Worker's webhook notifier can't do this job.
 3. You tap a reaction. The bot maps emoji → class, checks the allowlist, and
    union-merges `{capture_key: class}` into `labels.yaml` (R2 is the source of
    truth; the merge never deletes keys added by the classifier UI). Each label
-   also appends a provenance event to `labels/discord-events.jsonl`.
+   also appends a provenance event to `labels/discord-events.jsonl`, and the
+   bot **edits a 🏷️ Label field onto its post** as acknowledgment — e.g. "New
+   reaction (Not Out) recorded — 3/2004 training labels from Discord". Labels
+   count toward the *model* at the next `just train`. (Worker notification
+   messages record labels too but can't show the field — bots can't edit
+   webhook messages.)
 4. Re-labeling is just reacting again — last reaction wins. Reactions added
    while the bot was offline are recovered by a startup sweep of the last
    `sweep_hours` of channel history (majority vote; ties are skipped).

--- a/bot/labeler.py
+++ b/bot/labeler.py
@@ -41,6 +41,9 @@ EMOJI_TO_CLASS = {
 LABELS_KEY = "labels.yaml"  # same object the classifier UI and trainer share
 EVENTS_KEY = "labels/discord-events.jsonl"  # append-only provenance log
 
+# Embed field the bot edits onto its own post after recording a label.
+TELEMETRY_FIELD = "🏷️ Label"
+
 # Embed colors — mirror worker/src/discord-mountain-notify.ts.
 COLOR_VISIBLE = 0x2ECC71
 COLOR_NOT_VISIBLE = 0x95A5A6
@@ -266,6 +269,15 @@ def load_labels(storage, labels_key: str = LABELS_KEY) -> dict:
         return {}
 
 
+@dataclass(frozen=True)
+class LabelResult:
+    """Outcome of recording one label, with the stats the telemetry edit shows."""
+
+    labels: dict
+    total: int  # entries in labels.yaml after the merge
+    discord_count: int  # distinct captures ever labeled via Discord (events log)
+
+
 def record_label(
     storage,
     capture_key: str,
@@ -276,7 +288,7 @@ def record_label(
     labels_key: str = LABELS_KEY,
     events_key: str = EVENTS_KEY,
     now: datetime | None = None,
-) -> dict:
+) -> LabelResult:
     """Merge {capture_key: label} into labels.yaml and append a provenance event.
 
     Same union-merge contract as tools/classifier_server.py save_labels():
@@ -300,7 +312,41 @@ def record_label(
     except Exception:  # noqa: BLE001 — backend-specific miss/IO errors all mean "no log yet"
         existing = ""
     storage.put_text(events_key, existing + json.dumps(event) + "\n")
-    return labels
+
+    discord_captures = {capture_key}
+    for line in existing.splitlines():
+        try:
+            discord_captures.add(json.loads(line)["capture"])
+        except ValueError, KeyError:
+            continue
+    return LabelResult(
+        labels=labels, total=len(labels), discord_count=len(discord_captures)
+    )
+
+
+def telemetry_field(label: int, result: LabelResult) -> dict:
+    """The embed field acknowledging a recorded reaction, with running counts."""
+    return {
+        "name": TELEMETRY_FIELD,
+        "value": (
+            f"New reaction ({CLASS_LABELS[int(label)]}) recorded — "
+            f"{result.discord_count}/{result.total} training labels from Discord"
+        ),
+        "inline": False,
+    }
+
+
+def apply_telemetry(embed: Mapping[str, Any], field: Mapping[str, Any]) -> dict:
+    """Embed dict with *field* replacing any previous telemetry field.
+
+    Re-labeling edits the same field in place (last reaction wins), matching
+    the label-store semantics.
+    """
+    updated = dict(embed)
+    fields = [f for f in updated.get("fields", []) if f.get("name") != TELEMETRY_FIELD]
+    fields.append(dict(field))
+    updated["fields"] = fields
+    return updated
 
 
 # ---------- Reaction resolution ----------

--- a/bot/main.py
+++ b/bot/main.py
@@ -163,20 +163,43 @@ class MountainBot(discord.Client):
         ):
             return
 
-        key = await self._capture_key_for_message(payload.message_id)
-        if key is None:
+        labelable = await self._labelable_message(payload.message_id)
+        if labelable is None:
             return
+        message, key = labelable
         if not await asyncio.to_thread(self.storage.exists, key):
             logger.warning(f"reaction on {key} ignored: capture not in storage")
             return
-        await asyncio.to_thread(
+        result = await asyncio.to_thread(
             labeler.record_label, self.storage, key, cls, user_id=payload.user_id
         )
         logger.info(
             f"labeled {key} = {cls} ({labeler.CLASS_NAMES[cls]}) by user {payload.user_id}"
         )
+        await self._edit_telemetry(message, cls, result)
 
-    async def _capture_key_for_message(self, message_id: int) -> str | None:
+    async def _edit_telemetry(
+        self, message: discord.Message, cls: int, result: labeler.LabelResult
+    ) -> None:
+        """Acknowledge a recorded label on the post itself (edit-in-place).
+
+        Only the bot's own messages are editable — reactions on the Worker's
+        webhook notifications still record, they just can't show the field.
+        Best-effort: an edit failure never loses the already-recorded label.
+        """
+        if not self.user or message.author.id != self.user.id or not message.embeds:
+            return
+        try:
+            updated = labeler.apply_telemetry(
+                message.embeds[0].to_dict(), labeler.telemetry_field(cls, result)
+            )
+            await message.edit(embed=discord.Embed.from_dict(updated))
+        except discord.HTTPException as exc:
+            logger.warning(f"telemetry edit failed (label already recorded): {exc}")
+
+    async def _labelable_message(
+        self, message_id: int
+    ) -> tuple[discord.Message, str] | None:
         channel = await self._channel()
         try:
             message = await channel.fetch_message(message_id)
@@ -189,7 +212,10 @@ class MountainBot(discord.Client):
         if not message.author.bot or not message.embeds:
             return None
         footer = message.embeds[0].footer
-        return labeler.capture_key_from_footer(footer.text if footer else None)
+        key = labeler.capture_key_from_footer(footer.text if footer else None)
+        if key is None:
+            return None
+        return message, key
 
     async def sweep_missed_reactions(self) -> None:
         """Recover labels from reactions added while the bot was offline."""
@@ -221,7 +247,7 @@ class MountainBot(discord.Client):
             )
             if label is None or current.get(key) == label:
                 continue
-            await asyncio.to_thread(
+            result = await asyncio.to_thread(
                 labeler.record_label,
                 self.storage,
                 key,
@@ -231,6 +257,7 @@ class MountainBot(discord.Client):
             )
             current[key] = label
             swept += 1
+            await self._edit_telemetry(message, label, result)
         logger.info(f"reaction sweep complete: {swept} label(s) recovered")
 
 

--- a/bot/tests/test_labeler.py
+++ b/bot/tests/test_labeler.py
@@ -254,9 +254,22 @@ class TestRecordLabel:
 
     def test_creates_labels_file(self, tmp_path):
         store = LocalStorage(str(tmp_path))
-        merged = labeler.record_label(store, self.KEY, 1, user_id=111)
-        assert merged == {self.KEY: 1}
+        result = labeler.record_label(store, self.KEY, 1, user_id=111)
+        assert result.labels == {self.KEY: 1}
+        assert result.total == 1
+        assert result.discord_count == 1
         assert yaml.safe_load(store.get_text("labels.yaml")) == {self.KEY: 1}
+
+    def test_result_counts(self, tmp_path):
+        store = LocalStorage(str(tmp_path))
+        store.put_text("labels.yaml", yaml.safe_dump({"ui/images/a.jpg": 0}))
+        first = labeler.record_label(store, self.KEY, 1, user_id=111)
+        assert (first.total, first.discord_count) == (2, 1)
+        # Re-labeling the same capture doesn't inflate either count.
+        again = labeler.record_label(store, self.KEY, 0, user_id=111)
+        assert (again.total, again.discord_count) == (2, 1)
+        other = labeler.record_label(store, "other/images/b.jpg", 2, user_id=111)
+        assert (other.total, other.discord_count) == (3, 2)
 
     def test_union_merge_preserves_other_keys(self, tmp_path):
         store = LocalStorage(str(tmp_path))
@@ -293,6 +306,28 @@ class TestRecordLabel:
 
     def test_load_labels_missing_file(self, tmp_path):
         assert labeler.load_labels(LocalStorage(str(tmp_path))) == {}
+
+    def test_telemetry_field_text(self):
+        result = labeler.LabelResult(labels={}, total=2004, discord_count=3)
+        field = labeler.telemetry_field(0, result)
+        assert field["name"] == labeler.TELEMETRY_FIELD
+        assert (
+            field["value"]
+            == "New reaction (Not Out) recorded — 3/2004 training labels from Discord"
+        )
+
+    def test_apply_telemetry_appends_then_replaces(self):
+        embed = labeler.build_capture_embed(self.KEY, datetime(2026, 7, 26, tzinfo=UTC))
+        n_fields = len(embed["fields"])
+        result = labeler.LabelResult(labels={}, total=10, discord_count=1)
+        once = labeler.apply_telemetry(embed, labeler.telemetry_field(1, result))
+        assert len(once["fields"]) == n_fields + 1
+        # Re-label: the field is replaced in place, not stacked.
+        twice = labeler.apply_telemetry(once, labeler.telemetry_field(0, result))
+        assert len(twice["fields"]) == n_fields + 1
+        assert "Not Out" in twice["fields"][-1]["value"]
+        # Original legend field and footer survive edits.
+        assert twice["footer"]["text"] == self.KEY
 
     def test_uncached_storage_unwraps_cache(self, tmp_path):
         class FakeCached:

--- a/mountain.toml
+++ b/mountain.toml
@@ -45,7 +45,7 @@ cache_dir = ".r2cache"
 # cf.env; this section is behavior tuning only.
 post_interval_seconds = 3600 # one labelable capture per hour
 sweep_hours = 72 # startup sweep re-reads this much channel history for missed reactions
-state_url = "" # public state.json URL; when set, posts include the model's live prediction
+state_url = "https://pub-66d3d1f139004e29b2afcb5fba49bdb3.r2.dev/state.json" # public bucket; posts include the model's live prediction
 timezone = "America/Los_Angeles"
 # Posting window defaults to civil dawn→dusk at the webcam's coordinates (astral).
 # Uncomment both to force a fixed local-time window instead:


### PR DESCRIPTION
`BOT` — **FIELD UPGRADE**

# The post now talks back: label telemetry + live prediction context

> _Tap a reaction and the post acknowledges it — class recorded and running Discord-label counts — while new posts show what the model currently thinks._

> [!NOTE]
> **bot** · feat · risk: low

## What changed
- **Telemetry edit-in-place:** after recording a label the bot edits a 🏷️ Label field onto its post: "New reaction (Not Out) recorded — 3/2004 training labels from Discord" (distinct Discord-labeled captures / total `labels.yaml` entries; counts reach the *model* at the next `just train`). Re-labeling replaces the field (last wins, matching store semantics). Webhook notification messages record labels but can't be edited by a bot — they skip the field.
- **`[bot] state_url`** set to the public R2 bucket URL, so posts include the "Model says" prediction field from `state.json`.
- Pure logic (`LabelResult`, `telemetry_field`, `apply_telemetry`) in `bot/labeler.py` with tests; wiring in `bot/main.py` (reaction handler + startup sweep). Telemetry-edit failure never loses a recorded label.

## Verification
61 bot tests green (result counts incl. relabel no-inflation, field text, replace-not-stack, footer survival); ruff clean. Live check after deploy: react on the next post, watch the field appear.

No flow change beyond the acknowledgment edit.