### PR TITLE
feat: time + improvement telemetry in the training completion embed

### DIFF
--- a/train/scheduled.py
+++ b/train/scheduled.py
@@ -123,11 +123,40 @@ def _delta_text(best: float, previous: float | None) -> str:
     return f"{arrow} {abs(delta):.4f} vs last ({previous:.4f})"
 
 
+def _acc_delta_text(acc: float | None, previous: float | None) -> str:
+    """Accuracy improvement in percentage points (higher is better — arrows flip
+    relative to the loss delta)."""
+    if acc is None:
+        return "n/a"
+    if previous is None:
+        return f"{acc:.1%} — no previous run to compare"
+    delta_pt = (acc - previous) * 100
+    if abs(delta_pt) < 0.05:
+        return f"{acc:.1%} — unchanged vs last"
+    arrow = "▲ improved" if delta_pt > 0 else "▼ regressed"
+    return f"{acc:.1%} — {arrow} {abs(delta_pt):.1f}pt vs last ({previous:.1%})"
+
+
+def _duration_text(duration_s: float, summary: dict) -> str:
+    """Total wall time with the prefetch/epoch breakdown when the summary has it."""
+    parts = [f"{duration_s / 60:.0f} min total"]
+    prefetch_s = summary.get("prefetch_s")
+    if prefetch_s:
+        parts.append(f"prefetch {prefetch_s / 60:.1f} min")
+    epoch_times = [
+        e["duration_s"] for e in summary.get("per_epoch") or [] if e.get("duration_s")
+    ]
+    if epoch_times:
+        parts.append(f"~{sum(epoch_times) / len(epoch_times) / 60:.1f} min/epoch")
+    return " · ".join(parts)
+
+
 def result_embed(
     summary: dict,
     pending_n: int,
     previous_best: float | None,
     duration_s: float,
+    previous_best_acc: float | None = None,
 ) -> dict:
     counts = summary.get("class_counts", {})
     dataset = (
@@ -137,7 +166,13 @@ def result_embed(
     )
     best = summary.get("best_val_loss")
     best_epoch = summary.get("best_epoch")
-    last = (summary.get("per_epoch") or [{}])[-1]
+    per_epoch = summary.get("per_epoch") or [{}]
+    best_val_acc = summary.get("best_val_acc")
+    if best_val_acc is None:  # older summaries: recover from the best epoch's record
+        best_val_acc = next(
+            (e.get("val_acc") for e in per_epoch if e.get("epoch") == best_epoch), None
+        )
+    last = per_epoch[-1]
     uploaded = summary.get("checkpoint_keys_uploaded") or []
     checkpoint = (
         f"{len(uploaded)}/3 files → R2 (live on next container cold start)"
@@ -160,11 +195,20 @@ def result_embed(
                 "inline": False,
             },
             {
+                "name": "Val accuracy",
+                "value": _acc_delta_text(best_val_acc, previous_best_acc),
+                "inline": False,
+            },
+            {
                 "name": "Final epoch",
                 "value": f"val_acc {last.get('val_acc', 0.0):.1%} · train_loss {last.get('train_loss', 0.0):.4f}",
                 "inline": True,
             },
-            {"name": "Duration", "value": f"{duration_s / 60:.0f} min", "inline": True},
+            {
+                "name": "Duration",
+                "value": _duration_text(duration_s, summary),
+                "inline": True,
+            },
             {"name": "Checkpoint", "value": checkpoint, "inline": False},
         ],
         "footer": {"text": "is-the-mountain-out • scheduled training"},
@@ -342,11 +386,18 @@ def main(config: str, data_root: str, check: bool) -> None:
             "ran_at": started_at.isoformat(),
             "labels_total": summary.get("labels_loaded"),
             "best_val_loss": summary.get("best_val_loss"),
+            "best_val_acc": summary.get("best_val_acc"),
             "epochs": epochs,
         },
     )
     telemetry.update(
-        result_embed(summary, len(pending), watermark.get("best_val_loss"), duration_s)
+        result_embed(
+            summary,
+            len(pending),
+            watermark.get("best_val_loss"),
+            duration_s,
+            previous_best_acc=watermark.get("best_val_acc"),
+        )
     )
     print(
         f"run complete — best val_loss {summary.get('best_val_loss'):.4f}, "

--- a/train/scheduler.py
+++ b/train/scheduler.py
@@ -150,6 +150,7 @@ def batch(
     per_epoch: list[dict] = []
     uploaded_keys: list[str] = []
     best_epoch: int | None = None
+    best_val_acc: float | None = None
 
     def _write_summary(status: str, **extra) -> None:
         """Atomic (tmp+rename) summary write; a scheduled wrapper parses this
@@ -270,7 +271,11 @@ def batch(
             )
             prefetch_keys.append(str(img_p.parent.parent / "metar" / "metar.txt"))
             prefetch_keys.append(str(img_p.parent / f"{img_p.stem}.txt"))
+        prefetch_started = time.monotonic()
         storage.prefetch(prefetch_keys)
+        prefetch_s = round(time.monotonic() - prefetch_started, 1)
+    else:
+        prefetch_s = 0.0
 
     batch_size = 16
 
@@ -435,6 +440,7 @@ def batch(
         epoch_task = progress.add_task("[green]Epochs...", total=epochs)
 
         for epoch in range(epochs):
+            epoch_started = time.monotonic()
             random.shuffle(train_list)
             batch_task = progress.add_task(
                 f"[cyan]Epoch {epoch + 1}/{epochs}...", total=total_batches
@@ -563,12 +569,14 @@ def batch(
                     "train_loss": avg_loss,
                     "val_loss": val_loss,
                     "val_acc": val_acc,
+                    "duration_s": round(time.monotonic() - epoch_started, 1),
                 }
             )
 
             if val_loss < best_val_loss:
                 best_val_loss = val_loss
                 best_epoch = epoch + 1
+                best_val_acc = val_acc
                 uploaded_keys = trainer.model_wrapper.save_checkpoint(
                     trainer.config_loader.checkpoint_dir, storage=storage
                 )
@@ -615,6 +623,8 @@ def batch(
         train_n=len(train_list),
         val_n=len(val_list),
         best_val_loss=best_val_loss,
+        best_val_acc=best_val_acc,
+        prefetch_s=prefetch_s,
     )
 
     print(

--- a/train/tests/test_scheduled.py
+++ b/train/tests/test_scheduled.py
@@ -65,10 +65,24 @@ SUMMARY = {
     "labels_loaded": 2004,
     "class_counts": {"not_out": 1729, "full": 109, "partial": 166},
     "best_val_loss": 0.0765,
-    "best_epoch": 3,
+    "best_epoch": 2,
+    "best_val_acc": 0.979,
+    "prefetch_s": 372.0,
     "per_epoch": [
-        {"epoch": 1, "train_loss": 0.31, "val_loss": 0.09, "val_acc": 0.955},
-        {"epoch": 2, "train_loss": 0.22, "val_loss": 0.0765, "val_acc": 0.979},
+        {
+            "epoch": 1,
+            "train_loss": 0.31,
+            "val_loss": 0.09,
+            "val_acc": 0.955,
+            "duration_s": 180.0,
+        },
+        {
+            "epoch": 2,
+            "train_loss": 0.22,
+            "val_loss": 0.0765,
+            "val_acc": 0.979,
+            "duration_s": 192.0,
+        },
     ],
     "checkpoint_keys_uploaded": [
         "checkpoints/adapter_config.json",
@@ -85,13 +99,33 @@ class TestEmbeds:
         assert "4 new Discord label event(s)" in embed["fields"][0]["value"]
 
     def test_result_embed_improvement(self):
-        embed = scheduled.result_embed(SUMMARY, 4, previous_best=0.0782, duration_s=900)
+        embed = scheduled.result_embed(
+            SUMMARY, 4, previous_best=0.0782, duration_s=900, previous_best_acc=0.976
+        )
         values = {f["name"]: f["value"] for f in embed["fields"]}
         assert embed["color"] == scheduled.COLOR_OK
         assert "▼ improved 0.0017" in values["Best val loss"]
         assert "1729/109/166" in values["Dataset"]
-        assert values["Duration"] == "15 min"
         assert "3/3 files" in values["Checkpoint"]
+        # Time telemetry: total · prefetch · avg per-epoch.
+        assert values["Duration"] == "15 min total · prefetch 6.2 min · ~3.1 min/epoch"
+        # Accuracy improvement in percentage points, arrows flipped vs loss.
+        assert values["Val accuracy"] == "97.9% — ▲ improved 0.3pt vs last (97.6%)"
+
+    def test_acc_regression_and_first_run_text(self):
+        assert "▼ regressed 1.9pt" in scheduled._acc_delta_text(0.957, 0.976)
+        assert "no previous run" in scheduled._acc_delta_text(0.979, None)
+        assert scheduled._acc_delta_text(None, 0.976) == "n/a"
+
+    def test_result_embed_acc_fallback_from_per_epoch(self):
+        # Older summaries lack best_val_acc — recover it from the best epoch's record.
+        legacy = {k: v for k, v in SUMMARY.items() if k != "best_val_acc"}
+        embed = scheduled.result_embed(legacy, 1, previous_best=None, duration_s=600)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        assert values["Val accuracy"].startswith("97.9%")
+
+    def test_duration_text_without_breakdown(self):
+        assert scheduled._duration_text(600, {}) == "10 min total"
 
     def test_result_embed_regression_flagged(self):
         worse = dict(SUMMARY, best_val_loss=0.0900)


### PR DESCRIPTION
`TRAINING` — **TELEMETRY UPGRADE**

# The completion embed learns to talk about time and accuracy

> _The run's story in one card: how long (total · prefetch · per-epoch) and how much better (val loss Δ and val accuracy Δ in percentage points, each vs the previous scheduled run)._

> [!NOTE]
> **train** · feat · risk: low

## What changed
- `training batch --json-summary` now records `duration_s` per epoch, `prefetch_s`, and `best_val_acc` (accuracy at the best-val-loss epoch).
- The completion embed's **Duration** becomes `15 min total · prefetch 6.2 min · ~3.1 min/epoch`, and a new **Val accuracy** field shows `97.9% — ▲ improved 0.3pt vs last (97.6%)` (arrows flipped vs the loss delta — higher is better; regressions read ▼).
- The R2 watermark stores `best_val_acc` for the next comparison; legacy watermarks/summaries degrade gracefully ("no previous run to compare", per-epoch fallback for `best_val_acc`).

## Verification
76 tests green incl. new cases: duration breakdown string, acc improvement/regression/first-run/none texts, legacy-summary fallback, breakdown-less duration. New files ruff-clean + formatted. Note: the currently in-flight scheduled run launched with the previous code — its completion message uses the old format; every later run gets this one.