### PR TITLE
test(collect): revive the notebook_helpers tests and put pytest in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+# Runs the pytest suite on every PR and every push to main. Mirrors the ruff job's
+# style in lint.yml (checkout + astral-sh/setup-uv), but lives in its own workflow so
+# lint.yml stays a drop-in copy of the canonical ruff check.
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Pytest
+        run: uv run pytest -q

--- a/collect/tests/test_notebook_helpers.py
+++ b/collect/tests/test_notebook_helpers.py
@@ -7,7 +7,6 @@ import yaml
 
 from collect.notebook_helpers import CaptureBrowser, load_labels, save_labels
 
-
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------

--- a/collect/tests/test_notebook_helpers.py
+++ b/collect/tests/test_notebook_helpers.py
@@ -1,102 +1,230 @@
+"""Tests for collect.notebook_helpers — stubs ipywidgets so no kernel is needed."""
+
 import json
+
 import pytest
-from unittest.mock import patch
-from collect.notebook_helpers import (
-    get_job_captures,
-    get_job_status,
-    CaptureBrowser,
-    get_directory_captures,
-    get_upcoming_schedule,
-)
+import yaml
+
+from collect.notebook_helpers import CaptureBrowser, load_labels, save_labels
 
 
-@pytest.fixture
-def temp_log(tmp_path):
-    log_file = tmp_path / "collection.log"
-    return log_file
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
 
 
-def test_get_job_captures_empty(temp_log):
-    assert get_job_captures(temp_log) == []
+class _Widget:
+    """Stand-in for any ipywidgets widget: accepts anything, records attributes."""
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.__dict__.update(kwargs)
+        self.children = []
+
+    def on_click(self, _callback):
+        pass
 
 
-def test_get_job_captures_valid(temp_log):
-    entry = {
-        "timestamp": "2026-02-23T12:00:00Z",
+class _WidgetsStub:
+    """Returns a fresh `_Widget` for every `widgets.X(...)` lookup."""
+
+    def __getattr__(self, _name):
+        return _Widget
+
+
+@pytest.fixture()
+def log_path(tmp_path):
+    return tmp_path / "collection.log"
+
+
+@pytest.fixture()
+def browser(log_path, tmp_path, monkeypatch):
+    """A CaptureBrowser with ipywidgets/display stubbed out."""
+    monkeypatch.setattr("collect.notebook_helpers.widgets", _WidgetsStub())
+    monkeypatch.setattr("collect.notebook_helpers.display", lambda *_: None)
+    return CaptureBrowser(log_path=str(log_path), data_root=str(tmp_path / "data"))
+
+
+def write_log(path, *entries):
+    """Writes JSONL entries (dicts, or raw strings for malformed lines)."""
+    lines = [e if isinstance(e, str) else json.dumps(e) for e in entries]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def capture_entry(timestamp, image_path, metar_path="data/metar.txt"):
+    return {
+        "timestamp": timestamp,
         "event": "CAPTURE",
         "status": "SUCCESS",
-        "metadata": {
-            "image_path": "data/test.jpg",
-            "step_index": 1,
-            "metar_path": "data/metar.txt",
-        },
+        "metadata": {"image_path": image_path, "metar_path": metar_path},
     }
-    temp_log.write_text(json.dumps(entry) + "\n")
-
-    captures = get_job_captures(temp_log)
-    assert len(captures) == 1
-    assert captures[0]["step"] == 1
-    assert captures[0]["path"] == "data/test.jpg"
 
 
-def test_get_job_status_valid(temp_log):
-    entry = {
-        "event": "PROGRESS",
-        "status": "STATUS",
-        "metadata": {"progress": 5, "total": 10, "percentage": 50.0},
-    }
-    temp_log.write_text(json.dumps(entry) + "\n")
-
-    status = get_job_status(temp_log)
-    assert status["progress"] == 5
-    assert status["total"] == 10
+# ---------------------------------------------------------------------------
+# labels.yaml round-trip
+# ---------------------------------------------------------------------------
 
 
-def test_get_job_status_missing(temp_log):
-    assert get_job_status(temp_log) is None
+def test_load_labels_missing_file(tmp_path):
+    assert load_labels(tmp_path) == {}
 
 
-def test_get_directory_captures(tmp_path):
-    # Create mock structure
-    date_dir = tmp_path / "20260223"
-    date_dir.mkdir()
-    cap_dir = date_dir / "120000"
-    cap_dir.mkdir()
-    img_dir = cap_dir / "images"
-    img_dir.mkdir()
-    (img_dir / "test.jpg").write_text("fake image")
-
-    metar_dir = cap_dir / "metar"
-    metar_dir.mkdir()
-    (metar_dir / "metar.txt").write_text("KSEA 231200Z")
-
-    caps = get_directory_captures(tmp_path)
-    assert len(caps) == 1
-    assert caps[0]["metar"] is not None
-    assert "test" in caps[0]["path"]
+def test_load_labels_empty_file(tmp_path):
+    (tmp_path / "labels.yaml").write_text("")
+    assert load_labels(tmp_path) == {}
 
 
-@patch("collect.notebook_helpers.widgets")
-@patch("collect.notebook_helpers.display")
-def test_capture_browser_init(mock_display, mock_widgets, temp_log):
-    browser = CaptureBrowser(log_path=str(temp_log))
-    assert browser.log_path == str(temp_log)
+def test_save_then_load_labels_roundtrip(tmp_path):
+    labels = {"20260223/120000_us_UTC/images/a.jpg": 1, "b.jpg": 0}
+    save_labels(tmp_path, labels)
+    assert load_labels(tmp_path) == labels
+
+
+def test_save_labels_writes_yaml(tmp_path):
+    save_labels(tmp_path, {"a.jpg": 2})
+    assert yaml.safe_load((tmp_path / "labels.yaml").read_text()) == {"a.jpg": 2}
+
+
+# ---------------------------------------------------------------------------
+# CaptureBrowser construction
+# ---------------------------------------------------------------------------
+
+
+def test_init_stores_paths_and_defaults(browser, log_path):
+    assert browser.log_path == log_path
+    assert browser.batch_size == 20
     assert browser.all_captures == []
+    assert browser.current_page == 0
 
 
-@patch("collect.notebook_helpers.widgets")
-@patch("collect.notebook_helpers.display")
-@patch("collect.notebook_helpers.plt")
-def test_render_control_panel(mock_plt, mock_display, mock_widgets, temp_log):
-    browser = CaptureBrowser(log_path=str(temp_log))
-    browser.render_control_panel()
-    assert mock_widgets.VBox.called
-    # It now sets children instead of calling display
-    assert browser.control_container.children != []
+# ---------------------------------------------------------------------------
+# CaptureBrowser._load_captures
+# ---------------------------------------------------------------------------
 
 
-@patch("pathlib.Path.exists")
-def test_get_upcoming_schedule_missing(mock_exists):
-    # Mock files as NOT existing
-    mock_exists.return_value = False
-    assert get_upcoming_schedule() == []
+def test_load_captures_missing_log(browser):
+    assert browser._load_captures() == []
+
+
+def test_load_captures_reads_successful_capture(browser, log_path):
+    write_log(log_path, capture_entry("2026-02-23T12:00:00Z", "data/test.jpg"))
+
+    assert browser._load_captures() == [
+        {
+            "timestamp": "2026-02-23T12:00:00Z",
+            "image": "data/test.jpg",
+            "metar": "data/metar.txt",
+        }
+    ]
+
+
+def test_load_captures_metar_is_optional(browser, log_path):
+    entry = capture_entry("2026-02-23T12:00:00Z", "data/test.jpg")
+    del entry["metadata"]["metar_path"]
+    write_log(log_path, entry)
+
+    assert browser._load_captures()[0]["metar"] is None
+
+
+def test_load_captures_sorts_newest_first(browser, log_path):
+    write_log(
+        log_path,
+        capture_entry("2026-02-23T12:00:00Z", "old.jpg"),
+        capture_entry("2026-02-23T14:00:00Z", "new.jpg"),
+        capture_entry("2026-02-23T13:00:00Z", "mid.jpg"),
+    )
+
+    assert [c["image"] for c in browser._load_captures()] == [
+        "new.jpg",
+        "mid.jpg",
+        "old.jpg",
+    ]
+
+
+def test_load_captures_ignores_other_events_and_failures(browser, log_path):
+    failed = capture_entry("2026-02-23T12:00:00Z", "failed.jpg")
+    failed["status"] = "FAILURE"
+    progress = capture_entry("2026-02-23T12:30:00Z", "progress.jpg")
+    progress["event"] = "PROGRESS"
+    write_log(
+        log_path, failed, progress, capture_entry("2026-02-23T13:00:00Z", "ok.jpg")
+    )
+
+    assert [c["image"] for c in browser._load_captures()] == ["ok.jpg"]
+
+
+def test_load_captures_skips_malformed_lines(browser, log_path):
+    write_log(
+        log_path,
+        "not json at all",
+        {"event": "CAPTURE", "status": "SUCCESS"},  # no metadata key
+        capture_entry("2026-02-23T13:00:00Z", "ok.jpg"),
+    )
+
+    assert [c["image"] for c in browser._load_captures()] == ["ok.jpg"]
+
+
+# ---------------------------------------------------------------------------
+# CaptureBrowser.refresh_ui
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_ui_empty_log_shows_placeholder(browser):
+    browser.refresh_ui()
+
+    assert browser.all_captures == []
+    assert "<b>Total Captures:</b> 0" in browser.status_label.value
+    assert len(browser.grid_container.children) == 1
+
+
+def test_refresh_ui_renders_one_tile_per_capture(browser, log_path, tmp_path):
+    image = tmp_path / "shot.jpg"
+    image.write_bytes(b"\xff\xd8\xff not-really-a-jpeg")
+    metar = tmp_path / "metar.txt"
+    metar.write_text("KSEA 231200Z 10SM CLR\n")
+    write_log(
+        log_path,
+        capture_entry("2026-02-23T12:00:00Z", str(image), str(metar)),
+        capture_entry("2026-02-23T13:00:00Z", str(image), str(metar)),
+    )
+
+    browser.refresh_ui()
+
+    assert len(browser.all_captures) == 2
+    assert len(browser.grid_container.children) == 2
+    assert "<b>Showing:</b> 1-2" in browser.status_label.value
+
+
+def test_refresh_ui_skips_captures_whose_image_is_gone(browser, log_path, tmp_path):
+    image = tmp_path / "shot.jpg"
+    image.write_bytes(b"\xff\xd8\xff not-really-a-jpeg")
+    write_log(
+        log_path,
+        capture_entry("2026-02-23T12:00:00Z", str(image), None),
+        capture_entry("2026-02-23T13:00:00Z", str(tmp_path / "vanished.jpg"), None),
+    )
+
+    browser.refresh_ui()
+
+    # Both captures are indexed; only the readable one is rendered.
+    assert len(browser.all_captures) == 2
+    assert len(browser.grid_container.children) == 1
+
+
+def test_refresh_ui_paginates_by_batch_size(browser, log_path, tmp_path):
+    image = tmp_path / "shot.jpg"
+    image.write_bytes(b"\xff\xd8\xff not-really-a-jpeg")
+    browser.batch_size = 2
+    write_log(
+        log_path,
+        *[capture_entry(f"2026-02-23T1{i}:00:00Z", str(image), None) for i in range(5)],
+    )
+
+    browser.refresh_ui()
+    assert len(browser.grid_container.children) == 2
+    assert "<b>Showing:</b> 1-2" in browser.status_label.value
+
+    browser.current_page = 2
+    browser.refresh_ui()
+    assert len(browser.grid_container.children) == 1
+    assert "<b>Showing:</b> 5-5" in browser.status_label.value


### PR DESCRIPTION
Test suite

# The whole suite has been dark since March, and nothing noticed

> _One stale import in `collect/tests/test_notebook_helpers.py` aborted pytest at collection time — so `uv run pytest` ran zero tests. This rewrites the file against the module's real API and adds a pytest job to CI so it can't happen silently again._

> [!NOTE]
> **area:** collect / CI · **type:** test + chore · **risk:** low — test-only code plus one new workflow; no runtime or model behavior changes.

`collect/notebook_helpers.py` was rewritten in `53f2ced` ("Launch Phase 2: 30-day diffuse spring collection plan"), which cut `get_job_captures`, `get_job_status`, `get_directory_captures`, `get_upcoming_schedule`, the `matplotlib` import, and `CaptureBrowser.render_control_panel`. The test file was never updated, so its top-level `from collect.notebook_helpers import (...)` has raised `ImportError: cannot import name 'get_job_captures'` ever since.

That import runs during pytest **collection**, which means it doesn't fail one test — it aborts the run. A bare `uv run pytest` from the repo root reported `1 error during collection` and executed nothing. Until now no workflow ran pytest at all, so CI never saw it. Four months of commits landed on `main` with the suite effectively switched off.

## What changed

**Tests rewritten against the module that actually exists.** The removed helpers are genuinely gone — nothing in the repo calls them — so the file now covers today's public surface: `load_labels`, `save_labels`, and `CaptureBrowser` (`_load_captures`, `refresh_ui`). Coverage goes wider than the old file: newest-first ordering, malformed-JSON lines skipped, non-`CAPTURE`/`FAILURE` entries filtered out, optional `metar_path`, captures whose image file has vanished, and `batch_size` pagination including the final short page. 15 tests, up from 7.

**No kernel required.** `ipywidgets` and `IPython.display` are stubbed with `monkeypatch` via a tiny `_WidgetsStub`, so `refresh_ui` can be asserted on (`grid_container.children`, `status_label.value`) without a live notebook.

**A pytest job in CI.** New `.github/workflows/test.yml` runs `uv run pytest -q` on every PR and every push to `main`, using `actions/checkout@v4` + `astral-sh/setup-uv@v5` to match the ruff job's style. It's a separate workflow on purpose: `lint.yml` carries a header comment marking it a canonical drop-in ruff check copied across repos, and grafting a project-specific test job into it would break that.

## How it flows

```mermaid
graph TD
    A[uv run pytest] --> B[Collection phase]
    B --> C{"import collect.tests.test_notebook_helpers"}
    C -->|before: imports 5 deleted symbols| D["ImportError<br/>1 error during collection"]
    D --> E["0 tests run — suite silently dark"]
    C -->|after: imports load_labels / save_labels / CaptureBrowser| F[Collection succeeds]
    F --> G[Full suite executes]
    G --> H["New: Test workflow gates every PR and push to main"]
```

## Verification

The new workflow ran on this PR and passed on its first execution, before the rebase onto current `main`:

```
155 passed, 2 skipped, 1 warning in 18.85s
```

Collection is clean — no `error during collection`, which was the bug. `collect/tests/test_notebook_helpers.py` alone contributes **15 passed**. The CPU-wheel pin behaved as intended on the runner: 160 packages installed in 459ms, no CUDA payload, whole job green in 37s.

Since then this branch has merged current `main` (`f8c1009`), picking up #89/#93/#94/#95/#96. Re-run locally after the merge: **158 passed, 2 skipped**, collection still clean — the 3 extra come from `train/tests/test_scheduled.py`, which arrived with #94 and collects fine alongside this change. Lint is clean under the now-pinned gate: `uvx ruff@0.16.0 check .` → `All checks passed!`, `format --check` → `61 files already formatted`.

## Risk & rollout

Test-only code plus one additive workflow; nothing in `collect/`, `train/`, `worker/`, or `bot/` changes, so there is no runtime, model, or deploy impact and rollback is a plain revert.

Worth knowing for whoever watches the first few runs: `test.yml` installs the full dependency set including torch, and four tests in `train/tests/test_model.py` construct `convnext_tiny` with `pretrained=True`, which fetches weights from HuggingFace at test time. They pass on GitHub runners (proven by the green run above) but fail anywhere outbound access to `huggingface.co` is blocked. That's a pre-existing property of those tests, not something this PR introduces — but it does mean the new job is the first thing in CI that depends on Hub reachability.

**Follow-up, deliberately not here:** `captures.ipynb` is broken the same way the tests were — it still does `from collect.notebook_helpers import CaptureBrowser, get_data_root`, and `get_data_root` was deleted by that same `53f2ced`. Fixing it means deciding what data-root resolution should look like now, which is a scope call. Flagging it so it doesn't stay invisible for another four months.