### PR TITLE
feat(worker+bot): the alert you can argue with

### DIFF
--- a/BOT.md
+++ b/BOT.md
@@ -1,59 +1,69 @@
 # Discord reaction-labeling bot
 
-A gateway bot (`bot/`, discord.py) that turns a Discord channel into a mobile
-labeling surface for the classifier: it posts fresh webcam captures on an
-hourly daylight schedule, and your reactions become training labels.
+A gateway bot (`bot/`, discord.py) that turns your reactions on the Worker's
+visibility notifications into training labels.
 
 ```
 👍 = Full (1) · ⛅ = Partial (2) · 👎 = Not Out (0)
 ```
 
 Skin-tone variants (👍🏻…👍🏿) count as their base emoji. Labels land in the same
-`labels.yaml` the classifier UI and `just train` already share — so reacting on
-your phone feeds the next LoRA batch run with zero extra plumbing. This is a
-**bot** (Gateway websocket), not a webhook: reaction events only arrive over
-the Gateway, which is why the Worker's webhook notifier can't do this job.
+`labels.yaml` the classifier UI and `just train` already share — so correcting a
+call on your phone feeds the next LoRA batch run with zero extra plumbing. This
+is a **bot** (Gateway websocket), not a webhook: reaction events only arrive
+over the Gateway.
+
+**The bot does not post on a schedule.** It used to publish an hourly capture to
+label, which produced 24 near-identical "Not Out (100.0%)" quiz posts a day and
+buried the notifications that actually meant something. The Worker's
+state-change posts (`NOTIFICATIONS.md`) are now the whole labeling surface: they
+fire when the answer changes, and the label you give is a correction on a
+real prediction rather than a chore.
 
 ## How a label happens
 
-1. On the hour (inside civil dawn→dusk at the webcam's coordinates), the bot
-   runs the standard collector capture: webcam frame + paired METAR →
-   `data/YYYYMMDD/HHMMSS_us_UTC/…` → uploaded to R2 under the usual key. The
-   METAR pairing matters — labeled samples stay fully featured for the model's
-   dual (image ⊕ weather) input.
-2. It posts the frame to the configured channel with the model's live
-   prediction (from the public `state.json`, when `[bot] state_url` is set)
-   and seeds the three label reactions. The embed **footer carries the capture's
-   storage key** — the only message↔capture state, so nothing breaks on restart.
-3. You tap a reaction. The bot maps emoji → class, checks the allowlist, and
+1. The Worker confirms a visibility change (both directions, debounced over two
+   inference ticks), persists the announced frame + paired METAR to R2 under the
+   collector's standard capture key, and posts it to the channel **using this
+   bot's token** — attaching the frame, footering its capture key, and seeding
+   the three label reactions. The METAR pairing matters: labeled samples stay
+   fully featured for the model's dual (image ⊕ weather) input.
+2. You tap a reaction. The bot maps emoji → class, checks the allowlist, and
    union-merges `{capture_key: class}` into `labels.yaml` (R2 is the source of
    truth; the merge never deletes keys added by the classifier UI). Each label
-   also appends a provenance event to `labels/discord-events.jsonl`, and the
-   bot **edits a 🏷️ Label field onto its post** as acknowledgment — e.g. "New
-   reaction (Not Out) recorded — 3/2004 training labels from Discord". Labels
-   count toward the *model* at the next `just train`. (Worker notification
-   messages record labels too but can't show the field — bots can't edit
-   webhook messages.)
-4. Re-labeling is just reacting again — last reaction wins. Reactions added
+   also appends a provenance event to `labels/discord-events.jsonl`, and the bot
+   **edits a 🏷️ Label field onto the post** as acknowledgment — e.g. "New
+   reaction (Not Out) recorded — 3/2004 training labels from Discord".
+3. Re-labeling is just reacting again — last reaction wins. Reactions added
    while the bot was offline are recovered by a startup sweep of the last
    `sweep_hours` of channel history (majority vote; ties are skipped).
-5. **The Worker's "mountain is out!" notifications are labelable too.** On a
-   visibility transition the Worker persists the announced frame (+ METAR) to
-   R2 under a standard capture key and footers the notification with it
-   (`worker/src/index.ts`). The bot treats any *bot-authored* embed whose
-   footer parses as a capture key — and whose key actually exists in storage —
-   exactly like its own posts. A 👎 on a false positive is the highest-value
-   label this system can collect (precision is the stated priority).
-6. Next `just train` folds the Discord labels into the oversampled batch run
+4. Next `just train` folds the Discord labels into the oversampled batch run
    like any others.
+
+### Why the Worker posts with the bot's token
+
+The embed footer carries the capture key, and it is the **only** message↔capture
+state — nothing on disk, so labeling survives a restart. Reading it requires the
+bot to be able to see the embed.
+
+A bot without the privileged **Message Content** intent gets `embeds: []` for
+messages authored by anyone else. While the Worker posted through a webhook, the
+footer came back empty and **every reaction on a notification was silently
+dropped** — the feature was wired end to end and could never have worked.
+Posting as the bot makes each notification a message the bot authored, which
+Discord always delivers in full. No privileged intent needed, and the bot gains
+the ability to edit its acknowledgment onto the post.
+
+Messages that aren't bot-authored embeds with a real capture-key footer (older
+prose-footer notifications, human messages) are ignored, and a parsed key is
+additionally gated on actually existing in storage before anything is recorded.
 
 ## Setup (once)
 
 1. **Create the Discord app** (bot-per-purpose — its own app, not a shared
    token; register it in `tommyroar/discobots` → `DISCORD.md`). In the
    [developer portal](https://discord.com/developers/applications): New
-   Application → Bot → copy the token. No privileged intents needed (the bot
-   only reads embeds of its own messages, so Message Content stays off).
+   Application → Bot → copy the token. No privileged intents needed.
 2. **Invite it** with scope `bot` and permissions: View Channel, Send Messages,
    Embed Links, Attach Files, Add Reactions, Read Message History (permissions
    integer `117824`).
@@ -61,20 +71,20 @@ the Gateway, which is why the Worker's webhook notifier can't do this job.
    `DISCORD_CHANNEL_ID` (the labeling channel), optional
    `DISCORD_ALLOWED_USER_IDS` (comma-separated; empty = any human's reactions
    count — set it on shared servers), plus the existing R2 credentials.
-4. **Tune** the optional `[bot]` section in `mountain.toml`
-   (`post_interval_seconds`, `sweep_hours`, `state_url`, fixed
-   `window_start`/`window_end` overriding the solar window).
+4. **Give the Worker the same two values** so its notifications are bot-authored
+   (`NOTIFICATIONS.md`): `npx wrangler secret put DISCORD_BOT_TOKEN` and
+   `DISCORD_CHANNEL_ID` from `worker/`, then `npx wrangler deploy`.
+5. **Tune** the optional `[bot]` section in `mountain.toml` (`sweep_hours`,
+   `state_url`).
 
-Point `DISCORD_CHANNEL_ID` at the same channel the Worker's webhook
-notifications post to (`#mountain`) — that's what makes notification reactions
-labelable. Messages that aren't bot-authored embeds with a real capture-key
-footer (older prose-footer notifications, human messages) are ignored.
+`DISCORD_CHANNEL_ID` must be the same channel in both places — that's what makes
+the notifications labelable.
 
 ## Run
 
 ```bash
 just bot-post-once   # capture + post one labelable message, then exit (setup check)
-just bot             # the real thing: hourly daylight posts + reaction labeling
+just bot             # the real thing: reaction labeling + startup sweep
 
 # under Nomad on the always-on mini (sources cf.env itself):
 nomad job run nomad/bot.hcl
@@ -94,8 +104,14 @@ dependency so the inference container image never installs it.
 - **Posts but reactions don't label** — check `DISCORD_ALLOWED_USER_IDS`
   (your user id must be listed if it's non-empty) and that the reaction is one
   of 👍/⛅/👎 (anything else is ignored by design).
-- **No posts** — the bot only posts inside the daylight window; check
-  `nomad alloc logs` for `capture post failed` (webcam/R2 hiccups skip the
-  hour rather than posting an unlabelable message).
+- **A notification has no reactions and a prose footer** — the frame failed to
+  persist to R2, so the Worker deliberately posted an unlabelable message rather
+  than one pointing at a missing object. `npx wrangler tail` from `worker/` shows
+  the reason.
+- **Reactions on a message posted before this change do nothing** — correct.
+  Those are webhook-authored; the bot cannot read their embeds. Only posts from
+  the bot token are labelable.
 - **Missed reactions while down** — automatic: the startup sweep re-reads
   `sweep_hours` of history and records anything new.
+- **Quiet channel** — expected. Posts now track real visibility changes
+  (recently ~2–6 a day), not a fixed hourly cadence.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ uv run classify start [data_folder]
 uv run classify stop
 
 # Discord reaction-labeling bot (see BOT.md; discord.py lives in the `bot` dependency group)
-uv run --group bot bot run           # hourly daylight posts + reaction labeling
+uv run --group bot bot run           # reaction labeling + startup sweep
 uv run --group bot bot post-once     # one labelable post, then exit (setup check)
 
 # Nomad job management
@@ -71,7 +71,7 @@ FastAPI server writes its port to `data/classifier_server.port` at startup (dyna
 
 ### Discord labeling bot (`bot/`)
 
-Gateway bot (discord.py, `bot` dependency group) that posts an hourly daylight webcam capture to a Discord channel and records 👍/⛅/👎 reactions as Full/Partial/Not-Out labels — the mobile counterpart to the classifier UI. `bot/labeler.py` is pure logic (emoji normalization, capture-key footers, union-merge into the shared `labels.yaml`, solar posting window via astral); `bot/main.py` is the discord.py wiring (60s post loop, `on_raw_reaction_add`, startup sweep of missed reactions). Captures reuse `collect.collector.perform_capture`, so every posted frame lands in R2 under the standard key with paired METAR. See `BOT.md`.
+Gateway bot (discord.py, `bot` dependency group) that records 👍/⛅/👎 reactions as Full/Partial/Not-Out labels — the mobile counterpart to the classifier UI. **It does not post on a schedule**: the Worker's visibility-change notifications are the labeling surface, and the Worker writes them with *this bot's token* so they are bot-authored. That is load-bearing — without the privileged Message Content intent Discord blanks the embeds of any other author's messages, so while notifications came from a webhook the capture-key footer was unreadable and every reaction on one was silently dropped. `bot/labeler.py` is pure logic (emoji normalization, capture-key footers, union-merge into the shared `labels.yaml`); `bot/main.py` is the discord.py wiring (`on_raw_reaction_add`, startup sweep of missed reactions, and `post-once` as a manual setup check). See `BOT.md`.
 
 ### Configuration (`mountain.toml`)
 
@@ -85,10 +85,10 @@ Inference runs as the `mountain-inference` Cloudflare Worker + Container (cron `
 - **Terraform (`scripts/deploy-inference.sh` + `terraform/`):** retained as the intended path for reproducibility/IaC later, but the `terraform/` dir is currently absent and the script's TF path is stale — don't rely on it until it's rebuilt. Treat it as aspirational, not the working deploy.
 
 Worker secrets (set via `wrangler secret put`):
-- `DISCORD_WEBHOOK_URL` — Discord channel webhook URL the Worker posts visibility embeds to (the URL *is* the secret). Set with `npx wrangler secret put DISCORD_WEBHOOK_URL` from `worker/`. See `NOTIFICATIONS.md`. (Replaced the former `NTFY_TOPIC`/`NTFY_TOKEN` ntfy.sh secrets — those and the gitignored `ntfy.key`/`ntfy-token.key` files are now obsolete.)
+- `DISCORD_BOT_TOKEN` / `DISCORD_CHANNEL_ID` — the labeler bot's credentials, so the Worker posts visibility changes *as that bot* and they're reaction-labelable. Same values as `cf.env`. See `NOTIFICATIONS.md`. (Replaced `DISCORD_WEBHOOK_URL`, which made posts unreadable to the bot; delete it with `npx wrangler secret delete DISCORD_WEBHOOK_URL`. The former `NTFY_TOPIC`/`NTFY_TOKEN` ntfy.sh secrets and the gitignored `ntfy.key`/`ntfy-token.key` files are also obsolete.)
 - `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` ← `cf.env` — let the container pull its checkpoint from R2 on cold start.
 
-Notifications fire on the **Not Out → visible** transition via `worker/src/discord-mountain-notify.ts`. Failures are silent: `/notify-test` always returns `202` (publish is queued via `waitUntil`) and Discord errors are only `console.error`'d. To diagnose, `cd worker && npx wrangler tail --format json` and look for `Discord ... failed` or `DISCORD_WEBHOOK_URL not set`.
+Notifications fire on a visibility change in **both directions**, debounced over two consecutive inference ticks (`worker/src/transition.ts`, bookkeeping in `notify-state.json`; raw predictions flap). Each post attaches the announced frame — never a `webcam_url` link, which would silently become a different picture — and footers its R2 capture key so a reaction becomes a training label. Formatting and delivery: `worker/src/discord-mountain-notify.ts`. Failures are silent: `/notify-test` always returns `202` (publish is queued via `waitUntil`) and Discord errors are only `console.error`'d. To diagnose, `cd worker && npx wrangler tail --format json` and look for `Discord ... failed` or `DISCORD_BOT_TOKEN/DISCORD_CHANNEL_ID not set`. Worker tests: `cd worker && npm test`.
 
 ## Key Design Constraints
 

--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -1,50 +1,80 @@
 # Notifications
 
-The project uses a **Discord webhook** for real-time push notifications. Discord delivers to desktop and mobile (iOS/Android) via the Discord app, with no per-IP rate limit on incoming webhooks — which is why it replaced the old ntfy.sh path (anonymous ntfy publishing returned HTTP 429 from Cloudflare's shared egress IPs).
+The `mountain-inference` Cloudflare Worker posts to Discord whenever the answer
+to "is the mountain out?" changes. Discord delivers to desktop and mobile with
+no per-IP rate limit (which is why it replaced the old ntfy.sh path — anonymous
+ntfy publishing returned HTTP 429 from Cloudflare's shared egress IPs).
 
-> Related but distinct: the **reaction-labeling bot** (`BOT.md`) is a separate
-> Gateway app that posts hourly captures and turns reactions into training
-> labels. The two are designed to share a channel: on each transition the
-> Worker persists the announced frame to R2 and footers the notification with
-> its capture key, so a 👍/⛅/👎 reaction on a notification is picked up by the
-> bot as a label too — a 👎 on a false "the mountain is out!" corrects the
-> model with the exact offending frame.
-
-## Subscribe
-
-1. In the Discord server/channel you want the alerts in: **Channel → Edit → Integrations → Webhooks → New Webhook**.
-2. Copy the webhook URL. It looks like `https://discord.com/api/webhooks/<id>/<token>`. **The URL is the secret** — anyone who has it can post to the channel. Store it only as a Worker secret (below), never in a committed file.
+**The notification is also the feedback surface.** Each one carries the frame it
+announced and three seeded reactions; tapping one tells the model it was right
+or wrong, and the labeler bot (`BOT.md`) records it as a training label against
+that exact frame. A 👎 on a false "the mountain is out!" is the highest-value
+label this project can collect — precision over recall is the stated priority.
 
 ## What fires
 
-The `mountain-inference` Cloudflare Worker (`worker/src/index.ts`) posts one embed on the **Not Out → visible** transition (i.e. when the previous tick's `state.json` had `is_out: false` and the current tick predicts `Full` or `Partial`). The Discord formatting lives in `worker/src/discord-mountain-notify.ts`.
-
-| Trigger | Title | Color | Fields |
+| Trigger | Title | Color | Confidence shown |
 |---|---|---|---|
-| Not Out → Full or Partial | 🏔️ The mountain is out! | green | Confidence (combined visible-class %), Classification (Full/Partial) |
+| not out → Full or Partial | 🏔️ The mountain is out! | green | combined visible-class % |
+| out → Not Out | ☁️ The mountain is gone | gray | not-out % |
 
-The embed also attaches the webcam snapshot (`webcam_url`) as its image and stamps the prediction's `timestamp_utc`.
+Two rules shape when a change counts:
+
+- **Both directions.** The channel is the live answer, so it has to say when the
+  answer stops being yes as well as when it starts.
+- **A change must survive two consecutive inference ticks** before it posts
+  (`worker/src/transition.ts`). Raw predictions flap — real history has *out* at
+  16:46, *gone* at 17:01, *out* again at 18:01, which the old
+  compare-to-previous-tick logic would have announced three times. The debounce
+  costs one tick (~15 min) of latency on a genuine change and buys a channel
+  where every post means something. Bookkeeping lives in `notify-state.json`
+  next to `state.json`; if that object is missing or unreadable the Worker
+  re-adopts the current visibility **silently**, so a lost file is never a false
+  alert.
+
+The embed **attaches** the announced frame rather than linking `webcam_url` —
+that URL is `…/webcam2_latest.jpg`, so a linked image would quietly become a
+different picture later, and you must be labeling the frame you can see. The
+footer is the frame's R2 capture key, which is the contract `bot/labeler.py`
+parses. If the frame fails to persist, the post falls back to a prose footer and
+is simply not labelable.
+
+## Why a bot token and not a webhook
+
+Notifications used to go out through `DISCORD_WEBHOOK_URL`, and **every reaction
+on them was silently dropped**. A bot without the privileged Message Content
+intent receives `embeds: []` for messages authored by anyone else — including a
+webhook — so the labeler could never read the capture key out of the footer.
+
+Posting with the labeler's own bot token makes each notification a message the
+bot authored, which Discord always delivers in full. That fixes reaction
+labeling without requesting a privileged intent, and lets the bot edit its
+🏷️ Label acknowledgment onto the post.
 
 ## Secrets
 
-The Worker holds a single Discord secret, set via `wrangler secret put` (the live deploy path is wrangler, not Terraform):
+Both are set via `wrangler secret put` (the live deploy path is wrangler, not
+Terraform). They are the same values the bot reads from `cf.env`.
 
 | Secret | Required | Purpose |
 |---|---|---|
-| `DISCORD_WEBHOOK_URL` | yes | The Discord channel webhook URL to POST embeds to. A missing secret degrades to a logged skip — notifications simply don't send. |
+| `DISCORD_BOT_TOKEN` | yes | The labeler bot's token. The Worker posts and seeds reactions as that bot. |
+| `DISCORD_CHANNEL_ID` | yes | The channel to post in — the same one the bot watches. |
+
+A missing secret degrades to a logged skip: notifications simply don't send.
 
 ```bash
-# from worker/ — paste the webhook URL at the prompt (or pipe it in):
-npx wrangler secret put DISCORD_WEBHOOK_URL
+# from worker/ — same values as cf.env:
+npx wrangler secret put DISCORD_BOT_TOKEN
+npx wrangler secret put DISCORD_CHANNEL_ID
+npx wrangler secret delete DISCORD_WEBHOOK_URL   # retired
 npx wrangler deploy   # secrets only go live on the next deploy
 ```
 
 > **Obsolete:** the former `NTFY_TOPIC` / `NTFY_TOKEN` secrets and the gitignored
-> `ntfy.key` / `ntfy-token.key` files at the repo root are no longer used by the Worker.
-> Delete the old secrets with `npx wrangler secret delete NTFY_TOPIC` (and `NTFY_TOKEN`)
-> and remove the key files. The local-only `tools/local_notifier.py` stopgap (and its
-> `com.tommydoerr.mountain-notifier` launchd job) has been **retired** — the Worker posts
-> to Discord directly, so the IP-dodging local fallback is no longer needed.
+> `ntfy.key` / `ntfy-token.key` files at the repo root are no longer used.
+> The local-only `tools/local_notifier.py` stopgap (and its
+> `com.tommydoerr.mountain-notifier` launchd job) has been **retired**.
 
 ## Test
 
@@ -54,11 +84,21 @@ After deploying the Worker, hit the test endpoint:
 curl -X POST https://mountain-inference.<your-cf-subdomain>.workers.dev/notify-test
 ```
 
-That sends a one-shot blue test embed (no inference involved) — useful for verifying the Worker secret + Discord path without waiting for a transition. The endpoint always returns `202` (the publish is queued via `waitUntil`); if nothing arrives in Discord, tail the Worker to see the real result: `cd worker && npx wrangler tail --format json` then re-fire — a `Discord test notification failed: 401/404` line means the webhook URL is wrong or revoked, and `DISCORD_WEBHOOK_URL not set` means the secret is missing.
-
-You can also post directly from the terminal (bypassing the Worker entirely):
+That sends a one-shot blue test embed (no inference involved) — useful for
+verifying the Worker secrets + Discord path without waiting for a change. The
+endpoint always returns `202` (the publish is queued via `waitUntil`); if nothing
+arrives in Discord, tail the Worker for the real result:
 
 ```bash
-curl -sS -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" \
-  -d '{"embeds":[{"title":"test","description":"hello","color":3447003}]}'
+cd worker && npx wrangler tail --format json
+```
+
+`Discord test notification failed: 401` means the bot token is wrong or
+regenerated, `403`/`404` means the bot can't see or post in that channel, and
+`DISCORD_BOT_TOKEN/DISCORD_CHANNEL_ID not set` means a secret is missing.
+
+You can also post directly from the terminal, bypassing the Worker:
+
+```bash
+curl -sS -X POST "https://discord.com/api/v10/channels/$DISCORD_CHANNEL_ID/messages" -H "Authorization: Bot $DISCORD_BOT_TOKEN" -H "Content-Type: application/json" -d '{"embeds":[{"title":"test","description":"hello","color":3447003}]}'
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Append `?debug` to see confidence bars and the raw METAR readout.
 flowchart LR
   subgraph local["Mac mini (local)"]
     collector["collect collector<br/>(Nomad, on-demand)"]
-    labeler["bot labeler<br/>(Nomad, hourly daylight)"]
+    labeler["bot labeler<br/>(Nomad, always-on)"]
     trainer["training batch<br/>(MPS, on-demand)"]
   end
 
@@ -30,10 +30,10 @@ flowchart LR
   metar(["NOAA METAR (KSEA)"]) --> collector
   collector -- "captures + metar" --> r2priv
 
-  webcam --> labeler
-  metar --> labeler
-  labeler -- "captures + 👍⛅👎 labels" --> r2priv
-  labeler <-- "posts / reactions" --> discord(["Discord channel"])
+  worker -- "visibility change: frame + seeded 👍⛅👎 (as the bot)" --> discord(["Discord channel"])
+  worker -- "announced frame + metar" --> r2priv
+  discord -- "reactions" --> labeler
+  labeler -- "👍⛅👎 labels" --> r2priv
 
   r2priv -- "labels + cached images" --> trainer
   trainer -- "checkpoint" --> r2priv
@@ -61,6 +61,7 @@ sequenceDiagram
   participant M as NOAA METAR
   participant R2p as R2 (private)
   participant R2u as R2 (public)
+  participant D as Discord
 
   Cron->>W: scheduled() fires
   W->>C: POST /predict (DO binding)
@@ -73,6 +74,10 @@ sequenceDiagram
   C->>C: model.predict()
   C-->>W: PredictionState (class, confidence, weather)
   W->>R2u: PUT state.json
+  opt visibility changed, confirmed on 2 consecutive ticks
+    W->>R2p: PUT announced frame + metar
+    W->>D: POST embed as the labeler bot + seed 👍⛅👎
+  end
   W->>R2u: PUT history.jsonl (GET + append + PUT)
   Note over W,R2u: SPA picks up next 60s poll
 ```
@@ -165,7 +170,7 @@ uv run classify start [data_folder]
 uv run classify stop
 
 # Discord reaction-labeling bot (see BOT.md; needs cf.env)
-uv run --group bot bot run          # hourly daylight posts + reaction labeling
+uv run --group bot bot run          # reaction labeling + startup sweep
 uv run --group bot bot post-once    # post one labelable capture, then exit
 
 # Inference (server-side, used by the Cloudflare Container)
@@ -191,7 +196,7 @@ R2 S3 credentials (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`) live in `cf.env` 
 | Component | Host | Trigger |
 |---|---|---|
 | Capture collector | Mac mini (Nomad) | Cron, on-demand |
-| Discord labeling bot | Mac mini (Nomad) | Always-on (posts hourly in daylight) |
+| Discord labeling bot | Mac mini (Nomad) | Always-on (harvests reactions; the Worker does the posting) |
 | Training | Mac mini (MPS) | On-demand (`uv run training batch`) |
 | Inference cron | Cloudflare Worker | `*/15 * * * *` |
 | Inference compute | Cloudflare Container | Worker invocation |

--- a/bot/labeler.py
+++ b/bot/labeler.py
@@ -16,9 +16,7 @@ import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from datetime import time as dtime
 from typing import Any
-from zoneinfo import ZoneInfo
 
 import requests
 import yaml
@@ -80,13 +78,13 @@ def reaction_legend() -> str:
 
 # ---------- Message ↔ capture mapping ----------
 #
-# The embed footer carries the capture's storage key verbatim — on the bot's
-# own hourly posts AND on the Worker's transition notifications, which persist
-# the frame they announce and footer its key (worker/src/index.ts). It is the
-# only message↔capture state, so labeling survives restarts with nothing on
-# disk. Prose footers (historical notifications, anything else) never parse as
-# a capture, and the wiring additionally gates parsed keys on existing in
-# storage before recording a label.
+# The embed footer carries the capture's storage key verbatim. The Worker's
+# visibility notifications persist the frame they announce and footer its key
+# (worker/src/index.ts), and `bot post-once` does the same. It is the only
+# message↔capture state, so labeling survives restarts with nothing on disk.
+# Prose footers (historical notifications, anything else) never parse as a
+# capture, and the wiring additionally gates parsed keys on existing in storage
+# before recording a label.
 
 
 def footer_for_capture(capture_key: str) -> str:
@@ -108,14 +106,8 @@ class BotSettings:
     token: str
     channel_id: int
     allowed_user_ids: frozenset[int]  # empty → any human reaction counts
-    post_interval_seconds: int = 3600
     sweep_hours: int = 72
     state_url: str = ""
-    window_start: dtime | None = None  # fixed window; overrides solar
-    window_end: dtime | None = None
-    timezone: str = "America/Los_Angeles"
-    latitude: float = 0.0
-    longitude: float = 0.0
 
     @classmethod
     def from_mapping(
@@ -129,7 +121,6 @@ class BotSettings:
         """
         env = os.environ if env is None else env
         bot_cfg = config.get("bot", {})
-        webcam = config.get("webcam", {})
 
         token = env.get("DISCORD_BOT_TOKEN", "").strip()
         channel_raw = env.get("DISCORD_CHANNEL_ID", "").strip()
@@ -144,51 +135,13 @@ class BotSettings:
             int(part) for part in re.split(r"[,\s]+", allowed_raw) if part
         )
 
-        def parse_window(key: str) -> dtime | None:
-            raw = bot_cfg.get(key)
-            return dtime.fromisoformat(raw) if raw else None
-
         return cls(
             token=token,
             channel_id=int(channel_raw),
             allowed_user_ids=allowed,
-            post_interval_seconds=int(bot_cfg.get("post_interval_seconds", 3600)),
             sweep_hours=int(bot_cfg.get("sweep_hours", 72)),
             state_url=str(bot_cfg.get("state_url", "")),
-            window_start=parse_window("window_start"),
-            window_end=parse_window("window_end"),
-            timezone=str(bot_cfg.get("timezone", "America/Los_Angeles")),
-            latitude=float(webcam.get("latitude", 0.0)),
-            longitude=float(webcam.get("longitude", 0.0)),
         )
-
-
-# ---------- Posting schedule ----------
-
-
-def next_post_due(
-    last_post: datetime | None, now: datetime, interval_seconds: int
-) -> bool:
-    return last_post is None or (now - last_post).total_seconds() >= interval_seconds
-
-
-def in_daylight_window(settings: BotSettings, now: datetime) -> bool:
-    """True when *now* falls inside the posting window.
-
-    A fixed [bot] window_start/window_end pair wins when configured; otherwise
-    the window is civil dawn→dusk at the webcam's coordinates (astral — the
-    same library behind `collect schedule`'s solar-aligned capture plans).
-    """
-    local = now.astimezone(ZoneInfo(settings.timezone))
-    if settings.window_start is not None and settings.window_end is not None:
-        return settings.window_start <= local.time() <= settings.window_end
-
-    from astral import Observer
-    from astral.sun import sun
-
-    observer = Observer(latitude=settings.latitude, longitude=settings.longitude)
-    times = sun(observer, date=local.date(), tzinfo=local.tzinfo)
-    return times["dawn"] <= local <= times["dusk"]
 
 
 # ---------- Prediction context (public state.json) ----------

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,13 +1,20 @@
 """Discord reaction-labeling bot — gateway wiring around bot/labeler.py.
 
-Posts a fresh webcam capture to one Discord channel on an hourly daylight
-schedule, seeds the 👍/⛅/👎 label reactions, and records human reactions into
-the same labels.yaml the classifier UI and `training batch` already share.
-Reactions on the Worker's transition notifications count too — the Worker
-persists the announced frame and footers its capture key — so a 👎 on a false
-"the mountain is out!" is a training label against the exact offending frame.
-Reactions added while the bot was down are recovered by a startup sweep of
-recent channel history.
+Harvests 👍/⛅/👎 reactions on the Worker's visibility-change notifications into
+the same labels.yaml the classifier UI and `training batch` already share, so a
+👎 on a false "the mountain is out!" is a training label against the exact
+offending frame. Reactions added while the bot was down are recovered by a
+startup sweep of recent channel history.
+
+The bot does NOT post on a schedule. It used to publish an hourly capture to
+label, which produced 24 near-identical "Not Out (100.0%)" quiz posts a day —
+noise that buried the notifications that actually mean something. The Worker's
+state-change posts are now the whole labeling surface, and the Worker writes
+them with THIS bot's token (worker/src/discord-mountain-notify.ts) so they are
+bot-authored: without the privileged Message Content intent, Discord blanks the
+embeds of messages any other author wrote, which is exactly why reactions on
+the old webhook notifications were silently dropped. `bot post-once` remains as
+a manual setup check.
 
 Requires the `bot` dependency group:  uv run --group bot bot run
 """
@@ -23,7 +30,6 @@ from pathlib import Path
 
 import click
 import discord
-from discord.ext import tasks
 
 from bot import labeler
 from collect.collector import WeatherFetcher, perform_capture
@@ -33,7 +39,7 @@ logger = logging.getLogger("mountain.bot")
 
 
 class MountainBot(discord.Client):
-    """One channel, two jobs: post labelable captures, harvest reactions."""
+    """One channel, one job: turn reactions into training labels."""
 
     def __init__(
         self,
@@ -43,8 +49,11 @@ class MountainBot(discord.Client):
         post_once: bool = False,
     ):
         # Default (non-privileged) intents cover guilds + reactions. The
-        # message_content intent is NOT needed: the bot only reads embeds of
-        # its own messages, which Discord always delivers in full.
+        # message_content intent is NOT needed *because* every labelable post is
+        # written with this bot's token, and Discord always delivers a bot its
+        # own messages in full. Anything authored elsewhere arrives with
+        # `embeds: []`, which is precisely why the old webhook notifications
+        # were unlabelable — keep that invariant when adding a posting surface.
         super().__init__(intents=discord.Intents.default())
         self.settings = settings
         self.config_loader = config_loader
@@ -54,12 +63,7 @@ class MountainBot(discord.Client):
         # as a merge base would drop labels added to R2 by other surfaces.
         self.storage = labeler.uncached_storage(config_loader.get_storage(data_root))
         self.weather = WeatherFetcher(config_loader.metar_station)
-        self._last_post: datetime | None = None
         self._swept = False
-
-    async def setup_hook(self) -> None:
-        if not self.post_once:
-            self.post_loop.start()
 
     async def on_ready(self) -> None:
         logger.info(
@@ -79,26 +83,7 @@ class MountainBot(discord.Client):
             except Exception:
                 logger.exception("startup reaction sweep failed (continuing)")
 
-    # ---------- Posting ----------
-
-    @tasks.loop(seconds=60)
-    async def post_loop(self) -> None:
-        now = datetime.now(UTC)
-        if not labeler.next_post_due(
-            self._last_post, now, self.settings.post_interval_seconds
-        ):
-            return
-        if not labeler.in_daylight_window(self.settings, now):
-            return
-        try:
-            if await self.post_capture():
-                self._last_post = now
-        except Exception:
-            logger.exception("capture post failed (loop continues)")
-
-    @post_loop.before_loop
-    async def _wait_until_ready(self) -> None:
-        await self.wait_until_ready()
+    # ---------- Posting (manual setup check only — see module docstring) ----------
 
     def _capture(self) -> tuple[str, bytes, datetime] | None:
         """Blocking capture → (storage key, jpeg bytes, captured_at)."""
@@ -183,9 +168,9 @@ class MountainBot(discord.Client):
     ) -> None:
         """Acknowledge a recorded label on the post itself (edit-in-place).
 
-        Only the bot's own messages are editable — reactions on the Worker's
-        webhook notifications still record, they just can't show the field.
-        Best-effort: an edit failure never loses the already-recorded label.
+        Discord only lets a bot edit its own messages — which now includes the
+        Worker's notifications, since the Worker posts them with this bot's
+        token. Best-effort: an edit failure never loses the recorded label.
         """
         if not self.user or message.author.id != self.user.id or not message.embeds:
             return
@@ -205,10 +190,12 @@ class MountainBot(discord.Client):
             message = await channel.fetch_message(message_id)
         except discord.HTTPException:
             return None
-        # Labelable messages come from automation: the bot's own posts and the
-        # Worker's transition notifications (webhook authors are bots too).
-        # Human-authored embeds never count; the footer regex plus the caller's
-        # storage-existence gate keep arbitrary keys out of labels.yaml.
+        # Labelable messages come from automation: the Worker's visibility
+        # notifications and `bot post-once` captures, both written with this
+        # bot's token. Human-authored embeds never count; the footer regex plus
+        # the caller's storage-existence gate keep arbitrary keys out of
+        # labels.yaml. (`message.embeds` is only ever populated for messages
+        # this bot authored — see the module docstring on Message Content.)
         if not message.author.bot or not message.embeds:
             return None
         footer = message.embeds[0].footer
@@ -224,8 +211,8 @@ class MountainBot(discord.Client):
         current = await asyncio.to_thread(labeler.load_labels, self.storage)
         swept = 0
         async for message in channel.history(limit=500, after=after):
-            # Same acceptance rule as _capture_key_for_message: any bot-authored
-            # embed (own posts + Worker notifications) with a parsing footer.
+            # Same acceptance rule as _labelable_message: a bot-authored embed
+            # with a footer that parses as a capture key.
             if not message.author.bot or not message.embeds:
                 continue
             footer = message.embeds[0].footer
@@ -289,7 +276,7 @@ def cli() -> None:
     "--data-root", default=None, help="Defaults to $MOUNTAIN_DATA_ROOT or 'data'."
 )
 def run(config: str, data_root: str | None) -> None:
-    """Run the bot: hourly daylight capture posts + reaction labeling."""
+    """Run the bot: reaction labeling + startup sweep of missed reactions."""
     bot = _build(config, data_root)
     bot.run(bot.settings.token, log_handler=None)
 

--- a/bot/tests/test_labeler.py
+++ b/bot/tests/test_labeler.py
@@ -6,7 +6,6 @@ mirroring collect/tests/test_storage.py.
 
 import json
 from datetime import UTC, datetime
-from datetime import time as dtime
 from unittest.mock import patch
 
 import pytest
@@ -95,10 +94,9 @@ class TestFooter:
 
 BASE_CONFIG = {
     "bot": {
-        "post_interval_seconds": 1800,
+        "sweep_hours": 24,
         "state_url": "https://example.com/state.json",
     },
-    "webcam": {"latitude": 47.6533, "longitude": -122.3091},
 }
 
 
@@ -113,10 +111,8 @@ class TestBotSettings:
         assert s.token == "tok"
         assert s.channel_id == 1234
         assert s.allowed_user_ids == frozenset({111, 222})
-        assert s.post_interval_seconds == 1800
+        assert s.sweep_hours == 24
         assert s.state_url == "https://example.com/state.json"
-        assert s.latitude == pytest.approx(47.6533)
-        assert s.sweep_hours == 72  # default
 
     def test_missing_token_raises(self):
         with pytest.raises(ValueError, match="DISCORD_BOT_TOKEN"):
@@ -128,63 +124,26 @@ class TestBotSettings:
 
     def test_empty_allowlist_and_bot_section_optional(self):
         env = {"DISCORD_BOT_TOKEN": "tok", "DISCORD_CHANNEL_ID": "9"}
-        s = BotSettings.from_mapping({"webcam": {}}, env)
+        s = BotSettings.from_mapping({}, env)
         assert s.allowed_user_ids == frozenset()
-        assert s.post_interval_seconds == 3600
+        assert s.sweep_hours == 72  # default
+        assert s.state_url == ""
 
-    def test_fixed_window_parsed(self):
-        cfg = {"bot": {"window_start": "06:00", "window_end": "21:00"}, "webcam": {}}
+    def test_retired_posting_schedule_keys_are_ignored(self):
+        # The bot no longer posts on a schedule; a config left over from when it
+        # did must still load rather than blow up on an unknown key.
+        cfg = {
+            "bot": {
+                "post_interval_seconds": 1800,
+                "window_start": "06:00",
+                "window_end": "21:00",
+                "timezone": "America/Los_Angeles",
+            }
+        }
         env = {"DISCORD_BOT_TOKEN": "t", "DISCORD_CHANNEL_ID": "1"}
         s = BotSettings.from_mapping(cfg, env)
-        assert s.window_start == dtime(6, 0)
-        assert s.window_end == dtime(21, 0)
-
-
-def _settings(**overrides) -> BotSettings:
-    base = {
-        "token": "t",
-        "channel_id": 1,
-        "allowed_user_ids": frozenset(),
-        "latitude": 47.6533,
-        "longitude": -122.3091,
-        "timezone": "America/Los_Angeles",
-    }
-    base.update(overrides)
-    return BotSettings(**base)
-
-
-# ---------- Posting schedule ----------
-
-
-class TestSchedule:
-    def test_due_when_never_posted(self):
-        assert labeler.next_post_due(None, datetime.now(UTC), 3600)
-
-    def test_not_due_within_interval(self):
-        now = datetime(2026, 7, 1, 12, 30, tzinfo=UTC)
-        last = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
-        assert not labeler.next_post_due(last, now, 3600)
-
-    def test_due_after_interval(self):
-        now = datetime(2026, 7, 1, 13, 0, tzinfo=UTC)
-        last = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
-        assert labeler.next_post_due(last, now, 3600)
-
-    def test_fixed_window(self):
-        s = _settings(window_start=dtime(6, 0), window_end=dtime(21, 0))
-        noon_pt = datetime(2026, 7, 1, 19, 0, tzinfo=UTC)  # 12:00 PDT
-        midnight_pt = datetime(2026, 7, 1, 7, 30, tzinfo=UTC)  # 00:30 PDT
-        assert labeler.in_daylight_window(s, noon_pt)
-        assert not labeler.in_daylight_window(s, midnight_pt)
-
-    def test_solar_window_seattle(self):
-        # Real astral computation at the webcam's coordinates: Seattle summer
-        # noon is inside civil dawn→dusk, 1 AM is not.
-        s = _settings()
-        noon_pt = datetime(2026, 7, 1, 19, 0, tzinfo=UTC)
-        one_am_pt = datetime(2026, 7, 1, 8, 0, tzinfo=UTC)
-        assert labeler.in_daylight_window(s, noon_pt)
-        assert not labeler.in_daylight_window(s, one_am_pt)
+        assert s.channel_id == 1
+        assert not hasattr(s, "post_interval_seconds")
 
 
 # ---------- Prediction fetch ----------

--- a/cf.env.example
+++ b/cf.env.example
@@ -7,6 +7,10 @@ R2_SECRET_ACCESS_KEY=
 
 # Discord reaction-labeling bot (BOT.md). The token belongs to its own Discord
 # app — bot-per-purpose, per the tommyroar/discobots registry.
+#
+# The Worker holds these same two as secrets (`wrangler secret put`) so its
+# visibility notifications are posted BY this bot and are therefore
+# reaction-labelable — see NOTIFICATIONS.md for why that matters.
 DISCORD_BOT_TOKEN=
 DISCORD_CHANNEL_ID=
 # Comma-separated Discord user ids whose reactions count as training labels.

--- a/justfile
+++ b/justfile
@@ -11,7 +11,8 @@ default:
 train labels="data/labels.yaml" epochs="5":
     uv run training batch --labels {{labels}} --epochs {{epochs}}
 
-# Run the Discord reaction-labeling bot (needs cf.env — see BOT.md)
+# Run the Discord reaction-labeling bot: harvests reactions on the Worker's
+# visibility notifications into labels.yaml (needs cf.env — see BOT.md)
 bot:
     uv run --group bot bot run --config mountain.toml
 

--- a/mountain.toml
+++ b/mountain.toml
@@ -43,12 +43,8 @@ cache_dir = ".r2cache"
 
 [bot]
 # Discord reaction-labeling bot (BOT.md). Secrets + channel/user ids live in
-# cf.env; this section is behavior tuning only.
-post_interval_seconds = 3600 # one labelable capture per hour
+# cf.env; this section is behavior tuning only. The bot never posts on a
+# schedule — the Worker's visibility-change notifications are the labeling
+# surface — so there is no posting interval or daylight window to tune.
 sweep_hours = 72 # startup sweep re-reads this much channel history for missed reactions
-state_url = "https://pub-66d3d1f139004e29b2afcb5fba49bdb3.r2.dev/state.json" # public bucket; posts include the model's live prediction
-timezone = "America/Los_Angeles"
-# Posting window defaults to civil dawn→dusk at the webcam's coordinates (astral).
-# Uncomment both to force a fixed local-time window instead:
-# window_start = "06:00"
-# window_end = "21:00"
+state_url = "https://pub-66d3d1f139004e29b2afcb5fba49bdb3.r2.dev/state.json" # public bucket; `bot post-once` shows the model's live prediction

--- a/worker/package.json
+++ b/worker/package.json
@@ -7,7 +7,8 @@
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
     "tail": "wrangler tail mountain-inference",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test \"test/*.test.ts\""
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250401.0",

--- a/worker/src/discord-mountain-notify.ts
+++ b/worker/src/discord-mountain-notify.ts
@@ -1,37 +1,69 @@
-// Discord webhook notification module for is-the-mountain-out.
+// Discord notification module for is-the-mountain-out.
 //
-// Replaces the legacy ntfy.sh push path. The Worker calls:
-//   - notifyMountainVisibility(env, result) on the Not Out -> visible transition
-//   - notifyDiscordTest(env)               from the /notify-test endpoint
+// The Worker calls:
+//   - notifyMountainVisibility(env, result) on a confirmed visibility change
+//   - notifyDiscordTest(env)                from the /notify-test endpoint
 //
-// Integration (worker/src/index.ts):
-//   import { notifyMountainVisibility } from "./discord-mountain-notify";
-//   ctx.waitUntil(notifyMountainVisibility(env, result));
+// WHY A BOT TOKEN AND NOT A WEBHOOK
+// ---------------------------------
+// These notifications are the project's feedback surface: you react 👍/⛅/👎 to
+// confirm or correct the call, and the labeler bot (BOT.md) turns that into a
+// training label keyed on the announced frame. That only works if the bot can
+// READ the message's embed footer, which carries the capture key.
 //
-// Delivery never throws — webhook failures are logged and swallowed so they
-// cannot crash the scheduled handler or block the history append.
+// A bot without the privileged Message Content intent gets `embeds: []` for
+// messages authored by anyone else — including a webhook. So while the Worker
+// posted via `DISCORD_WEBHOOK_URL`, every reaction on a notification was
+// silently dropped. Posting with the labeler's own bot token makes the
+// notification a message the bot authored, which Discord always delivers in
+// full. No privileged intent, and the bot can also edit its 🏷️ Label
+// acknowledgment onto the post.
+//
+// The announced frame is uploaded as an ATTACHMENT rather than linked as
+// `webcam_url`: that URL is `…/webcam2_latest.jpg`, so a linked image silently
+// becomes a different picture later. You must be labeling the frame you can
+// see.
+//
+// Delivery never throws — failures are logged and swallowed so they cannot
+// crash the scheduled handler or block the history append.
+
+const DISCORD_API = "https://discord.com/api/v10";
 
 export interface PredictionResult {
   visible: boolean;
-  confidence: number; // 0..1, combined visible-class confidence
-  label: string; // "Full" | "Partial" | raw class name
-  imageUrl?: string; // webcam snapshot to embed
+  confidence: number; // 0..1, confidence in the announced state
+  label: string; // "Full" | "Partial" | "Not Out"
   timestamp?: string; // ISO 8601; defaults to now
-  // R2 key of the persisted frame this notification announces. When set it
-  // becomes the embed footer verbatim — the contract the labeler bot parses so
-  // a 👍/⛅/👎 reaction on the notification records a training label.
+  // The announced frame, persisted to R2 by the caller. Both are required for
+  // the post to be labelable: the bytes so the embed shows the frame that was
+  // classified, the key so a reaction can be recorded against it.
+  frame?: ArrayBuffer;
   captureKey?: string;
+  // Fallback image when no frame was persisted (post is then not labelable).
+  imageUrl?: string;
 }
 
 export interface Env {
-  // Discord webhook URL. Optional so a missing secret degrades to a logged
-  // skip rather than a thrown error (mirrors the old NTFY_TOPIC guard).
-  DISCORD_WEBHOOK_URL?: string;
+  // Both optional so a missing secret degrades to a logged skip rather than a
+  // thrown error. Set with `wrangler secret put` — see NOTIFICATIONS.md.
+  DISCORD_BOT_TOKEN?: string;
+  DISCORD_CHANNEL_ID?: string;
 }
 
 const COLOR_VISIBLE = 0x2ecc71; // green
 const COLOR_NOT_VISIBLE = 0x95a5a6; // gray
 const COLOR_TEST = 0x3498db; // blue
+
+// The label vocabulary, mirroring bot/labeler.py EMOJI_TO_CLASS. Seeded onto
+// every labelable post in this order, and rendered as the legend below — which
+// matches bot/labeler.py reaction_legend() (ordered by class index, descending)
+// so both surfaces read identically.
+const LABEL_REACTIONS = [
+  { emoji: "⛅", label: "Partial" },
+  { emoji: "👍", label: "Full" },
+  { emoji: "👎", label: "Not Out" },
+];
+const REACTION_LEGEND = LABEL_REACTIONS.map((r) => `${r.emoji} ${r.label}`).join(" · ");
 
 interface DiscordEmbed {
   title: string;
@@ -43,76 +75,139 @@ interface DiscordEmbed {
   timestamp?: string;
 }
 
-// Single delivery path for every embed. Guards on a missing webhook, logs
-// non-2xx responses with a truncated body, and swallows network errors.
-async function postWebhook(env: Env, embed: DiscordEmbed, context: string): Promise<boolean> {
-  if (!env.DISCORD_WEBHOOK_URL) {
-    console.warn(`DISCORD_WEBHOOK_URL not set; skipping Discord ${context}`);
-    return false;
+function botHeaders(env: Env): Record<string, string> {
+  return { Authorization: `Bot ${env.DISCORD_BOT_TOKEN}` };
+}
+
+/**
+ * Post one embed to the configured channel as the bot, optionally attaching a
+ * JPEG frame. Returns the new message id, or null if the post did not land.
+ */
+async function postAsBot(
+  env: Env,
+  embed: DiscordEmbed,
+  context: string,
+  frame?: ArrayBuffer,
+): Promise<string | null> {
+  if (!env.DISCORD_BOT_TOKEN || !env.DISCORD_CHANNEL_ID) {
+    console.warn(`DISCORD_BOT_TOKEN/DISCORD_CHANNEL_ID not set; skipping Discord ${context}`);
+    return null;
   }
   try {
-    const response = await fetch(env.DISCORD_WEBHOOK_URL, {
+    let body: BodyInit;
+    const headers = botHeaders(env);
+    if (frame) {
+      // Multipart: the embed references the upload by name. Content-Type is
+      // left unset so fetch writes the multipart boundary itself.
+      const form = new FormData();
+      form.append("payload_json", JSON.stringify({ embeds: [embed] }));
+      form.append("files[0]", new Blob([frame], { type: "image/jpeg" }), "capture.jpg");
+      body = form;
+    } else {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify({ embeds: [embed] });
+    }
+
+    const response = await fetch(`${DISCORD_API}/channels/${env.DISCORD_CHANNEL_ID}/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ embeds: [embed] }),
+      headers,
+      body,
     });
     if (!response.ok) {
-      const body = await response.text().catch(() => "(unreadable body)");
+      const text = await response.text().catch(() => "(unreadable body)");
       console.error(
-        `Discord ${context} failed: ${response.status} ${response.statusText} — ${body.slice(0, 200)}`,
+        `Discord ${context} failed: ${response.status} ${response.statusText} — ${text.slice(0, 200)}`,
       );
-      return false;
+      return null;
     }
-    return true;
+    const message = (await response.json()) as { id?: string };
+    return message.id ?? null;
   } catch (err) {
     console.error(
       `Discord ${context} request error:`,
       err instanceof Error ? err.message : String(err),
     );
-    return false;
+    return null;
   }
 }
 
 /**
- * Post a Discord embed announcing the mountain visibility prediction.
- * Returns true if the webhook was delivered successfully, false otherwise.
+ * Seed the three label reactions so the post is one tap away from a label.
+ *
+ * Sequential by necessity — Discord rate-limits reaction adds per channel, and
+ * a 429 is honored once before giving up on that emoji. Best-effort: a missing
+ * seed reaction costs a tap, not the label (the bot records any human reaction
+ * on the message).
+ */
+async function seedLabelReactions(env: Env, messageId: string): Promise<void> {
+  const base = `${DISCORD_API}/channels/${env.DISCORD_CHANNEL_ID}/messages/${messageId}/reactions`;
+  for (const { emoji } of LABEL_REACTIONS) {
+    const url = `${base}/${encodeURIComponent(emoji)}/@me`;
+    try {
+      let response = await fetch(url, { method: "PUT", headers: botHeaders(env) });
+      if (response.status === 429) {
+        const retry = (await response.json().catch(() => ({}))) as { retry_after?: number };
+        await new Promise((resolve) => setTimeout(resolve, (retry.retry_after ?? 1) * 1000));
+        response = await fetch(url, { method: "PUT", headers: botHeaders(env) });
+      }
+      if (!response.ok) {
+        console.warn(`seeding reaction ${emoji} failed: ${response.status} ${response.statusText}`);
+      }
+    } catch (err) {
+      console.warn(`seeding reaction ${emoji} errored:`, err instanceof Error ? err.message : String(err));
+    }
+  }
+}
+
+/**
+ * Announce a confirmed visibility change and make it labelable.
+ * Returns true if the message was posted.
  */
 export async function notifyMountainVisibility(env: Env, result: PredictionResult): Promise<boolean> {
-  const { visible, confidence, label, imageUrl, timestamp, captureKey } = result;
-  const confidencePct = (confidence * 100).toFixed(1);
-  const ts = timestamp ?? new Date().toISOString();
+  const { visible, confidence, label, timestamp, frame, captureKey, imageUrl } = result;
+  const labelable = Boolean(frame && captureKey);
+
+  const fields = [
+    { name: "Confidence", value: `${(confidence * 100).toFixed(1)}%`, inline: true },
+    { name: "Classification", value: label, inline: true },
+  ];
+  if (labelable) {
+    fields.push({ name: "Right or wrong?", value: REACTION_LEGEND, inline: false });
+  }
 
   const embed: DiscordEmbed = {
-    title: visible ? "🏔️ The mountain is out!" : "☁️ The mountain is not visible",
+    title: visible ? "🏔️ The mountain is out!" : "☁️ The mountain is gone",
     color: visible ? COLOR_VISIBLE : COLOR_NOT_VISIBLE,
-    fields: [
-      { name: "Confidence", value: `${confidencePct}%`, inline: true },
-      { name: "Classification", value: label, inline: true },
-    ],
-    // The capture key makes the notification labelable (react 👍/⛅/👎 to
-    // correct or confirm the model); prose footer = not labelable.
+    fields,
+    // The capture key IS the footer — the contract bot/labeler.py parses. A
+    // prose footer means the frame never persisted, so nothing is labelable.
     footer: { text: captureKey ?? "is-the-mountain-out • Automated prediction" },
-    timestamp: ts,
+    timestamp: timestamp ?? new Date().toISOString(),
   };
-  if (imageUrl) {
+  if (labelable) {
+    embed.image = { url: "attachment://capture.jpg" };
+  } else if (imageUrl) {
     embed.image = { url: imageUrl };
   }
 
-  return postWebhook(env, embed, "visibility notification");
+  const messageId = await postAsBot(env, embed, "visibility notification", labelable ? frame : undefined);
+  if (messageId === null) return false;
+  if (labelable) await seedLabelReactions(env, messageId);
+  return true;
 }
 
 /**
- * Post a one-shot Discord test embed (no inference involved) so the
- * Worker -> Discord webhook path can be verified end to end.
+ * Post a one-shot test embed (no inference involved) so the Worker → Discord
+ * path can be verified end to end.
  */
 export async function notifyDiscordTest(env: Env): Promise<boolean> {
   const embed: DiscordEmbed = {
     title: "🏔️ Worker notification test",
     description:
-      "Test from the mountain-inference Worker. If you see this in Discord, the Worker → Discord webhook path is healthy.",
+      "Test from the mountain-inference Worker. If you see this in Discord, the Worker → Discord bot-token path is healthy.",
     color: COLOR_TEST,
     footer: { text: "is-the-mountain-out • Notification test" },
     timestamp: new Date().toISOString(),
   };
-  return postWebhook(env, embed, "test notification");
+  return (await postAsBot(env, embed, "test notification")) !== null;
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -15,6 +15,7 @@
 
 import { Container, getContainer } from "@cloudflare/containers";
 import { notifyDiscordTest, notifyMountainVisibility } from "./discord-mountain-notify";
+import { INITIAL_NOTIFY_STATE, decideTransition, type NotifyState } from "./transition";
 
 interface Env {
   INFERENCE_CONTAINER: DurableObjectNamespace<InferenceContainer>;
@@ -22,10 +23,12 @@ interface Env {
   CAPTURE_BUCKET: R2Bucket;
   R2_ACCESS_KEY_ID: string;
   R2_SECRET_ACCESS_KEY: string;
-  // Discord webhook URL the Worker posts visibility transitions to. Optional so
-  // a missing secret degrades to a logged skip rather than a thrown error. Set
-  // out-of-band with `wrangler secret put DISCORD_WEBHOOK_URL`.
-  DISCORD_WEBHOOK_URL?: string;
+  // Credentials the Worker posts visibility changes with — as the labeler bot,
+  // so the posts are reaction-labelable (see discord-mountain-notify.ts).
+  // Optional so a missing secret degrades to a logged skip rather than a thrown
+  // error. Set out-of-band with `wrangler secret put`.
+  DISCORD_BOT_TOKEN?: string;
+  DISCORD_CHANNEL_ID?: string;
 }
 
 export class InferenceContainer extends Container<Env> {
@@ -67,6 +70,10 @@ type HistoryRecord =
 
 const STATE_KEY = "state.json";
 const HISTORY_KEY = "history.jsonl";
+// Notification bookkeeping (what the channel was last told, plus any flip
+// awaiting confirmation). Separate from state.json so the SPA's contract stays
+// exactly the published prediction — see transition.ts for the state machine.
+const NOTIFY_STATE_KEY = "notify-state.json";
 
 const isoUtc = (d: Date) => d.toISOString().replace(/\.\d{3}Z$/, "Z");
 
@@ -86,15 +93,23 @@ async function publishState(env: Env, state: PredictionState): Promise<void> {
   });
 }
 
-async function getPreviousState(env: Env): Promise<PredictionState | null> {
+async function getNotifyState(env: Env): Promise<NotifyState> {
   try {
-    const obj = await env.STATE_BUCKET.get(STATE_KEY);
-    if (!obj) return null;
-    return JSON.parse(await obj.text()) as PredictionState;
+    const obj = await env.STATE_BUCKET.get(NOTIFY_STATE_KEY);
+    if (!obj) return INITIAL_NOTIFY_STATE;
+    return { ...INITIAL_NOTIFY_STATE, ...(JSON.parse(await obj.text()) as Partial<NotifyState>) };
   } catch (e) {
-    console.warn("failed to read previous state for transition check:", e);
-    return null;
+    // Unreadable bookkeeping re-adopts the current visibility silently rather
+    // than announcing it — a corrupt object must not become a false alert.
+    console.warn("failed to read notify state; re-adopting current visibility:", e);
+    return INITIAL_NOTIFY_STATE;
   }
+}
+
+async function putNotifyState(env: Env, state: NotifyState): Promise<void> {
+  await env.STATE_BUCKET.put(NOTIFY_STATE_KEY, JSON.stringify(state, null, 2) + "\n", {
+    httpMetadata: { contentType: "application/json" },
+  });
 }
 
 // METAR source for persisted transition captures — same NOAA endpoint and
@@ -104,9 +119,13 @@ const METAR_URL = "https://tgftp.nws.noaa.gov/data/observations/metar/stations/K
 // Persist the frame (and METAR) a transition notification announces, under the
 // collector's standard capture-key layout, so a reaction on the notification
 // can label a real stored capture (the labeler bot gates on the key existing).
-// Returns the image key, or null on failure — the notification then falls back
-// to its prose footer and simply isn't labelable, mirroring today's behavior.
-async function persistTransitionCapture(env: Env, state: PredictionState): Promise<string | null> {
+// Returns the key AND the bytes — the notification embeds these exact bytes as
+// an attachment, so what you react to is what gets labeled. Null on failure:
+// the notification then falls back to a prose footer and isn't labelable.
+async function persistTransitionCapture(
+  env: Env,
+  state: PredictionState,
+): Promise<{ key: string; frame: ArrayBuffer } | null> {
   try {
     const frameResp = await fetch(state.webcam_url);
     if (!frameResp.ok) throw new Error(`webcam fetch returned ${frameResp.status}`);
@@ -139,27 +158,42 @@ async function persistTransitionCapture(env: Env, state: PredictionState): Promi
     } catch (e) {
       console.warn("transition METAR persist failed (image kept):", e);
     }
-    return imageKey;
+    return { key: imageKey, frame };
   } catch (e) {
     console.error("transition capture persist failed; notification will not be labelable:", e);
     return null;
   }
 }
 
-// Fire only on the Not Out → visible transition, mirroring tools/detect_mountain.py.
-async function notifyTransition(env: Env, prev: PredictionState | null, next: PredictionState): Promise<void> {
-  if (!next.is_out) return;
-  if (prev?.is_out) return;
-  const visible = (next.confidence?.full ?? 0) + (next.confidence?.partial ?? 0);
-  const label = next.class_name === "full" ? "Full" : "Partial";
-  const captureKey = await persistTransitionCapture(env, next);
+// Announce a confirmed change in BOTH directions — the channel is the live
+// answer to "is the mountain out?", so it has to say when the answer stops
+// being yes as well as when it starts. `decideTransition` supplies the
+// two-consecutive-ticks debounce that keeps flapping predictions off the wire.
+async function notifyTransition(env: Env, next: PredictionState): Promise<void> {
+  const { post, next: notifyState } = decideTransition(
+    await getNotifyState(env),
+    next.is_out,
+    isoUtc(new Date()),
+  );
+  // Persist BEFORE posting: a duplicate alert is worse than a missed one, and
+  // a crash between the two would otherwise re-announce on the next tick.
+  await putNotifyState(env, notifyState);
+  if (!post) return;
+
+  const visible = next.is_out;
+  const confidence = visible
+    ? (next.confidence?.full ?? 0) + (next.confidence?.partial ?? 0)
+    : (next.confidence?.not_out ?? 0);
+  const label = visible ? (next.class_name === "full" ? "Full" : "Partial") : "Not Out";
+  const capture = await persistTransitionCapture(env, next);
   await notifyMountainVisibility(env, {
-    visible: true,
-    confidence: visible,
+    visible,
+    confidence,
     label,
-    imageUrl: next.webcam_url,
     timestamp: next.timestamp_utc,
-    captureKey: captureKey ?? undefined,
+    frame: capture?.frame,
+    captureKey: capture?.key,
+    imageUrl: next.webcam_url,
   });
 }
 
@@ -180,11 +214,9 @@ async function tick(env: Env): Promise<void> {
   const startedAt = new Date();
   let record: HistoryRecord;
   try {
-    // Read prev state BEFORE the new write so we can compare for transition detection.
-    const prev = await getPreviousState(env);
     const state = await callContainer(env);
     await publishState(env, state);
-    await notifyTransition(env, prev, state);
+    await notifyTransition(env, state);
     const finishedAt = new Date();
     record = {
       started_at: isoUtc(startedAt),

--- a/worker/src/transition.ts
+++ b/worker/src/transition.ts
@@ -1,0 +1,68 @@
+// Debounced visibility-transition state machine — pure, so it can be tested
+// without a Worker runtime (`npm test` in worker/).
+//
+// Why a state machine and not "compare this tick to the previous state.json":
+// the raw predictions flap. Real history has out at 16:46, gone at 17:01, out
+// again at 18:01 — three notifications for what a human would call one change.
+// So a flip must survive TWO CONSECUTIVE ticks before it is announced: the
+// first tick that disagrees with the announced state only arms `pending`, and
+// the tick after it either confirms (announce) or clears it (flap, stay quiet).
+//
+// Cost of the debounce: one inference tick (~15 min) of latency on a genuine
+// change. Benefit: the channel says "the mountain is out" only when it stays
+// out, which is what makes the notification worth reacting to.
+
+export interface NotifyState {
+  /** Visibility the channel was last told about. null = never announced. */
+  announced_is_out: boolean | null;
+  /** A disagreeing observation awaiting confirmation on the next tick. */
+  pending_is_out: boolean | null;
+  /** When `pending_is_out` was armed (ISO 8601), for debugging. */
+  pending_since: string | null;
+}
+
+export const INITIAL_NOTIFY_STATE: NotifyState = {
+  announced_is_out: null,
+  pending_is_out: null,
+  pending_since: null,
+};
+
+export interface TransitionDecision {
+  /** Announce this tick's visibility to the channel. */
+  post: boolean;
+  /** State to persist for the next tick. */
+  next: NotifyState;
+}
+
+/**
+ * Decide whether `isOut` is a confirmed change worth announcing.
+ *
+ * @param state  persisted state from the previous tick
+ * @param isOut  this tick's prediction
+ * @param now    ISO timestamp used to stamp a newly armed `pending`
+ */
+export function decideTransition(state: NotifyState, isOut: boolean, now: string): TransitionDecision {
+  // First observation ever (or after the state object is lost): adopt the
+  // current visibility silently. Announcing here would fire a notification on
+  // every deploy that resets the object, which is noise, not news.
+  if (state.announced_is_out === null) {
+    return { post: false, next: { announced_is_out: isOut, pending_is_out: null, pending_since: null } };
+  }
+
+  // Agrees with what the channel already knows — nothing to say, and any
+  // half-armed flip is now disproven.
+  if (isOut === state.announced_is_out) {
+    return { post: false, next: { ...state, pending_is_out: null, pending_since: null } };
+  }
+
+  // Disagrees, and the previous tick disagreed the same way: two in a row.
+  if (state.pending_is_out === isOut) {
+    return { post: true, next: { announced_is_out: isOut, pending_is_out: null, pending_since: null } };
+  }
+
+  // First tick of a disagreement — arm it and wait one more tick.
+  return {
+    post: false,
+    next: { announced_is_out: state.announced_is_out, pending_is_out: isOut, pending_since: now },
+  };
+}

--- a/worker/test/transition.test.ts
+++ b/worker/test/transition.test.ts
@@ -1,0 +1,61 @@
+// Run with: npm test   (node:test + native TypeScript stripping, no deps)
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { INITIAL_NOTIFY_STATE, decideTransition, type NotifyState } from "../src/transition.ts";
+
+const NOW = "2026-07-28T00:00:00Z";
+
+/** Feed a tick sequence through the machine; return the ticks that announced. */
+function run(ticks: boolean[], from: NotifyState = INITIAL_NOTIFY_STATE): boolean[] {
+  let state = from;
+  const announced: boolean[] = [];
+  for (const isOut of ticks) {
+    const { post, next } = decideTransition(state, isOut, NOW);
+    if (post) announced.push(isOut);
+    state = next;
+  }
+  return announced;
+}
+
+test("first observation is adopted silently, not announced", () => {
+  const { post, next } = decideTransition(INITIAL_NOTIFY_STATE, true, NOW);
+  assert.equal(post, false);
+  assert.equal(next.announced_is_out, true);
+});
+
+test("a change announces only after it survives a second tick", () => {
+  assert.deepEqual(run([false, true]), [], "one disagreeing tick only arms pending");
+  assert.deepEqual(run([false, true, true]), [true]);
+});
+
+test("a single-tick flap is swallowed", () => {
+  const notOut: NotifyState = { announced_is_out: false, pending_is_out: null, pending_since: null };
+  // The real 2026-07-24 sequence: out, gone for one tick, out again. The old
+  // compare-to-previous-tick logic posted three times; this posts once.
+  assert.deepEqual(run([true, true, false, true, true], notOut), [true]);
+});
+
+test("both directions announce", () => {
+  assert.deepEqual(run([false, true, true, false, false]), [true, false]);
+});
+
+test("a confirmed state is not re-announced while it holds", () => {
+  assert.deepEqual(run([false, true, true, true, true, true]), [true]);
+});
+
+test("pending is cleared once the flip is disproven", () => {
+  const armed = decideTransition({ announced_is_out: false, pending_is_out: null, pending_since: null }, true, NOW);
+  assert.equal(armed.next.pending_is_out, true);
+  assert.equal(armed.next.pending_since, NOW);
+
+  const disproven = decideTransition(armed.next, false, NOW);
+  assert.equal(disproven.post, false);
+  assert.equal(disproven.next.pending_is_out, null);
+  assert.equal(disproven.next.pending_since, null);
+  assert.equal(disproven.next.announced_is_out, false);
+});
+
+test("a lost state object re-adopts silently instead of firing", () => {
+  assert.deepEqual(run([true, true], INITIAL_NOTIFY_STATE), []);
+});


### PR DESCRIPTION
`ML-OPS` — **FIELD REPORT**

# The alert you can argue with

> _Every 👍/⛅/👎 ever tapped on a "the mountain is out!" notification was thrown away. The bot could not read the message it was reacting to — and the feature had been shipped, documented, and believed for weeks._

> [!NOTE]
> **worker + bot** · feat · risk: medium — swaps the Discord delivery path; needs two Worker secrets set before deploy

The labeling loop had two surfaces. One posted a fresh frame every hour and asked you to classify it — 24 near-identical `Not Out (100.0%)` quiz posts a day. The other announced real visibility changes and, on paper, took the same reactions as corrections. The noisy one worked. The one worth answering was inert.

One Discord rule explains it: a bot without the privileged **Message Content** intent receives `embeds: []` for any message it did not author. Notifications came from a webhook, so `_labelable_message` read a `None` footer, found no capture key, and returned before recording anything. Confirmed against the live channel, not inferred — `GET /applications/@me` returns `flags: 0`, and fetching notification `1531508095682084936` with the bot token yields empty `embeds` while the bot's own posts come back whole.

> _"The highest-value label this project can collect is a 👎 on a false alarm — and that was exactly the one it dropped."_

## The fix: the Worker posts as the bot

- Delivery moves from `DISCORD_WEBHOOK_URL` to bot-token REST — `POST /channels/{id}/messages`, then three `PUT …/reactions/{emoji}/@me` to seed the vote. The notification becomes a message the bot authored, so the footer is readable, the label records, and the bot can edit its 🏷️ acknowledgment on. No privileged intent requested.
- **Both directions** — `🏔️ The mountain is out!` and `☁️ The mountain is gone`. The channel is the live answer, so it has to say when the answer stops being yes.
- **Two-tick debounce** (`worker/src/transition.ts`). Predictions flap: real history has *out* 16:46 → *gone* 17:01 → *out* 18:01, announced three times by the old compare-to-previous-tick logic. A change must now survive a second tick — ~15 min of latency for a channel where every post means something. State lives in `notify-state.json`; if it is lost or corrupt the Worker re-adopts current visibility **silently**, so it can never manufacture a false alert.
- **The frame is attached, not linked.** The embed pointed at `webcam_url` — `…/webcam2_latest.jpg` — so an old alert quietly showed a *newer* picture. You must be labeling the frame you can see.
- **The hourly quiz is gone.** `post_loop`, `next_post_due`, `in_daylight_window` and the window/timezone config are removed; `bot post-once` stays as a setup check.

## How it flows

```mermaid
flowchart TD
  tick["Worker cron */15 → PredictionState"] --> gate{"is_out differs from<br/>last announced?"}
  gate -- no --> quiet["clear pending · stay quiet"]
  gate -- "yes, 1st tick" --> arm["arm pending — flap guard"]
  arm --> quiet
  gate -- "yes, 2nd tick" --> persist["persist frame + METAR → R2<br/>standard capture key"]
  persist --> post["POST as the labeler bot<br/>frame attached · footer = capture key"]
  post --> seed["seed 👍 ⛅ 👎"]
  seed --> you(["you tap one"])
  you --> read["gateway bot reads its OWN embed<br/>— the part that used to come back empty"]
  read --> store[("labels.yaml + discord-events.jsonl")]
  store --> train["next just train"]
```

## Screens

No screenshots: the change is undeployed, so the live channel still shows the old format. The new embed carries **Confidence** and **Classification** inline, a **Right or wrong?** legend (`⛅ Partial · 👍 Full · 👎 Not Out`), the attached frame, and the capture key as its footer. A reaction adds **🏷️ Label** — *"New reaction (Not Out) recorded — 3/2004 training labels from Discord"*.

## Verification

- `cd worker && npm test` — 7 new tests pass, covering the real 2026-07-24 flap sequence, both-direction announcement, silent bootstrap, and pending-cleared-on-disproof.
- `npm run typecheck` clean · `uv run pytest` 135 passed, 2 skipped · `uvx ruff check . && uvx ruff format --check .` clean.
- The "replaying older images" report was checked and is **not** a bug — 12 consecutive posted frames hash distinct.

## Rollout

Secrets must land **before** the deploy, or notifications degrade to a logged skip and go silent.

- [ ] `cd worker && npx wrangler secret put DISCORD_BOT_TOKEN` (same value as `cf.env`)
- [ ] `npx wrangler secret put DISCORD_CHANNEL_ID`
- [ ] `npx wrangler deploy` — secrets only go live on the next deploy
- [ ] `npx wrangler secret delete DISCORD_WEBHOOK_URL`
- [ ] `nomad job restart mountain-labeler` — the running bot is still the hourly-posting build
- [ ] `curl -X POST …/notify-test`, then `npx wrangler tail --format json`

## Risk

Reactions on notifications posted *before* this change still do nothing — webhook-authored, unfixable retroactively. The first real change after deploy needs two ticks, since `notify-state.json` bootstraps by adopting current visibility silently. Label supply drops from ~24/day to the visibility-change rate (recently ~2–6/day) — deliberate; those are corrections on real predictions rather than busywork.

Rollback is `wrangler rollback` plus re-adding `DISCORD_WEBHOOK_URL`. Nothing in R2 changes shape and `notify-state.json` is ignored by the old code.

**Pre-existing, untouched:** `collect/tests/test_notebook_helpers.py` fails to import `get_job_captures`, so bare `uv run pytest` is red on `main` too. CI runs only ruff, so it is invisible there.
