### PR TITLE
ci: pin ruff so the lint gate stops drifting with upstream releases

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,14 @@ on:
   push:
     branches: [main]
 
+# Pin ruff. `uvx ruff` resolves the newest release at run time, so the repo's lint
+# policy silently changes whenever ruff ships new default rules. That is what turned
+# main red on 2026-07-26: 0.16.0 widened the default rule set, and 245 findings the
+# project had never opted into appeared with no source change. Bump this deliberately,
+# with the resulting fixes in the same PR, rather than letting a release do it mid-flight.
+env:
+  RUFF_VERSION: "0.15.8"
+
 jobs:
   ruff:
     runs-on: ubuntu-latest
@@ -16,6 +24,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Ruff lint
-        run: uvx ruff check --output-format=github .
+        run: uvx ruff@${{ env.RUFF_VERSION }} check --output-format=github .
       - name: Ruff format check
-        run: uvx ruff format --check .
+        run: uvx ruff@${{ env.RUFF_VERSION }} format --check .


### PR DESCRIPTION
CI

# `main` has been red for three days, and nobody changed any code

> _`lint.yml` runs an unpinned `uvx ruff`, so the repo's lint policy is whatever ruff shipped most recently. 0.16.0 widened the default rule set and 245 findings appeared out of nowhere. Pinning the version turns CI green without touching a single source file._

> [!NOTE]
> **area:** CI · **type:** chore · **risk:** low — one workflow file; no source, runtime, or deploy changes.

The repo has no `[tool.ruff]` block and no `ruff.toml`, so it inherits ruff's built-in defaults wholesale. `uvx ruff` resolves the newest release at run time. Put those together and the lint gate's definition of "clean" changes on ruff's release schedule, not this project's.

On 2026-07-26 that bill came due. ruff 0.16.0 widened its default rule set, and `main` went from green to 245 findings across ~25 files — `I001`, `UP006/UP007/UP017/UP035/UP045`, `BLE001`, `S110/S112`, `LOG015`, `DTZ005`, `PERF102`, `RUF046`, `PLW1509/PLW1510`, `SIM102/SIM117`, `PIE790/PIE810`, `C414`, `EXE001`. None of them were opted into, and no commit caused them.

| commit | date | ruff |
| --- | --- | --- |
| `2b95999` | 2026-07-04 | ✅ |
| `742fe18` | 2026-07-04 | ✅ |
| `55f2062` | 2026-07-26 | ❌ |
| … 4 more pushes … | 2026-07-26 | ❌ |
| `ec42e75` (current `main`) | 2026-07-26 | ❌ |

A permanently-red gate is worse than no gate: it trains everyone to scroll past the ❌, which is exactly how the pytest breakage in #91 sat unnoticed on `main` for four months.

## What changed

**One file, `.github/workflows/lint.yml`.** A `RUFF_VERSION: "0.15.8"` env var, consumed as `uvx ruff@${{ env.RUFF_VERSION }}` by both the lint and format steps, plus a comment explaining why the pin exists so the next person doesn't "helpfully" remove it.

**Deliberately a freeze, not a decision.** 0.15.8 is the last version `main` was green under. This PR restores a trustworthy signal and buys time; it does not rule on whether the repo *wants* 0.16.0's stricter defaults.

## How it flows

```mermaid
graph TD
    A[push or PR] --> B[lint.yml]
    B --> C{"uvx ruff — version resolved how?"}
    C -->|before: unpinned, newest at run time| D["ruff 0.16.0 arrives 2026-07-26"]
    D --> E["245 findings, main red, no source change"]
    C -->|after: uvx ruff@RUFF_VERSION| F["ruff 0.15.8, always"]
    F --> G[green gate — drift only on a deliberate bump]
```

## Verification

Both ruff versions run locally against `main`'s tree at `ec42e75`, no cache:

```
uvx ruff@0.15.8 check .          →  All checks passed!
uvx ruff@0.15.8 format --check . →  48 files already formatted
uvx ruff@0.16.0 check .          →  Found 245 errors.
```

So the pin alone is sufficient — zero source files need to change for this gate to go green. The 245/0 split is also the proof that the failure was never about anyone's code.

## Risk & rollout

Changes one workflow file. No source, no dependencies, no deploy path, no runtime behavior; rollback is a revert. The pin can only make CI *more* permissive than it is today, so it cannot mask a regression that the gate was previously catching — it restores the exact rule set `main` was verified against through 2026-07-04.

**The real trade-off:** pinning means the repo stops picking up new ruff rules for free, and stale pins rot quietly. The comment in the workflow is the mitigation — it says to bump deliberately, with the resulting fixes in the same PR.

**Follow-up, deliberately not here:** adopting 0.16.0's defaults. 112 of the 245 are `--fix`-able and 9 more need `--unsafe-fixes`, but the residue needs judgment rather than a sweep — `BLE001` and `S110` on `except Exception: pass` are load-bearing in the collector's retry and METAR-fetch paths, not lint noise. That wants its own PR where the bump and the fixes land together. An explicit `[tool.ruff]` `select` block is the more durable end state if the repo would rather pin the rules than the binary.

Diagnosed while working #91; that PR is unaffected by this one and its `pytest` job passes independently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvQ3BFPUoaFXmqiXKaPaW1)_