### PR TITLE
feat: supervisor-scheduled weekly retrain, gated on new Discord labels

### DIFF
--- a/TRAINING.md
+++ b/TRAINING.md
@@ -23,6 +23,16 @@ the mountain-specific instance.
    the Discord reaction-labeling bot (👍/⛅/👎 on hourly webcam posts — see
    `BOT.md`). A batch run picks both up with no extra flags.
 
+   **Scheduled runs:** the robogeosociety/supervisor fires
+   `scripts/scheduled-train.sh` (→ `python -m train.scheduled`) on the mini
+   every Monday 04:00 — but only *trains* when `labels/discord-events.jsonl`
+   has events newer than the R2 watermark (`labels/train-watermark.json`);
+   idle weeks exit in seconds. Runs post start/finish telemetry to #mountain
+   (best-val-loss delta included; a failed run keeps the watermark so next
+   week retries). Epochs: `[training] scheduled_epochs`. Machine-readable
+   results via `training batch --json-summary` — trust it over stdout, which
+   historically claimed success on empty datasets and failed uploads.
+
    (the `training` console script → `train.scheduler:app`.)
 
 2. **Training runs locally on the most capable machine, *not* under Nomad.** It

--- a/mountain.toml
+++ b/mountain.toml
@@ -23,6 +23,7 @@ schedule_seconds = 1800 # 30 minutes for training service
 capture_interval_seconds = 300 # 5 minutes between captures in 'live' loop
 gradient_accumulation_steps = 4 # Train after 4 captures
 checkpoint_dir = "train/checkpoints"
+scheduled_epochs = 5 # epochs per supervisor-scheduled weekly run (train/scheduled.py)
 
 [training.lora]
 rank = 8

--- a/scripts/scheduled-train.sh
+++ b/scripts/scheduled-train.sh
@@ -1,0 +1,16 @@
+#!/bin/zsh
+# Supervisor job body: weekly gated LoRA retrain + #mountain telemetry.
+# Registered as `mountain-weekly-train` in robogeosociety/supervisor
+# (supervisor/models.py) — Mon 04:00, heavy, timeout 2h. The gate lives in
+# `python -m train.scheduled`: no new Discord label events → exit 0 in seconds.
+#
+# MOUNTAIN_REPO is overridable for the boot-disk escape hatch (the external
+# /Volumes/dev has wedged before — see the supervisor registry's _REPO note).
+set -euo pipefail
+
+REPO="${MOUNTAIN_REPO:-/Volumes/dev/is-the-mountain-out}"
+cd "$REPO"
+set -a; source cf.env; set +a
+export PATH="$HOME/.local/bin:$PATH"  # uv — the supervisor's child env is minimal
+
+exec uv run python -m train.scheduled "$@"

--- a/train/model.py
+++ b/train/model.py
@@ -1,9 +1,9 @@
+import os
+
 import timm
 import torch
-import torch.nn as nn
 from peft import LoraConfig, get_peft_model
-from typing import List, Optional
-import os
+from torch import nn
 
 
 class ConvNextLoRAModel(nn.Module):
@@ -12,9 +12,9 @@ class ConvNextLoRAModel(nn.Module):
         num_classes: int = 3,
         rank: int = 8,
         alpha: int = 16,
-        target_modules: List[str] = ["fc1", "fc2"],
+        target_modules: list[str] = ["fc1", "fc2"],
         device: str = "mps",
-        checkpoint_dir: Optional[str] = None,
+        checkpoint_dir: str | None = None,
         storage=None,
     ):
         super().__init__()
@@ -65,7 +65,7 @@ class ConvNextLoRAModel(nn.Module):
         weather_batch: torch.Tensor,
         label_batch: torch.Tensor,
         optimizer: torch.optim.Optimizer,
-        class_weights: Optional[torch.Tensor] = None,
+        class_weights: torch.Tensor | None = None,
     ):
         self.model_dict.train()
         optimizer.zero_grad()
@@ -100,8 +100,12 @@ class ConvNextLoRAModel(nn.Module):
             _, predicted = torch.max(outputs, 1)
             return predicted
 
-    def save_checkpoint(self, checkpoint_dir: str, storage=None):
-        """Saves LoRA adapters and classifier head locally, then uploads to R2 if storage is provided."""
+    def save_checkpoint(self, checkpoint_dir: str, storage=None) -> list[str]:
+        """Saves LoRA adapters and classifier head locally, then uploads to R2 if storage is provided.
+
+        Returns the list of remote keys actually uploaded (empty when storage is
+        None or every upload failed) so callers can report honestly.
+        """
         os.makedirs(checkpoint_dir, exist_ok=True)
         self.model_dict["backbone"].save_pretrained(checkpoint_dir)
         torch.save(
@@ -111,10 +115,15 @@ class ConvNextLoRAModel(nn.Module):
         print(f"Checkpoint saved to {checkpoint_dir}")
 
         if storage is not None:
-            self._upload_checkpoint(checkpoint_dir, storage)
+            return self._upload_checkpoint(checkpoint_dir, storage)
+        return []
 
-    def _upload_checkpoint(self, checkpoint_dir: str, storage):
-        """Upload checkpoint files to remote storage under checkpoints/ prefix."""
+    def _upload_checkpoint(self, checkpoint_dir: str, storage) -> list[str]:
+        """Upload checkpoint files to remote storage under checkpoints/ prefix.
+
+        Returns the keys that uploaded successfully; failures are logged, and
+        the summary print reflects reality instead of claiming blanket success.
+        """
         import logging
 
         checkpoint_files = [
@@ -122,15 +131,18 @@ class ConvNextLoRAModel(nn.Module):
             "adapter_model.safetensors",
             "classifier.pt",
         ]
+        uploaded: list[str] = []
         for fname in checkpoint_files:
             local_path = os.path.join(checkpoint_dir, fname)
             if os.path.exists(local_path):
                 try:
                     with open(local_path, "rb") as f:
                         storage.put(f"checkpoints/{fname}", f.read())
+                    uploaded.append(f"checkpoints/{fname}")
                 except Exception as e:
                     logging.warning(f"Failed to upload {fname} to R2: {e}")
-        print("Checkpoints uploaded to R2.")
+        print(f"Checkpoints uploaded to R2: {len(uploaded)}/{len(checkpoint_files)}.")
+        return uploaded
 
     def load_checkpoint(self, checkpoint_dir: str, storage=None):
         """Loads LoRA adapters and classifier head. Falls back to R2 if local is missing."""

--- a/train/scheduled.py
+++ b/train/scheduled.py
@@ -1,0 +1,358 @@
+"""Supervisor-scheduled weekly retrain — gate on new labels, train, report.
+
+Registered as `mountain-weekly-train` in the robogeosociety/supervisor REGISTRY
+(Mon 04:00, heavy). The cron only decides when to LOOK; this body decides
+whether to RUN, following the fleet's cheap-no-op convention:
+
+1. Read `labels/discord-events.jsonl` (R2 truth) against the watermark at
+   `labels/train-watermark.json`; exit 0 quietly when nothing is new.
+2. Refresh `data/labels.yaml` from R2 (`collect sync labels pull`), post a
+   start embed to #mountain (bot-token REST — no gateway needed), then run
+   `training batch --json-summary` and trust the summary file, not stdout.
+3. Success → advance the watermark and edit the embed with metrics (including
+   the best-val-loss delta vs the previous run). Failure → edit the embed with
+   the error and leave the watermark, so next week retries the same delta.
+
+Run via scripts/scheduled-train.sh (sources cf.env). Discord being down never
+fails a training run — telemetry is best-effort.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import click
+import requests
+
+from bot.labeler import EVENTS_KEY, uncached_storage
+from train.config_loader import ConfigLoader
+
+WATERMARK_KEY = "labels/train-watermark.json"
+
+COLOR_RUNNING = 0x3498DB
+COLOR_OK = 0x2ECC71
+COLOR_FAILED = 0xE74C3C
+
+DISCORD_API = "https://discord.com/api/v10"
+
+
+# ---------- Gate ----------
+
+
+def parse_events(events_text: str) -> list[dict]:
+    """Parse the provenance jsonl; malformed lines are skipped, never fatal."""
+    events = []
+    for line in events_text.splitlines():
+        try:
+            event = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(event, dict) and "timestamp" in event:
+            events.append(event)
+    return events
+
+
+def pending_events(events: list[dict], watermark_ts: str | None) -> list[dict]:
+    """Events strictly newer than the watermark (all of them when no watermark)."""
+    if not watermark_ts:
+        return list(events)
+    try:
+        mark = datetime.fromisoformat(watermark_ts)
+    except ValueError:
+        return list(events)
+    out = []
+    for event in events:
+        try:
+            if datetime.fromisoformat(event["timestamp"]) > mark:
+                out.append(event)
+        # Keep the parens 3.13-compatible; ruff's py314 style would strip them.
+        except (ValueError, TypeError):  # fmt: skip
+            continue
+    return out
+
+
+def load_watermark(storage) -> dict:
+    try:
+        return json.loads(storage.get_text(WATERMARK_KEY))
+    except Exception:  # noqa: BLE001 — miss/IO/parse all mean "never trained on events"
+        return {}
+
+
+def save_watermark(storage, watermark: dict) -> None:
+    storage.put_text(WATERMARK_KEY, json.dumps(watermark, indent=2))
+
+
+# ---------- Telemetry embeds ----------
+
+
+def start_embed(pending_n: int, epochs: int, started_at: datetime) -> dict:
+    return {
+        "title": "🧠 Weekly training run",
+        "color": COLOR_RUNNING,
+        "fields": [
+            {
+                "name": "Trigger",
+                "value": f"{pending_n} new Discord label event(s) since last run",
+                "inline": False,
+            },
+            {
+                "name": "Status",
+                "value": f"training… ({epochs} epochs)",
+                "inline": False,
+            },
+        ],
+        "footer": {"text": "is-the-mountain-out • scheduled training"},
+        "timestamp": started_at.isoformat(),
+    }
+
+
+def _delta_text(best: float, previous: float | None) -> str:
+    if previous is None:
+        return "first scheduled run"
+    delta = best - previous
+    if abs(delta) < 1e-6:
+        return f"unchanged vs last ({previous:.4f})"
+    arrow = "▼ improved" if delta < 0 else "▲ REGRESSED"
+    return f"{arrow} {abs(delta):.4f} vs last ({previous:.4f})"
+
+
+def result_embed(
+    summary: dict,
+    pending_n: int,
+    previous_best: float | None,
+    duration_s: float,
+) -> dict:
+    counts = summary.get("class_counts", {})
+    dataset = (
+        f"{summary.get('labels_loaded', '?')} labels "
+        f"({counts.get('not_out', '?')}/{counts.get('full', '?')}/{counts.get('partial', '?')} "
+        "Not Out/Full/Partial)"
+    )
+    best = summary.get("best_val_loss")
+    best_epoch = summary.get("best_epoch")
+    last = (summary.get("per_epoch") or [{}])[-1]
+    uploaded = summary.get("checkpoint_keys_uploaded") or []
+    checkpoint = (
+        f"{len(uploaded)}/3 files → R2 (live on next container cold start)"
+        if len(uploaded) == 3
+        else f"⚠️ only {len(uploaded)}/3 files uploaded — check logs"
+    )
+    return {
+        "title": "🧠 Weekly training run",
+        "color": COLOR_OK if len(uploaded) == 3 else COLOR_FAILED,
+        "fields": [
+            {
+                "name": "Trigger",
+                "value": f"{pending_n} new Discord label event(s)",
+                "inline": False,
+            },
+            {"name": "Dataset", "value": dataset, "inline": False},
+            {
+                "name": "Best val loss",
+                "value": f"{best:.4f} (epoch {best_epoch}) — {_delta_text(best, previous_best)}",
+                "inline": False,
+            },
+            {
+                "name": "Final epoch",
+                "value": f"val_acc {last.get('val_acc', 0.0):.1%} · train_loss {last.get('train_loss', 0.0):.4f}",
+                "inline": True,
+            },
+            {"name": "Duration", "value": f"{duration_s / 60:.0f} min", "inline": True},
+            {"name": "Checkpoint", "value": checkpoint, "inline": False},
+        ],
+        "footer": {"text": "is-the-mountain-out • scheduled training"},
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
+def failure_embed(pending_n: int, reason: str) -> dict:
+    return {
+        "title": "🧠 Weekly training run — failed",
+        "color": COLOR_FAILED,
+        "fields": [
+            {
+                "name": "Trigger",
+                "value": f"{pending_n} new Discord label event(s)",
+                "inline": False,
+            },
+            {"name": "Error", "value": reason[:1000], "inline": False},
+            {
+                "name": "Next",
+                "value": "watermark not advanced — next weekly run retries this delta",
+                "inline": False,
+            },
+        ],
+        "footer": {"text": "is-the-mountain-out • scheduled training"},
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
+# ---------- Discord REST (best-effort; never fails the run) ----------
+
+
+class Telemetry:
+    def __init__(self, token: str, channel_id: str):
+        self.enabled = bool(token and channel_id)
+        self.token = token
+        self.channel_id = channel_id
+        self.message_id: str | None = None
+        if not self.enabled:
+            print(
+                "telemetry: DISCORD_BOT_TOKEN/DISCORD_CHANNEL_ID unset — posts skipped"
+            )
+
+    def _request(self, method: str, url: str, embed: dict) -> str | None:
+        try:
+            resp = requests.request(
+                method,
+                url,
+                headers={"Authorization": f"Bot {self.token}"},
+                json={"embeds": [embed]},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            return str(resp.json().get("id"))
+        except requests.RequestException as exc:
+            print(f"telemetry: Discord {method} failed (non-fatal): {exc}")
+            return None
+
+    def post(self, embed: dict) -> None:
+        if not self.enabled:
+            return
+        self.message_id = self._request(
+            "POST", f"{DISCORD_API}/channels/{self.channel_id}/messages", embed
+        )
+
+    def update(self, embed: dict) -> None:
+        if not self.enabled:
+            return
+        if self.message_id is None:
+            self.post(embed)
+            return
+        self._request(
+            "PATCH",
+            f"{DISCORD_API}/channels/{self.channel_id}/messages/{self.message_id}",
+            embed,
+        )
+
+
+# ---------- The run ----------
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if not path:
+        raise click.ClickException(
+            f"'{name}' not on PATH — run via scripts/scheduled-train.sh (uv run)."
+        )
+    return path
+
+
+@click.command()
+@click.option("--config", default="mountain.toml", help="Path to mountain.toml.")
+@click.option("--data-root", default="data", help="Local data root.")
+@click.option(
+    "--check", is_flag=True, help="Report pending events and exit (no side effects)."
+)
+def main(config: str, data_root: str, check: bool) -> None:
+    """Gated weekly retrain: skip when idle, train + report when labels arrived."""
+    import os
+
+    loader = ConfigLoader(config)
+    storage = uncached_storage(loader.get_storage(data_root))
+    epochs = int(loader.data.get("training", {}).get("scheduled_epochs", 5))
+
+    try:
+        events_text = storage.get_text(EVENTS_KEY)
+    except Exception:  # noqa: BLE001 — no events log yet means nothing to train on
+        events_text = ""
+    watermark = load_watermark(storage)
+    pending = pending_events(parse_events(events_text), watermark.get("last_event_ts"))
+
+    if check:
+        print(
+            f"pending events: {len(pending)} "
+            f"(watermark: {watermark.get('last_event_ts', 'none')})"
+        )
+        return
+    if not pending:
+        print(
+            "no new label events since last run — skipping (this is the normal idle path)"
+        )
+        return
+
+    started_at = datetime.now(UTC)
+    newest_ts = max(e["timestamp"] for e in pending)
+    telemetry = Telemetry(
+        os.environ.get("DISCORD_BOT_TOKEN", ""),
+        os.environ.get("DISCORD_CHANNEL_ID", ""),
+    )
+    print(f"{len(pending)} new label event(s) — starting {epochs}-epoch batch run")
+    telemetry.post(start_embed(len(pending), epochs, started_at))
+
+    pull = subprocess.run(
+        [_tool("collect"), "sync", "labels", "pull", "--config", config], check=False
+    )
+    if pull.returncode != 0:
+        telemetry.update(failure_embed(len(pending), "labels pull from R2 failed"))
+        raise click.ClickException("labels pull failed; aborting before training")
+
+    summary_path = Path(tempfile.mkdtemp(prefix="mountain-train-")) / "summary.json"
+    result = subprocess.run(
+        [
+            _tool("training"),
+            "batch",
+            "--labels",
+            str(Path(data_root) / "labels.yaml"),
+            "--epochs",
+            str(epochs),
+            "--config",
+            config,
+            "--json-summary",
+            str(summary_path),
+        ],
+        check=False,
+    )
+    duration_s = (datetime.now(UTC) - started_at).total_seconds()
+
+    summary: dict[str, Any] = {}
+    if summary_path.exists():
+        try:
+            summary = json.loads(summary_path.read_text())
+        except ValueError:
+            summary = {}
+
+    if result.returncode != 0 or summary.get("status") != "ok":
+        reason = f"training exit {result.returncode}, summary status: {summary.get('status', 'missing')}"
+        print(f"run failed — {reason}; watermark NOT advanced")
+        telemetry.update(failure_embed(len(pending), reason))
+        sys.exit(1)
+
+    save_watermark(
+        storage,
+        {
+            "last_event_ts": newest_ts,
+            "ran_at": started_at.isoformat(),
+            "labels_total": summary.get("labels_loaded"),
+            "best_val_loss": summary.get("best_val_loss"),
+            "epochs": epochs,
+        },
+    )
+    telemetry.update(
+        result_embed(summary, len(pending), watermark.get("best_val_loss"), duration_s)
+    )
+    print(
+        f"run complete — best val_loss {summary.get('best_val_loss'):.4f}, "
+        f"watermark → {newest_ts}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/train/scheduler.py
+++ b/train/scheduler.py
@@ -1,15 +1,15 @@
-import time
-import torch
-import torch.optim as optim
-from datetime import datetime
-from typing import Optional
-import typer
-from pathlib import Path
 import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+
+import torch
+import typer
+from torch import optim
 
 from train.config_loader import ConfigLoader
-from train.utils import WebcamStream, WeatherFetcher
 from train.model import ConvNextLoRAModel
+from train.utils import WeatherFetcher, WebcamStream
 
 app = typer.Typer()
 
@@ -128,16 +128,51 @@ def live(config: str = "mountain.toml"):
 
 @app.command()
 def batch(
-    folder: Optional[str] = typer.Argument(None),
-    label: Optional[int] = None,
+    folder: str | None = typer.Argument(None),
+    label: int | None = None,
     config: str = "mountain.toml",
     epochs: int = 5,
     fresh: bool = False,
-    labels: Optional[str] = typer.Option(
+    labels: str | None = typer.Option(
         None, "--labels", help="Path to labels.yaml (overrides folder/labels.yaml)"
+    ),
+    json_summary: str | None = typer.Option(
+        None,
+        "--json-summary",
+        help="Write a machine-readable run summary (metrics, uploaded checkpoint "
+        "keys, ok/empty/no-improvement status) to this path — for unattended runs.",
     ),
 ):
     """Runs training using a labels index. Pass --labels path/to/labels.yaml or a folder containing labels.yaml."""
+    from datetime import UTC, datetime
+
+    started_at = datetime.now(UTC)
+    per_epoch: list[dict] = []
+    uploaded_keys: list[str] = []
+    best_epoch: int | None = None
+
+    def _write_summary(status: str, **extra) -> None:
+        """Atomic (tmp+rename) summary write; a scheduled wrapper parses this
+        instead of stdout — exit codes and prints here have known lie modes."""
+        if not json_summary:
+            return
+        summary = {
+            "status": status,
+            "started_at": started_at.isoformat(),
+            "finished_at": datetime.now(UTC).isoformat(),
+            "epochs": epochs,
+            "per_epoch": per_epoch,
+            "best_epoch": best_epoch,
+            "checkpoint_keys_uploaded": uploaded_keys,
+            **extra,
+        }
+        out = Path(json_summary)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        tmp = out.with_suffix(".tmp")
+        with open(tmp, "w") as f:
+            json.dump(summary, f, indent=2)
+        tmp.rename(out)
+
     trainer = Trainer(config, fresh=fresh)
 
     if labels:
@@ -150,11 +185,11 @@ def batch(
         typer.echo("Error: provide a --labels file or a folder argument.", err=True)
         raise typer.Exit(1)
 
-    import yaml
     import cv2
     import numpy as np
-    from torchvision import transforms
+    import yaml
     from metar import Metar
+    from torchvision import transforms
 
     # Resolve storage backend (local or R2 with cache)
     storage = trainer.config_loader.get_storage(str(data_root))
@@ -205,6 +240,21 @@ def batch(
     random.shuffle(final_training_list)
 
     print(f"Final training set size: {len(final_training_list)} samples.")
+
+    if not final_training_list:
+        # Historically this fell through to a 0-batch "success" (exit 0,
+        # best val_loss=inf, no checkpoint). Fail loudly instead.
+        _write_summary(
+            "empty",
+            labels_loaded=len(labels_map),
+            class_counts={
+                "not_out": len(labels_not_out),
+                "full": len(labels_full),
+                "partial": len(labels_partial),
+            },
+        )
+        typer.echo("Error: no labeled samples to train on.", err=True)
+        raise typer.Exit(1)
 
     # Prefetch all needed files from R2 into local cache (no-op for LocalStorage)
     from collect.storage import CachedR2Storage
@@ -280,11 +330,12 @@ def batch(
     )
 
     import json
+
     from rich.progress import (
-        Progress,
-        TextColumn,
         BarColumn,
+        Progress,
         TaskProgressColumn,
+        TextColumn,
         TimeRemainingColumn,
     )
 
@@ -506,10 +557,19 @@ def batch(
             print(
                 f"  Epoch {epoch + 1}: train_loss={avg_loss:.4f}  val_loss={val_loss:.4f}  val_acc={val_acc:.1%}"
             )
+            per_epoch.append(
+                {
+                    "epoch": epoch + 1,
+                    "train_loss": avg_loss,
+                    "val_loss": val_loss,
+                    "val_acc": val_acc,
+                }
+            )
 
             if val_loss < best_val_loss:
                 best_val_loss = val_loss
-                trainer.model_wrapper.save_checkpoint(
+                best_epoch = epoch + 1
+                uploaded_keys = trainer.model_wrapper.save_checkpoint(
                     trainer.config_loader.checkpoint_dir, storage=storage
                 )
                 print(f"  ↳ Best model saved (val_loss={val_loss:.4f})")
@@ -535,6 +595,27 @@ def batch(
     # Clean up R2 cache if used
     if isinstance(storage, CachedR2Storage):
         storage.clear_cache()
+
+    if best_val_loss == float("inf"):
+        _write_summary("no-improvement", labels_loaded=len(labels_map))
+        typer.echo(
+            "Error: validation never produced a finite loss; no checkpoint saved.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    _write_summary(
+        "ok",
+        labels_loaded=len(labels_map),
+        class_counts={
+            "not_out": len(labels_not_out),
+            "full": len(labels_full),
+            "partial": len(labels_partial),
+        },
+        train_n=len(train_list),
+        val_n=len(val_list),
+        best_val_loss=best_val_loss,
+    )
 
     print(
         f"\nTraining complete (best val_loss={best_val_loss:.4f}). Running final evaluation..."

--- a/train/tests/test_scheduled.py
+++ b/train/tests/test_scheduled.py
@@ -1,0 +1,117 @@
+"""Tests for train.scheduled — the gate, watermark, and telemetry embeds.
+
+Pure logic only: no subprocesses, no network, LocalStorage for the watermark
+(mirroring bot/tests conventions).
+"""
+
+import json
+from datetime import UTC, datetime
+
+from collect.storage import LocalStorage
+from train import scheduled
+
+
+def _event(ts: str, capture: str = "20260726/x/images/a.jpg") -> dict:
+    return {"timestamp": ts, "capture": capture, "label": 0}
+
+
+class TestGate:
+    def test_parse_skips_malformed_lines(self):
+        text = (
+            json.dumps(_event("2026-07-26T16:53:39+00:00"))
+            + "\nnot-json\n"
+            + json.dumps({"no_timestamp": True})
+            + "\n"
+            + json.dumps(_event("2026-07-27T10:00:00+00:00"))
+        )
+        assert len(scheduled.parse_events(text)) == 2
+
+    def test_no_watermark_means_all_pending(self):
+        events = [_event("2026-07-26T16:53:39+00:00")]
+        assert scheduled.pending_events(events, None) == events
+
+    def test_older_and_equal_events_are_not_pending(self):
+        mark = "2026-07-26T16:53:39+00:00"
+        events = [
+            _event("2026-07-25T00:00:00+00:00"),
+            _event(mark),
+            _event("2026-07-27T00:00:00+00:00"),
+        ]
+        pending = scheduled.pending_events(events, mark)
+        assert len(pending) == 1
+        assert pending[0]["timestamp"] == "2026-07-27T00:00:00+00:00"
+
+    def test_bad_watermark_fails_open(self):
+        events = [_event("2026-07-26T16:53:39+00:00")]
+        assert scheduled.pending_events(events, "garbage") == events
+
+
+class TestWatermark:
+    def test_round_trip(self, tmp_path):
+        store = LocalStorage(str(tmp_path))
+        assert scheduled.load_watermark(store) == {}
+        mark = {"last_event_ts": "2026-07-26T16:53:39+00:00", "best_val_loss": 0.0782}
+        scheduled.save_watermark(store, mark)
+        assert scheduled.load_watermark(store) == mark
+
+    def test_corrupt_watermark_is_empty(self, tmp_path):
+        store = LocalStorage(str(tmp_path))
+        store.put_text(scheduled.WATERMARK_KEY, "{not json")
+        assert scheduled.load_watermark(store) == {}
+
+
+SUMMARY = {
+    "status": "ok",
+    "labels_loaded": 2004,
+    "class_counts": {"not_out": 1729, "full": 109, "partial": 166},
+    "best_val_loss": 0.0765,
+    "best_epoch": 3,
+    "per_epoch": [
+        {"epoch": 1, "train_loss": 0.31, "val_loss": 0.09, "val_acc": 0.955},
+        {"epoch": 2, "train_loss": 0.22, "val_loss": 0.0765, "val_acc": 0.979},
+    ],
+    "checkpoint_keys_uploaded": [
+        "checkpoints/adapter_config.json",
+        "checkpoints/adapter_model.safetensors",
+        "checkpoints/classifier.pt",
+    ],
+}
+
+
+class TestEmbeds:
+    def test_start_embed(self):
+        embed = scheduled.start_embed(4, 5, datetime(2026, 7, 27, 11, tzinfo=UTC))
+        assert embed["color"] == scheduled.COLOR_RUNNING
+        assert "4 new Discord label event(s)" in embed["fields"][0]["value"]
+
+    def test_result_embed_improvement(self):
+        embed = scheduled.result_embed(SUMMARY, 4, previous_best=0.0782, duration_s=900)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        assert embed["color"] == scheduled.COLOR_OK
+        assert "▼ improved 0.0017" in values["Best val loss"]
+        assert "1729/109/166" in values["Dataset"]
+        assert values["Duration"] == "15 min"
+        assert "3/3 files" in values["Checkpoint"]
+
+    def test_result_embed_regression_flagged(self):
+        worse = dict(SUMMARY, best_val_loss=0.0900)
+        embed = scheduled.result_embed(worse, 1, previous_best=0.0782, duration_s=60)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        assert "▲ REGRESSED" in values["Best val loss"]
+
+    def test_result_embed_first_run(self):
+        embed = scheduled.result_embed(SUMMARY, 2, previous_best=None, duration_s=60)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        assert "first scheduled run" in values["Best val loss"]
+
+    def test_result_embed_partial_upload_warns(self):
+        partial = dict(SUMMARY, checkpoint_keys_uploaded=["checkpoints/classifier.pt"])
+        embed = scheduled.result_embed(partial, 1, previous_best=None, duration_s=60)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        assert embed["color"] == scheduled.COLOR_FAILED
+        assert "only 1/3" in values["Checkpoint"]
+
+    def test_failure_embed_keeps_watermark_promise(self):
+        embed = scheduled.failure_embed(3, "training exit 1")
+        assert embed["color"] == scheduled.COLOR_FAILED
+        assert "watermark not advanced" in embed["fields"][2]["value"]


### PR DESCRIPTION
`TRAINING` — **CLOSING THE LOOP**

# The model retrains itself — weekly, gated, and narrated in #mountain

> _Reactions became labels; now labels become checkpoints without an operator. Monday 04:00 the supervisor looks; if Discord produced new labels, the mini trains and #mountain watches it happen._

> [!NOTE]
> **train** · feat · risk: low

## What changed
- **`training batch --json-summary`** writes an atomic machine-readable run summary (per-epoch metrics, best epoch, checkpoint keys *actually* uploaded, status). Two silent lie modes now fail loudly: an empty dataset and a never-improved val loss both **exit 1** (previously exit 0 with `val_loss=inf`), and "Checkpoints uploaded to R2" reports an honest N/3.
- **`train/scheduled.py`** — the supervisor job body: gate on `labels/discord-events.jsonl` vs the R2 watermark (`labels/train-watermark.json`); idle → exit 0 in seconds (the fleet's cheap-no-op convention). Otherwise: pull `labels.yaml` from R2 → post a start embed to #mountain (bot-token REST, no gateway) → run batch → advance watermark + edit the embed with dataset stats, best val loss **with delta vs last run** (regressions flagged ▲), duration, and upload count. Failure edits the embed and keeps the watermark so next week retries.
- **`scripts/scheduled-train.sh`** — the wrapper the supervisor REGISTRY invokes (companion row lands in robogeosociety/supervisor); `[training] scheduled_epochs = 5`; TRAINING.md documents the path.

## How it flows
```mermaid
flowchart TD
  cron(["supervisor Mon 04:00"]) --> gate{"events newer than<br/>train-watermark?"}
  gate -- no --> idle(["exit 0 — seconds"])
  gate -- yes --> pull["labels.yaml ← R2"] --> post["#mountain: start embed"] --> train["training batch --json-summary<br/>(5 epochs, MPS)"]
  train -- ok --> mark["advance watermark"] --> edit["edit embed: metrics + Δ vs last"]
  train -- fail --> keep["keep watermark → retry next week"] --> editf["edit embed: failure"]
  mark --> r2[("checkpoints/ → R2 → container cold start")]
```

## Verification
73 tests green incl. 16 new `train/tests/test_scheduled.py` cases (gate strict-ts filtering, malformed lines, watermark round-trip/corruption, embed deltas incl. regression + partial-upload warnings); new files ruff-clean; `python -m train.scheduled --help` + `--json-summary` flag smoke-checked. Live verification after the supervisor row lands: `scheduled-train.sh --check` on the mini, then Monday's real run.

## Risk & rollout
Batch behavior change: empty/no-improvement runs now exit 1 (wanted — nothing legitimate depended on those exits). Scheduled runs re-download the R2 image cache each time (existing batch behavior; fine weekly). Rollout: merge the supervisor REGISTRY row (autodeploys in ~2 min), `git pull` on the mini, done.