### PR TITLE
fix: narrow blind except clauses in train/utils.py METAR handling

### DIFF
--- a/train/utils.py
+++ b/train/utils.py
@@ -1,3 +1,4 @@
+import logging
 import cv2
 import torch
 import numpy as np
@@ -56,8 +57,8 @@ class WeatherFetcher:
             if response.status_code == 200:
                 lines = response.text.strip().split("\n")
                 return lines[-1] if lines else None
-        except Exception as e:
-            print(f"Error fetching METAR: {e}")
+        except requests.RequestException as e:
+            logging.warning(f"Error fetching METAR: {e}")
         return None
 
     def parse_metar_to_vector(self, metar_text: str) -> torch.Tensor:
@@ -74,8 +75,15 @@ class WeatherFetcher:
                         if layers
                         else 1.0
                     )
-            except Exception:
-                pass
+            except (Metar.ParserError, AttributeError, IndexError, ValueError) as e:
+                # Live METAR text off the NOAA feed is sometimes truncated or
+                # malformed (station outage, mid-write scrape, format drift).
+                # Metar.Metar() wraps any internal parse failure as ParserError
+                # in strict mode; AttributeError/IndexError/ValueError cover the
+                # sky-layer/value() lookups above on a report that parsed but has
+                # an unexpected shape. Fall back to the neutral defaults already
+                # set above rather than taking down the training loop.
+                logging.warning(f"Could not parse METAR text {metar_text!r}: {e}")
         return torch.tensor([vis, ceil], dtype=torch.float32)
 
     def get_weather_vector(self) -> torch.Tensor:


### PR DESCRIPTION
`TRAIN` — **CODE HYGIENE**

# Stop swallowing METAR failures whole

> _Two `except Exception` blocks in the live-training weather path caught everything
> and either printed to stdout or said nothing at all. Now they catch only what the
> METAR stack can actually raise, and log it._

> [!NOTE]
> **train** · fix · risk: low · no issue

`train/utils.py`'s `WeatherFetcher` feeds visibility and ceiling into every training
step, scraped live off NOAA's METAR feed for KSEA. Both error paths were blind: one
caught `Exception` and `print`ed, the other caught `Exception` and silently `pass`ed.

Ruff flagged this `BLE001`/`S110` on 2026-07-26, tangled up with an unrelated problem:
`uvx ruff` was unpinned, so 0.16.0's wider default rule set lit up 245 findings across
~25 untouched files. `fix(ci): pin ruff and declare the lint rule set (#90)` (merged
2026-07-29) fixed that — ruff is pinned to 0.16.0, `pyproject.toml` declares
`select = ["E4","E7","E9","F"]`, and `Lint` has been green since. That PR deferred
these two blind-except sites for "case-by-case review, not a sweep." This is that
review.

## What actually changed
- **`fetch_latest_metar`**: `except Exception` → `except requests.RequestException`
  (the only thing `requests.get` raises), and swapped `print` for `logging.warning`.
- **`parse_metar_to_vector`**: `except Exception: pass` → catches
  `(Metar.ParserError, AttributeError, IndexError, ValueError)`, now logged.
  `metar/Metar.py` wraps any internal handler failure as `ParserError` in strict mode;
  the other three cover `obs.sky` indexing / `.value()` unit conversion on a report
  that parsed but came back an unexpected shape.
- The neutral defaults (`vis=0.0`, `ceil=1.0`) set before the `try` are unchanged — a
  bad METAR read still falls back quietly, it just also logs *why* now.
- No behavior change on the happy path.

> _"A bad METAR read should fall back quietly — it shouldn't fail silently."_

## How it flows
No flow change — narrows two `except` clauses and adds logging. The call graph
(`get_weather_vector` → `fetch_latest_metar` → `parse_metar_to_vector`) is unchanged.

## Verification
- `uvx ruff@0.16.0 check --output-format=github .` (the exact pinned CI command,
  run from inside the repo) — clean.
- `uvx ruff@0.16.0 format --check .` — clean.
- `ruff check --select BLE,S110 train/utils.py` (the wider family CI doesn't select) —
  also clean, confirming this is a real fix, not an artifact of the narrower select.
- `uv run pytest -q` — 131 passed, 2 skipped (excludes one pre-existing collection
  error and 4 pre-existing model-download failures, see Risk). No dedicated
  `WeatherFetcher` unit tests exist; the exception surface was verified by reading the
  `metar`/`requests` source.

## Risk & rollout
- Low risk: two narrowed except clauses plus a logging swap, no config/dependency
  change.
- **Not CI-gated either way** — `select` doesn't include `BLE`/`S`, so this wasn't
  required for `Lint`. It's the follow-up review PR #90 called for.
- Flagged separately, out of scope here: `collect/tests/test_notebook_helpers.py`
  fails to import (`get_job_captures` missing from `collect/notebook_helpers.py`), and
  `train/tests/test_model.py` fails locally on a missing `~/.cache/huggingface/hub`
  dir — both pre-existing, unrelated, and not CI-gated (no `Test` lane exists).
