### PR TITLE
fix(ci): the rules changed underneath us

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+      # Ruff is PINNED. Unpinned `uvx ruff` resolves the latest release, so a
+      # ruff version bump can turn this gate red with zero code change — which
+      # is exactly what 0.16.0 did on 2026-07-26 by expanding its DEFAULT rule
+      # selection. Bump this deliberately, in a PR, alongside the matching rev
+      # in .pre-commit-config.yaml and the rule set in pyproject [tool.ruff].
       - name: Ruff lint
-        run: uvx ruff check --output-format=github .
+        run: uvx ruff@0.16.0 check --output-format=github .
       - name: Ruff format check
-        run: uvx ruff format --check .
+        run: uvx ruff@0.16.0 format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,12 @@
 # Canonical pre-commit config — source of truth: robogeosociety/.github, synced by scripts/sync.sh.
 # One-time per clone:   uv tool install pre-commit && pre-commit install
-# Ruff version here is kept in lockstep with the ruff run in CI.
+# Ruff version here is kept in lockstep with the ruff run in CI — that promise was
+# not being kept: this pinned v0.12.0 while CI's unpinned `uvx ruff` floated to the
+# latest release. Both now pin 0.16.0; bump them together.
 minimum_pre_commit_version: "3.5.0"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
+    rev: v0.16.0
     hooks:
       - id: ruff          # lint (auto-fixes locally; CI only checks)
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,22 @@ collect = "collect.collector:cli"
 classify = "collect.classifier:cli_wrapper"
 bot = "bot.main:cli"
 
+[tool.ruff.lint]
+# The rule set is DECLARED, not inherited. Ruff's implicit default is a moving
+# target: 0.16.0 widened it from these four families to ~40 (BLE, S, UP, LOG,
+# PL, DTZ, RUF…), which surfaced 245 findings in untouched code and turned CI
+# red without a single line changing. This pins the gate's meaning; the version
+# is pinned separately in .github/workflows/lint.yml.
+#
+# E4/E7/E9 (import, statement and runtime pycodestyle errors) + F (pyflakes)
+# were ruff's default through 0.15.x and are what this codebase has always been
+# held to. Widening it is a deliberate, separate change — `ruff check
+# --select I,UP --fix` alone rewrites ~90 lines across 32 files, and the
+# behavioral families (BLE001 blind-except, S110 try-except-pass) mark
+# intentional best-effort error handling that must be reviewed case by case,
+# not swept.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.setuptools]
 packages = ["train", "collect", "bot"]
 


### PR DESCRIPTION
`CI` — **POST-MORTEM**

# The rules changed underneath us

> _Nobody touched the code. `ruff` shipped 0.16.0, quietly widened what it checks by default, and an unpinned CI gate went red across 32 files it had passed the day before._

> [!NOTE]
> **ci** · fix · risk: low — config only, no source file touched

The Lint check has been failing on `main` since 2026-07-26 (`d19cdaf`..`ec42e75`), through five consecutive runs and every PR since. The diff that caused it does not exist.

`.github/workflows/lint.yml` ran `uvx ruff check .` — unpinned, so CI resolves whatever ruff released most recently. On 2026-07-26 that became **0.16.0**, which widened ruff's *default* rule selection from four families to roughly forty (`BLE`, `S`, `UP`, `LOG`, `PL`, `DTZ`, `RUF`…). The repo carries no `[tool.ruff]` section, so it inherited the new defaults wholesale: **245 findings across 32 untouched files**.

> _"An unpinned linter with an undeclared rule set isn't a quality gate — it's a subscription to someone else's opinions."_

## Two things were floating. Both are now nailed down.

- **The rule set is declared.** `pyproject.toml` gains `[tool.ruff.lint] select = ["E4", "E7", "E9", "F"]` — ruff's own default through 0.15.x, and the bar this codebase has actually been held to since the gate was added. What CI means no longer depends on ruff's release notes.
- **The version is pinned.** `lint.yml` runs `uvx ruff@0.16.0`, and `.pre-commit-config.yaml` moves `v0.12.0` → `v0.16.0`. That file's header already promised "kept in lockstep with the ruff run in CI"; it was pinned three minor versions behind a target that floated. Now they match, and a bump is a reviewed change rather than a Tuesday.

**No source file is modified.** Adopting the wider rule set is a real decision with a real cost, and it is not this PR's: `ruff check --select I,UP --fix` alone rewrites ~90 lines across 32 files, and the behavioral families are not mechanical — `BLE001` (50 hits) and `S110` (14) mark deliberate best-effort error handling, the kind that has to be read one at a time or silenced with a reasoned `# noqa`, never swept.

## What decides pass/fail now

```mermaid
flowchart TD
  push["push / PR"] --> ver{"ruff version"}
  ver -- "was: uvx ruff = latest" --> drift["drifts on its own → 0.16.0"]
  ver -- "now: uvx ruff@0.16.0" --> fixed["moves only when lint.yml does"]
  drift --> rules
  fixed --> rules{"rule set"}
  rules -- "was: unset = ruff defaults" --> red["~40 families · 245 findings · red"]
  rules -- "now: select in pyproject" --> green["E4 · E7 · E9 · F · clean"]
```

## Verification

Exact CI commands, on this branch: `uvx ruff@0.16.0 check --output-format=github .` clean · `uvx ruff@0.16.0 format --check .` 61 files formatted · `uv run pytest --ignore=collect/tests/test_notebook_helpers.py` 140 passed, 2 skipped.

Diagnosis confirmed on unmodified `main`: `ruff@0.15.16 check .` passes, `ruff@0.16.0 check .` reports 245 errors, `ruff@0.16.0 check . --select E4,E7,E9,F` passes. The code was never the variable.

## Risk & follow-ups

Config only — three lines, nothing to roll back. The gate is now *narrow and explicit* rather than *wide and accidental*, enforcing exactly what it did last week, on purpose.

- **Both edited files are copies of org canon** — `lint.yml` is headed "Canonical ruff CI check", and `.pre-commit-config.yaml` names `robogeosociety/.github` as its source of truth, synced by `scripts/sync.sh`. Every repo synced from that template is red for this same reason, and the next sync will undo this unless it goes upstream too.
- **Adopting more rules** (`I` and `UP` are safe and auto-fixable; `BLE`/`S`/`LOG` are not) deserves its own PR against a stable baseline.
- **Separately red:** `collect/tests/test_notebook_helpers.py` can't import `get_job_captures`, aborting bare `uv run pytest` at collection. Fixed in its own session; untouched here.
