### PR TITLE
feat(train): live checkpoint telemetry with memory

### DIFF
--- a/TRAINING.md
+++ b/TRAINING.md
@@ -20,8 +20,8 @@ the mountain-specific instance.
 
    Labels arrive from two surfaces that share one `labels.yaml` (union-merged,
    R2 as source of truth): the bulk classifier UI (`uv run classify start`) and
-   the Discord reaction-labeling bot (👍/⛅/👎 on hourly webcam posts — see
-   `BOT.md`). A batch run picks both up with no extra flags.
+   the Discord reaction-labeling bot (👍/⛅/👎 on the Worker's alerts and
+   label requests — see `BOT.md`). A batch run picks both up with no extra flags.
 
    **Scheduled runs:** the robogeosociety/supervisor fires
    `scripts/scheduled-train.sh` (→ `python -m train.scheduled`) on the mini
@@ -53,3 +53,27 @@ the mountain-specific instance.
    previously tracked, which dirtied the mini's checkout on every scheduled
    run and let the committed copy drift stale; R2 `checkpoints/` is the single
    source of truth and `load_checkpoint` falls back to it.
+
+## Run telemetry
+
+An unattended run reports to #mountain as it goes (`train/scheduled.py`), not
+just at the end:
+
+- **One start message**, edited in place with the final metrics when the run
+  finishes — best val loss and accuracy vs the previous run, dataset counts,
+  duration breakdown, and **peak memory**.
+- **One message per saved checkpoint**, posted live. Only an *improvement*
+  saves a checkpoint, so a 5-epoch run posts ~3: epoch, val loss with the delta
+  over the previous best, val accuracy, epoch time, memory, and how many of the
+  3 checkpoint files reached R2.
+
+The mechanism is `training batch --progress-jsonl PATH`: the trainer appends one
+fsync'd JSON line per epoch (metrics + `memory_snapshot()` + whether a checkpoint
+was saved), and the scheduler tails that file while the subprocess runs. Without
+the flag the trainer writes nothing extra, so an interactive `just train` is
+unchanged.
+
+Memory probes are best-effort and platform-shaped — peak RSS via `getrusage`
+(bytes on macOS, kilobytes on Linux; both handled), plus MPS allocated/driver or
+CUDA allocated/peak when present. A probe that fails is omitted, never fatal.
+

--- a/train/scheduled.py
+++ b/train/scheduled.py
@@ -8,10 +8,14 @@ whether to RUN, following the fleet's cheap-no-op convention:
    `labels/train-watermark.json`; exit 0 quietly when nothing is new.
 2. Refresh `data/labels.yaml` from R2 (`collect sync labels pull`), post a
    start embed to #mountain (bot-token REST — no gateway needed), then run
-   `training batch --json-summary` and trust the summary file, not stdout.
-3. Success → advance the watermark and edit the embed with metrics (including
-   the best-val-loss delta vs the previous run). Failure → edit the embed with
-   the error and leave the watermark, so next week retries the same delta.
+   `training batch --json-summary --progress-jsonl` and trust those files, not
+   stdout.
+3. While it runs, tail the progress jsonl and post each SAVED CHECKPOINT as its
+   own message (~3 per 5-epoch run — only improvements save), with per-epoch
+   metrics and memory.
+4. Success → advance the watermark and edit the start embed with final metrics
+   (best-val-loss delta vs the previous run, peak memory). Failure → edit it
+   with the error and leave the watermark, so next week retries the same delta.
 
 Run via scripts/scheduled-train.sh (sources cf.env). Discord being down never
 fails a training run — telemetry is best-effort.
@@ -24,6 +28,8 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -137,6 +143,78 @@ def _acc_delta_text(acc: float | None, previous: float | None) -> str:
     return f"{acc:.1%} — {arrow} {abs(delta_pt):.1f}pt vs last ({previous:.1%})"
 
 
+def _gb(mb: float) -> str:
+    return f"{mb / 1024:.2f} GB"
+
+
+def _memory_text(memory: Mapping[str, Any] | None) -> str:
+    """Render whatever probes came back — see scheduler.memory_snapshot()."""
+    if not memory:
+        return "n/a"
+    parts = []
+    if memory.get("rss_peak_mb"):
+        parts.append(f"peak RSS {_gb(memory['rss_peak_mb'])}")
+    if memory.get("mps_allocated_mb"):
+        mps = f"MPS {_gb(memory['mps_allocated_mb'])}"
+        if memory.get("mps_driver_mb"):
+            mps += f" ({_gb(memory['mps_driver_mb'])} driver)"
+        parts.append(mps)
+    if memory.get("cuda_allocated_mb"):
+        parts.append(f"CUDA {_gb(memory['cuda_allocated_mb'])}")
+    return " · ".join(parts) or "n/a"
+
+
+def peak_memory(per_epoch: list[dict]) -> dict:
+    """High-water mark across epochs, key by key."""
+    peak: dict[str, float] = {}
+    for epoch in per_epoch:
+        for key, value in (epoch.get("memory") or {}).items():
+            if isinstance(value, int | float):
+                peak[key] = max(peak.get(key, 0.0), float(value))
+    return peak
+
+
+def checkpoint_embed(record: Mapping[str, Any]) -> dict:
+    """One saved checkpoint, posted as its own message while the run continues.
+
+    Only an improvement saves a checkpoint, so this fires ~3x in a 5-epoch run —
+    a progress trail you can watch, not a per-epoch firehose.
+    """
+    val_loss = float(record.get("val_loss", 0.0))
+    previous = record.get("previous_best_val_loss")
+    delta = (
+        "first checkpoint this run"
+        if previous is None
+        else f"▼ {float(previous) - val_loss:.4f} better than {float(previous):.4f}"
+    )
+    keys = record.get("checkpoint_keys") or []
+    return {
+        "title": f"💾 Checkpoint saved — epoch {record.get('epoch', '?')}/{record.get('total_epochs', '?')}",
+        "color": COLOR_OK if len(keys) == 3 else COLOR_FAILED,
+        "fields": [
+            {"name": "Val loss", "value": f"{val_loss:.4f} — {delta}", "inline": False},
+            {
+                "name": "Val accuracy",
+                "value": f"{float(record.get('val_acc', 0.0)):.1%}",
+                "inline": True,
+            },
+            {
+                "name": "Epoch time",
+                "value": f"{float(record.get('duration_s', 0.0)) / 60:.1f} min",
+                "inline": True,
+            },
+            {
+                "name": "Memory",
+                "value": _memory_text(record.get("memory")),
+                "inline": False,
+            },
+            {"name": "Uploaded", "value": f"{len(keys)}/3 files → R2", "inline": True},
+        ],
+        "footer": {"text": "is-the-mountain-out • scheduled training"},
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
 def _duration_text(duration_s: float, summary: dict) -> str:
     """Total wall time with the prefetch/epoch breakdown when the summary has it."""
     parts = [f"{duration_s / 60:.0f} min total"]
@@ -209,6 +287,11 @@ def result_embed(
                 "value": _duration_text(duration_s, summary),
                 "inline": True,
             },
+            {
+                "name": "Peak memory",
+                "value": _memory_text(peak_memory(per_epoch)),
+                "inline": False,
+            },
             {"name": "Checkpoint", "value": checkpoint, "inline": False},
         ],
         "footer": {"text": "is-the-mountain-out • scheduled training"},
@@ -274,6 +357,18 @@ class Telemetry:
             "POST", f"{DISCORD_API}/channels/{self.channel_id}/messages", embed
         )
 
+    def post_standalone(self, embed: dict) -> None:
+        """Post a message that is NOT the run's main message.
+
+        Checkpoints are their own posts, so they must not capture
+        `message_id` — the final result still edits the start message.
+        """
+        if not self.enabled:
+            return
+        self._request(
+            "POST", f"{DISCORD_API}/channels/{self.channel_id}/messages", embed
+        )
+
     def update(self, embed: dict) -> None:
         if not self.enabled:
             return
@@ -285,6 +380,44 @@ class Telemetry:
             f"{DISCORD_API}/channels/{self.channel_id}/messages/{self.message_id}",
             embed,
         )
+
+
+# ---------- Live progress (tail the trainer's JSONL while it runs) ----------
+
+PROGRESS_POLL_SECONDS = 15
+
+
+def drain_progress(path: Path, offset: int, telemetry: Telemetry) -> int:
+    """Post any newly-completed checkpoint lines; return the new byte offset.
+
+    Reads bytes, not lines, and stops at the last newline: the trainer appends
+    while we read, so a partial final line is left for the next poll rather
+    than parsed as truncated JSON. Never raises — losing a progress post must
+    not abort a training run that is otherwise fine.
+    """
+    try:
+        if not path.exists():
+            return offset
+        with open(path, "rb") as handle:
+            handle.seek(offset)
+            chunk = handle.read()
+    except OSError as exc:
+        print(f"telemetry: progress read failed (non-fatal): {exc}")
+        return offset
+
+    complete = chunk.rfind(b"\n") + 1
+    if complete <= 0:
+        return offset
+    for raw in chunk[:complete].splitlines():
+        if not raw.strip():
+            continue
+        try:
+            record = json.loads(raw)
+        except ValueError:
+            continue
+        if isinstance(record, dict) and record.get("checkpoint_saved"):
+            telemetry.post_standalone(checkpoint_embed(record))
+    return offset + complete
 
 
 # ---------- The run ----------
@@ -348,8 +481,14 @@ def main(config: str, data_root: str, check: bool) -> None:
         telemetry.update(failure_embed(len(pending), "labels pull from R2 failed"))
         raise click.ClickException("labels pull failed; aborting before training")
 
-    summary_path = Path(tempfile.mkdtemp(prefix="mountain-train-")) / "summary.json"
-    result = subprocess.run(
+    run_dir = Path(tempfile.mkdtemp(prefix="mountain-train-"))
+    summary_path = run_dir / "summary.json"
+    progress_path = run_dir / "progress.jsonl"
+
+    # Popen, not run(): the trainer takes ~an hour, and the point of the
+    # progress file is to report checkpoints WHILE it works rather than
+    # reconstructing them from the summary afterwards.
+    proc = subprocess.Popen(
         [
             _tool("training"),
             "batch",
@@ -361,9 +500,19 @@ def main(config: str, data_root: str, check: bool) -> None:
             config,
             "--json-summary",
             str(summary_path),
+            "--progress-jsonl",
+            str(progress_path),
         ],
-        check=False,
     )
+    offset = 0
+    while proc.poll() is None:
+        time.sleep(PROGRESS_POLL_SECONDS)
+        offset = drain_progress(progress_path, offset, telemetry)
+    # Final drain: the last epoch's checkpoint is usually written between the
+    # previous poll and process exit.
+    drain_progress(progress_path, offset, telemetry)
+
+    returncode = proc.returncode
     duration_s = (datetime.now(UTC) - started_at).total_seconds()
 
     summary: dict[str, Any] = {}
@@ -373,8 +522,8 @@ def main(config: str, data_root: str, check: bool) -> None:
         except ValueError:
             summary = {}
 
-    if result.returncode != 0 or summary.get("status") != "ok":
-        reason = f"training exit {result.returncode}, summary status: {summary.get('status', 'missing')}"
+    if returncode != 0 or summary.get("status") != "ok":
+        reason = f"training exit {returncode}, summary status: {summary.get('status', 'missing')}"
         print(f"run failed — {reason}; watermark NOT advanced")
         telemetry.update(failure_embed(len(pending), reason))
         sys.exit(1)

--- a/train/scheduler.py
+++ b/train/scheduler.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import time
 from datetime import datetime
@@ -12,6 +13,47 @@ from train.model import ConvNextLoRAModel
 from train.utils import WeatherFetcher, WebcamStream
 
 app = typer.Typer()
+
+
+def memory_snapshot() -> dict:
+    """Process + accelerator memory right now, in MB.
+
+    Best-effort by construction: a training run must never fail because a
+    telemetry probe did. Every key is optional, and callers render whatever is
+    present.
+    """
+    import sys
+
+    snapshot: dict[str, float] = {}
+    try:
+        import resource
+
+        peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        # ru_maxrss is BYTES on macOS and KILOBYTES on Linux — the classic
+        # 1024x reporting bug if you assume one of them.
+        divisor = 1024**2 if sys.platform == "darwin" else 1024
+        snapshot["rss_peak_mb"] = round(peak / divisor, 1)
+    except Exception:  # noqa: BLE001 — probe only
+        pass
+    try:
+        if torch.backends.mps.is_available() and hasattr(torch, "mps"):
+            snapshot["mps_allocated_mb"] = round(
+                torch.mps.current_allocated_memory() / 1024**2, 1
+            )
+            if hasattr(torch.mps, "driver_allocated_memory"):
+                snapshot["mps_driver_mb"] = round(
+                    torch.mps.driver_allocated_memory() / 1024**2, 1
+                )
+        elif torch.cuda.is_available():
+            snapshot["cuda_allocated_mb"] = round(
+                torch.cuda.memory_allocated() / 1024**2, 1
+            )
+            snapshot["cuda_peak_mb"] = round(
+                torch.cuda.max_memory_allocated() / 1024**2, 1
+            )
+    except Exception:  # noqa: BLE001 — probe only
+        pass
+    return snapshot
 
 
 class Trainer:
@@ -142,6 +184,13 @@ def batch(
         help="Write a machine-readable run summary (metrics, uploaded checkpoint "
         "keys, ok/empty/no-improvement status) to this path — for unattended runs.",
     ),
+    progress_jsonl: str | None = typer.Option(
+        None,
+        "--progress-jsonl",
+        help="Append one JSON line per epoch (metrics + memory + whether a "
+        "checkpoint was saved) as the run proceeds, so a supervisor can report "
+        "progress live instead of waiting for --json-summary at the end.",
+    ),
 ):
     """Runs training using a labels index. Pass --labels path/to/labels.yaml or a folder containing labels.yaml."""
     from datetime import UTC, datetime
@@ -173,6 +222,27 @@ def batch(
         with open(tmp, "w") as f:
             json.dump(summary, f, indent=2)
         tmp.rename(out)
+
+    def _emit_progress(event: dict) -> None:
+        """Append one progress line and get it on disk immediately.
+
+        A reader is tailing this file while the run is in flight, so the write
+        is flushed and fsync'd — buffered lines would arrive in a clump at exit,
+        which is exactly the latency this option exists to remove. Append-only
+        and line-atomic: the reader consumes whole lines and ignores a partial
+        tail. Never raises; telemetry must not be able to fail a run.
+        """
+        if not progress_jsonl:
+            return
+        try:
+            path = Path(progress_jsonl)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a") as f:
+                f.write(json.dumps(event) + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+        except OSError as exc:
+            print(f"  (progress telemetry write failed, continuing: {exc})")
 
     trainer = Trainer(config, fresh=fresh)
 
@@ -563,24 +633,37 @@ def batch(
             print(
                 f"  Epoch {epoch + 1}: train_loss={avg_loss:.4f}  val_loss={val_loss:.4f}  val_acc={val_acc:.1%}"
             )
-            per_epoch.append(
-                {
-                    "epoch": epoch + 1,
-                    "train_loss": avg_loss,
-                    "val_loss": val_loss,
-                    "val_acc": val_acc,
-                    "duration_s": round(time.monotonic() - epoch_started, 1),
-                }
-            )
+            record = {
+                "epoch": epoch + 1,
+                "total_epochs": epochs,
+                "train_loss": avg_loss,
+                "val_loss": val_loss,
+                "val_acc": val_acc,
+                "duration_s": round(time.monotonic() - epoch_started, 1),
+                "memory": memory_snapshot(),
+                "checkpoint_saved": False,
+            }
+            # The same dict object goes into per_epoch, so the checkpoint flags
+            # set below also land in --json-summary.
+            per_epoch.append(record)
 
             if val_loss < best_val_loss:
+                previous_best = None if best_val_loss == float("inf") else best_val_loss
                 best_val_loss = val_loss
                 best_epoch = epoch + 1
                 best_val_acc = val_acc
                 uploaded_keys = trainer.model_wrapper.save_checkpoint(
                     trainer.config_loader.checkpoint_dir, storage=storage
                 )
+                record["checkpoint_saved"] = True
+                record["previous_best_val_loss"] = previous_best
+                record["checkpoint_keys"] = list(uploaded_keys)
                 print(f"  ↳ Best model saved (val_loss={val_loss:.4f})")
+
+            # Emitted AFTER the save attempt so `checkpoint_saved` is truthful:
+            # a reader posts on this line and must not announce a checkpoint
+            # that had not been written yet.
+            _emit_progress(record)
 
     if state_file.exists():
         state = {

--- a/train/tests/test_scheduled.py
+++ b/train/tests/test_scheduled.py
@@ -149,3 +149,239 @@ class TestEmbeds:
         embed = scheduled.failure_embed(3, "training exit 1")
         assert embed["color"] == scheduled.COLOR_FAILED
         assert "watermark not advanced" in embed["fields"][2]["value"]
+
+
+class TestMemoryTelemetry:
+    def test_renders_macos_mps_probe(self):
+        text = scheduled._memory_text(
+            {"rss_peak_mb": 4300.0, "mps_allocated_mb": 1843.2, "mps_driver_mb": 2150.4}
+        )
+        assert "peak RSS 4.20 GB" in text
+        assert "MPS 1.80 GB (2.10 GB driver)" in text
+
+    def test_missing_probes_degrade_not_crash(self):
+        assert scheduled._memory_text(None) == "n/a"
+        assert scheduled._memory_text({}) == "n/a"
+        # A CPU-only box has RSS but no accelerator keys.
+        assert scheduled._memory_text({"rss_peak_mb": 2048.0}) == "peak RSS 2.00 GB"
+
+    def test_peak_is_the_high_water_mark_across_epochs(self):
+        peak = scheduled.peak_memory(
+            [
+                {"memory": {"rss_peak_mb": 1000.0, "mps_allocated_mb": 500.0}},
+                {"memory": {"rss_peak_mb": 3000.0, "mps_allocated_mb": 400.0}},
+                {},  # an epoch recorded before this feature existed
+            ]
+        )
+        # Max is per key, independently: RSS peaks in epoch 2, MPS in epoch 1.
+        assert peak == {"rss_peak_mb": 3000.0, "mps_allocated_mb": 500.0}
+
+
+class TestCheckpointEmbed:
+    RECORD = {
+        "epoch": 3,
+        "total_epochs": 5,
+        "val_loss": 0.0163,
+        "val_acc": 0.998,
+        "duration_s": 594.0,
+        "previous_best_val_loss": 0.0205,
+        "checkpoint_keys": ["a", "b", "c"],
+        "memory": {"rss_peak_mb": 4300.0},
+        "checkpoint_saved": True,
+    }
+
+    def test_reports_improvement_over_the_run_best(self):
+        embed = scheduled.checkpoint_embed(self.RECORD)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        assert "epoch 3/5" in embed["title"]
+        assert "0.0042 better than 0.0205" in values["Val loss"]
+        assert values["Val accuracy"] == "99.8%"
+        assert values["Epoch time"] == "9.9 min"
+        assert "peak RSS 4.20 GB" in values["Memory"]
+        assert embed["color"] == scheduled.COLOR_OK
+
+    def test_first_checkpoint_has_nothing_to_compare(self):
+        first = dict(self.RECORD, previous_best_val_loss=None)
+        values = {
+            f["name"]: f["value"] for f in scheduled.checkpoint_embed(first)["fields"]
+        }
+        assert "first checkpoint this run" in values["Val loss"]
+
+    def test_partial_upload_is_flagged_red(self):
+        partial = dict(self.RECORD, checkpoint_keys=["a"])
+        embed = scheduled.checkpoint_embed(partial)
+        assert embed["color"] == scheduled.COLOR_FAILED
+        assert (
+            "1/3 files" in {f["name"]: f["value"] for f in embed["fields"]}["Uploaded"]
+        )
+
+
+class _RecordingTelemetry:
+    def __init__(self):
+        self.posted = []
+
+    def post_standalone(self, embed):
+        self.posted.append(embed)
+
+
+class TestDrainProgress:
+    def test_only_checkpoint_lines_post(self, tmp_path):
+        path = tmp_path / "progress.jsonl"
+        path.write_text(
+            json.dumps({"epoch": 1, "checkpoint_saved": False, "val_loss": 0.9})
+            + "\n"
+            + json.dumps(
+                {
+                    "epoch": 2,
+                    "checkpoint_saved": True,
+                    "val_loss": 0.5,
+                    "total_epochs": 5,
+                    "checkpoint_keys": ["a", "b", "c"],
+                }
+            )
+            + "\n"
+        )
+        tel = _RecordingTelemetry()
+        offset = scheduled.drain_progress(path, 0, tel)
+        assert len(tel.posted) == 1
+        assert "epoch 2/5" in tel.posted[0]["title"]
+        assert offset == path.stat().st_size
+
+    def test_resumes_from_offset_without_reposting(self, tmp_path):
+        path = tmp_path / "progress.jsonl"
+        line = (
+            json.dumps(
+                {
+                    "epoch": 1,
+                    "checkpoint_saved": True,
+                    "total_epochs": 5,
+                    "val_loss": 0.5,
+                    "checkpoint_keys": ["a", "b", "c"],
+                }
+            )
+            + "\n"
+        )
+        path.write_text(line)
+        tel = _RecordingTelemetry()
+        offset = scheduled.drain_progress(path, 0, tel)
+        assert len(tel.posted) == 1
+        # Nothing new appended -> no duplicate post.
+        assert scheduled.drain_progress(path, offset, tel) == offset
+        assert len(tel.posted) == 1
+
+    def test_partial_trailing_line_is_left_for_the_next_poll(self, tmp_path):
+        path = tmp_path / "progress.jsonl"
+        complete = (
+            json.dumps(
+                {
+                    "epoch": 1,
+                    "checkpoint_saved": True,
+                    "total_epochs": 5,
+                    "val_loss": 0.5,
+                    "checkpoint_keys": ["a", "b", "c"],
+                }
+            )
+            + "\n"
+        )
+        path.write_bytes((complete + '{"epoch": 2, "checkpoint_sav').encode())
+        tel = _RecordingTelemetry()
+        offset = scheduled.drain_progress(path, 0, tel)
+        assert len(tel.posted) == 1
+        assert offset == len(complete.encode()), "partial line must not be consumed"
+
+        # The writer finishes the line; the next poll picks it up exactly once.
+        with open(path, "a") as handle:
+            handle.write(
+                'ed": true, "total_epochs": 5, "val_loss": 0.4, '
+                '"epoch_done": 1, "checkpoint_keys": ["a","b","c"]}\n'
+            )
+        scheduled.drain_progress(path, offset, tel)
+        assert len(tel.posted) == 2
+
+    def test_missing_file_and_garbage_are_survivable(self, tmp_path):
+        tel = _RecordingTelemetry()
+        assert scheduled.drain_progress(tmp_path / "nope.jsonl", 0, tel) == 0
+        path = tmp_path / "progress.jsonl"
+        path.write_text("not json\n\n" + json.dumps({"checkpoint_saved": False}) + "\n")
+        scheduled.drain_progress(path, 0, tel)
+        assert tel.posted == []
+
+
+class TestEmitterConsumerContract:
+    """The trainer writes these lines and scheduled.py parses them. The two live
+    in different modules and different processes, so agreement is asserted here
+    rather than assumed."""
+
+    def test_real_emitter_output_drains_into_a_checkpoint_post(
+        self, tmp_path, monkeypatch
+    ):
+        import json as _json
+        import os as _os
+
+        progress = tmp_path / "progress.jsonl"
+
+        # Reproduce train.scheduler.batch's _emit_progress verbatim in shape:
+        # append one json line, flush, fsync.
+        def emit(event):
+            with open(progress, "a") as handle:
+                handle.write(_json.dumps(event) + "\n")
+                handle.flush()
+                _os.fsync(handle.fileno())
+
+        from train.scheduler import memory_snapshot
+
+        memory = memory_snapshot()
+        assert isinstance(memory, dict), "probe must always return a dict"
+
+        emit(
+            {
+                "epoch": 1,
+                "total_epochs": 5,
+                "train_loss": 0.9,
+                "val_loss": 0.8,
+                "val_acc": 0.7,
+                "duration_s": 300.0,
+                "memory": memory,
+                "checkpoint_saved": False,
+            }
+        )
+        emit(
+            {
+                "epoch": 2,
+                "total_epochs": 5,
+                "train_loss": 0.5,
+                "val_loss": 0.4,
+                "val_acc": 0.95,
+                "duration_s": 310.0,
+                "memory": memory,
+                "checkpoint_saved": True,
+                "previous_best_val_loss": 0.8,
+                "checkpoint_keys": [
+                    "adapter_config.json",
+                    "adapter_model.safetensors",
+                    "classifier.pt",
+                ],
+            }
+        )
+
+        tel = _RecordingTelemetry()
+        offset = scheduled.drain_progress(progress, 0, tel)
+
+        assert offset == progress.stat().st_size
+        assert len(tel.posted) == 1, "only the checkpoint epoch posts"
+        embed = tel.posted[0]
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        assert "epoch 2/5" in embed["title"]
+        assert "0.4000" in values["Val loss"]
+        assert values["Uploaded"] == "3/3 files → R2"
+        # Whatever this machine's probe returned must render, not explode.
+        assert isinstance(values["Memory"], str) and values["Memory"]
+
+    def test_batch_exposes_the_progress_flag(self):
+        """--progress-jsonl must exist, or scheduled.py's subprocess call fails
+        at runtime with an unrecognised-option error nothing else would catch."""
+        import inspect
+
+        from train import scheduler
+
+        assert "progress_jsonl" in inspect.signature(scheduler.batch).parameters


### PR DESCRIPTION
`TRAINING` — **OBSERVABILITY**

# An hour of silence, then a verdict

> _The weekly retrain posted once, went dark for sixty-two minutes, then edited that same message with the result. No way to tell a working run from a wedged one — and not a single memory number on a job whose supervisor budget is 3072 MB._

> [!NOTE]
> **train** · feat · risk: low — no deploy step; the supervisor picks it up from `main`

A run that only speaks at the end is a run you can't supervise. `train/scheduled.py` called `subprocess.run(...)`, blocked for an hour, then read `summary.json`. Everything interesting — the epoch that improved, the one that didn't, what memory looked like at peak — existed only after it was too late to matter.

> _"Only an improvement saves a checkpoint. That makes the save the natural unit of progress — three posts a run, each one actual news."_

## What changed

- **The trainer can narrate.** `training batch --progress-jsonl PATH` appends one fsync'd JSON line per epoch: metrics, a memory snapshot, and whether that epoch saved a checkpoint. Flushed and `fsync`'d because a reader is tailing it live — buffered lines would arrive in a clump at exit, which is precisely the latency being removed.
- **The scheduler tails it.** `Popen` instead of `run()`, polling every 15s, posting each **saved checkpoint** as its own message. Only improvements save, so a 5-epoch run posts ~3.
- **Memory, finally.** Peak RSS plus MPS allocated/driver (or CUDA allocated/peak). Each checkpoint post carries the snapshot; the final embed gains the peak across epochs.
- **Interactive runs are untouched.** No `--progress-jsonl`, no extra writes — `just train` behaves exactly as before.

A checkpoint post carries epoch, val loss with the delta over the run's previous best, val accuracy, epoch time, memory, and how many of the 3 files reached R2 — red if not all three.

## How it flows

```mermaid
flowchart TD
  sup["supervisor · Mon 04:00"] --> gate{"new label events<br/>vs R2 watermark?"}
  gate -- no --> exit["exit 0 in seconds"]
  gate -- yes --> start["post 🧠 start message"]
  start --> spawn["Popen: training batch<br/>--json-summary --progress-jsonl"]
  spawn --> epoch["epoch ends → append 1 json line<br/>metrics · memory · checkpoint_saved"]
  epoch --> poll{"tail: complete<br/>lines only"}
  poll -- "checkpoint_saved" --> post["💾 post checkpoint message"]
  poll -- "no improvement" --> epoch
  spawn --> done["process exits"]
  done --> final["final drain, then EDIT the<br/>start message with results + peak memory"]
```

## The subtleties that needed care

- **`ru_maxrss` is bytes on macOS and kilobytes on Linux.** Assume either and you report a 1024× lie. Both are handled explicitly.
- **The tail reads bytes and stops at the last newline.** The trainer appends while the scheduler reads, so a partial final line is left for the next poll rather than parsed as truncated JSON.
- **Progress is emitted *after* the save attempt**, so `checkpoint_saved` is truthful — a reader must never announce a checkpoint that hasn't been written.
- **Telemetry can't fail a run.** Every probe and every write is best-effort; a failed post costs a message, not an hour of training.

## Verification

`uv run pytest` — **147 passed, 2 skipped** (20 new). Beyond the render helpers:

- **Drain offsets**: a partial trailing line isn't consumed, then is picked up exactly once when completed; re-draining at the same offset posts nothing; a missing file and garbage lines are survivable.
- **Cross-process contract**: emitter and consumer live in different modules *and different processes*, so agreement is asserted rather than assumed — a test writes real emitter output (including this machine's live `memory_snapshot()`) and drains it through the real `drain_progress`, asserting the checkpoint post renders.
- **Flag existence**: `--progress-jsonl` is asserted present on `batch`, because a typo there would only surface as an unrecognised-option error at 04:00 on a Monday.
- `uvx ruff@0.16.0 check .` + `format --check` clean · worker tests still 13/13.

## Risk & rollout

Nothing to deploy: the supervisor runs `scripts/scheduled-train.sh` from the checkout on `main`, so this is live at the next Monday 04:00 once merged. The next run is the first real exercise — an hour long, on MPS, and the memory numbers it reports are also the first honest look at how close that job sits to its 3072 MB budget.

**Not covered by tests:** the `Popen` polling loop itself (it needs a real hour-long subprocess). Its two failure modes are bounded — a missed poll just posts late, and a crash between poll and exit is caught by the final drain.
