### PR TITLE
feat: the Worker stops depending on one laptop being awake

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,145 @@
+# Deploy the mountain-inference Worker from CI.
+#
+# This replaces "a human runs scripts/deploy-worker.sh on the Mac mini" as the
+# normal deploy path. The script survives as the break-glass path (see its
+# header); everything it did — gate, deploy, and record a GitHub Deployment with
+# success/failure status so the Environments page reflects reality — happens
+# here instead, on a runner, from the exact commit that landed on main.
+#
+# Auth: `secrets.CLOUDFLARE_API_TOKEN`. The workspace rule is "auth via code
+# flow, never mint tokens", but headless CI cannot run the `wrangler login`
+# browser flow, so a scoped API token is the sanctioned exception. It is created
+# by a human, once, and set with:
+#
+#   gh secret set CLOUDFLARE_API_TOKEN -R robogeosociety/is-the-mountain-out
+#
+# Required token scope is documented in CLAUDE.md → Deployment (Cloudflare).
+# Until that secret exists the deploy job fails at the preflight step with an
+# explicit message — never a wrangler stack trace.
+name: Deploy Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'worker/**'
+      - '.github/workflows/deploy-worker.yml'
+      - '.github/workflows/worker-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  # Never cancel a deploy in flight — a half-applied wrangler deploy is worse
+  # than a queued one. Later pushes wait their turn.
+  group: deploy-worker-production
+  cancel-in-progress: false
+
+jobs:
+  # Same tests + typecheck that gate every PR. A deploy cannot outrun them.
+  test:
+    uses: ./.github/workflows/worker-ci.yml
+
+  deploy:
+    name: wrangler deploy
+    needs: test
+    runs-on: ubuntu-latest
+    # The `production` GitHub environment. Add a required reviewer there to turn
+    # this into an approval gate; nothing in this file has to change.
+    environment:
+      name: production
+      url: ${{ vars.WORKER_URL || 'https://mountain-inference.tommy-b-doerr.workers.dev' }}
+    env:
+      # `secrets` is not available in a job-level `if:`, so the missing-secret
+      # check is a first step rather than a skip condition.
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      # Account id is not a secret (it is already in worker/wrangler.toml's
+      # container image ref). Overridable with a repo variable.
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID || 'd7adee58513c1b2f770ccaac90cf114f' }}
+      WORKER_URL: ${{ vars.WORKER_URL || 'https://mountain-inference.tommy-b-doerr.workers.dev' }}
+      GH_TOKEN: ${{ github.token }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      # Fail loudly and legibly when the secret is absent, BEFORE any GitHub
+      # Deployment is created — otherwise a missing credential would leave a
+      # dangling `in_progress` deployment on the Environments page forever.
+      - name: Preflight — CLOUDFLARE_API_TOKEN must be set
+        run: |
+          if [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "CLOUDFLARE_API_TOKEN is present."
+            exit 0
+          fi
+          {
+            echo '## Deploy blocked — `CLOUDFLARE_API_TOKEN` is not set'
+            echo
+            echo 'This repository has no Cloudflare credential, so the Worker cannot be'
+            echo 'deployed from CI. Nothing was deployed and no GitHub Deployment was'
+            echo 'created.'
+            echo
+            echo 'Create a scoped Cloudflare API token (see CLAUDE.md → Deployment'
+            echo '(Cloudflare) for the exact permissions), then run:'
+            echo
+            echo '```sh'
+            echo 'gh secret set CLOUDFLARE_API_TOKEN -R robogeosociety/is-the-mountain-out'
+            echo '```'
+            echo
+            echo 'Until then, deploy with the break-glass path: `scripts/deploy-worker.sh`.'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error title=CLOUDFLARE_API_TOKEN not set::No Cloudflare credential in this repo. Run: gh secret set CLOUDFLARE_API_TOKEN -R ${GITHUB_REPOSITORY} (see CLAUDE.md for the required token scope). Nothing was deployed."
+          exit 1
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      - name: Install dependencies
+        working-directory: worker
+        run: npm ci || npm ci --omit=optional --ignore-scripts
+
+      # Mirrors scripts/deploy-worker.sh: best-effort Deployment record, so a
+      # GitHub API hiccup logs a warning but never blocks the actual deploy.
+      - name: Create GitHub Deployment
+        id: deployment
+        run: |
+          body="$(printf '{"ref":"%s","environment":"production","production_environment":true,"auto_merge":false,"required_contexts":[],"description":"CI wrangler deploy of mountain-inference"}' "$GITHUB_SHA")"
+          id="$(printf '%s' "$body" | gh api "repos/$GITHUB_REPOSITORY/deployments" --input - --jq '.id' 2>/dev/null || true)"
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+          if [ -n "$id" ]; then
+            echo "GitHub Deployment #$id created"
+            gh api "repos/$GITHUB_REPOSITORY/deployments/$id/statuses" \
+              -f state=in_progress -f environment=production \
+              -f environment_url="$WORKER_URL" -f log_url="$RUN_URL" \
+              -f description='Deploying via wrangler (CI)' >/dev/null 2>&1 \
+              || echo "::warning::could not set deployment status=in_progress"
+          else
+            echo "::warning::GitHub Deployment not created; continuing with the deploy"
+          fi
+
+      - name: wrangler deploy
+        working-directory: worker
+        run: npx wrangler deploy
+
+      - name: Mark deployment success
+        if: success() && steps.deployment.outputs.id != ''
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/deployments/${{ steps.deployment.outputs.id }}/statuses" \
+            -f state=success -f environment=production \
+            -f environment_url="$WORKER_URL" -f log_url="$RUN_URL" \
+            -f description="Deployed to $WORKER_URL" >/dev/null \
+            || echo "::warning::could not set deployment status=success"
+          echo "Deployed $GITHUB_SHA → $WORKER_URL" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark deployment failure
+        if: failure() && steps.deployment.outputs.id != ''
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/deployments/${{ steps.deployment.outputs.id }}/statuses" \
+            -f state=failure -f environment=production \
+            -f environment_url="$WORKER_URL" -f log_url="$RUN_URL" \
+            -f description='wrangler deploy failed (CI)' >/dev/null \
+            || echo "::warning::could not set deployment status=failure"

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -4,7 +4,9 @@
 # normal deploy path. The script survives as the break-glass path (see its
 # header); everything it did — gate, deploy, and record a GitHub Deployment with
 # success/failure status so the Environments page reflects reality — happens
-# here instead, on a runner, from the exact commit that landed on main.
+# here instead, on a runner, from the exact commit that landed on main. The
+# Deployment record comes free with the `environment:` key below; see the note
+# on that block for why this workflow makes no explicit deployments API calls.
 #
 # Auth: `secrets.CLOUDFLARE_API_TOKEN`. The workspace rule is "auth via code
 # flow, never mint tokens", but headless CI cannot run the `wrangler login`
@@ -29,7 +31,6 @@ on:
 
 permissions:
   contents: read
-  deployments: write
 
 concurrency:
   # Never cancel a deploy in flight — a half-applied wrangler deploy is worse
@@ -46,8 +47,18 @@ jobs:
     name: wrangler deploy
     needs: test
     runs-on: ubuntu-latest
-    # The `production` GitHub environment. Add a required reviewer there to turn
-    # this into an approval gate; nothing in this file has to change.
+    # The `production` GitHub environment does double duty here.
+    #
+    # 1. Approval gate: add a required reviewer to the environment and this job
+    #    waits for it. Nothing in this file has to change.
+    # 2. Deployment bookkeeping. This is the whole reason there are no explicit
+    #    `gh api .../deployments` calls here, unlike scripts/deploy-worker.sh:
+    #    an `environment:` job ALREADY creates a GitHub Deployment and moves it
+    #    in_progress → success/failure, carrying `url` below through as
+    #    environment_url plus a log_url back to this job. Verified on run
+    #    30559836026 — a failed deploy produced exactly the in_progress →
+    #    failure pair the script produces by hand. Recording our own on top
+    #    would put two entries on the Environments page for every deploy.
     environment:
       name: production
       url: ${{ vars.WORKER_URL || 'https://mountain-inference.tommy-b-doerr.workers.dev' }}
@@ -59,12 +70,11 @@ jobs:
       # container image ref). Overridable with a repo variable.
       CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID || 'd7adee58513c1b2f770ccaac90cf114f' }}
       WORKER_URL: ${{ vars.WORKER_URL || 'https://mountain-inference.tommy-b-doerr.workers.dev' }}
-      GH_TOKEN: ${{ github.token }}
-      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      # Fail loudly and legibly when the secret is absent, BEFORE any GitHub
-      # Deployment is created — otherwise a missing credential would leave a
-      # dangling `in_progress` deployment on the Environments page forever.
+      # Fail loudly and legibly when the secret is absent, and fail FIRST — the
+      # environment's deployment record is already open by the time any step
+      # runs, so the sooner this exits the sooner that record lands on
+      # `failure` instead of sitting `in_progress`.
       - name: Preflight — CLOUDFLARE_API_TOKEN must be set
         run: |
           if [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
@@ -75,8 +85,7 @@ jobs:
             echo '## Deploy blocked — `CLOUDFLARE_API_TOKEN` is not set'
             echo
             echo 'This repository has no Cloudflare credential, so the Worker cannot be'
-            echo 'deployed from CI. Nothing was deployed and no GitHub Deployment was'
-            echo 'created.'
+            echo 'deployed from CI. Nothing was deployed.'
             echo
             echo 'Create a scoped Cloudflare API token (see CLAUDE.md → Deployment'
             echo '(Cloudflare) for the exact permissions), then run:'
@@ -102,44 +111,10 @@ jobs:
         working-directory: worker
         run: npm ci || npm ci --omit=optional --ignore-scripts
 
-      # Mirrors scripts/deploy-worker.sh: best-effort Deployment record, so a
-      # GitHub API hiccup logs a warning but never blocks the actual deploy.
-      - name: Create GitHub Deployment
-        id: deployment
-        run: |
-          body="$(printf '{"ref":"%s","environment":"production","production_environment":true,"auto_merge":false,"required_contexts":[],"description":"CI wrangler deploy of mountain-inference"}' "$GITHUB_SHA")"
-          id="$(printf '%s' "$body" | gh api "repos/$GITHUB_REPOSITORY/deployments" --input - --jq '.id' 2>/dev/null || true)"
-          echo "id=$id" >> "$GITHUB_OUTPUT"
-          if [ -n "$id" ]; then
-            echo "GitHub Deployment #$id created"
-            gh api "repos/$GITHUB_REPOSITORY/deployments/$id/statuses" \
-              -f state=in_progress -f environment=production \
-              -f environment_url="$WORKER_URL" -f log_url="$RUN_URL" \
-              -f description='Deploying via wrangler (CI)' >/dev/null 2>&1 \
-              || echo "::warning::could not set deployment status=in_progress"
-          else
-            echo "::warning::GitHub Deployment not created; continuing with the deploy"
-          fi
-
       - name: wrangler deploy
         working-directory: worker
         run: npx wrangler deploy
 
-      - name: Mark deployment success
-        if: success() && steps.deployment.outputs.id != ''
-        run: |
-          gh api "repos/$GITHUB_REPOSITORY/deployments/${{ steps.deployment.outputs.id }}/statuses" \
-            -f state=success -f environment=production \
-            -f environment_url="$WORKER_URL" -f log_url="$RUN_URL" \
-            -f description="Deployed to $WORKER_URL" >/dev/null \
-            || echo "::warning::could not set deployment status=success"
-          echo "Deployed $GITHUB_SHA → $WORKER_URL" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Mark deployment failure
-        if: failure() && steps.deployment.outputs.id != ''
-        run: |
-          gh api "repos/$GITHUB_REPOSITORY/deployments/${{ steps.deployment.outputs.id }}/statuses" \
-            -f state=failure -f environment=production \
-            -f environment_url="$WORKER_URL" -f log_url="$RUN_URL" \
-            -f description='wrangler deploy failed (CI)' >/dev/null \
-            || echo "::warning::could not set deployment status=failure"
+      - name: Summary
+        if: success()
+        run: echo "Deployed \`$GITHUB_SHA\` → $WORKER_URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -1,0 +1,61 @@
+# Worker CI — the PR gate for worker/ (TypeScript).
+#
+# Until this existed, only ruff (lint.yml) gated pull requests, so a TypeScript
+# regression in the Worker could merge with `npm test` and `npm run typecheck`
+# never having run anywhere but a laptop.
+#
+# Deliberately NOT path-filtered: a path-filtered job that never starts reports
+# as "pending" forever once it is made a required check, silently blocking every
+# non-worker PR. The job takes well under a minute, so it just always runs.
+#
+# Exposed as `workflow_call` so deploy-worker.yml gates the production deploy on
+# exactly these checks rather than a copy that drifts. There is no push:main
+# trigger on purpose — a worker change landing on main is verified by the deploy
+# workflow calling this one, so main gets these checks without a duplicate run.
+name: Worker CI
+
+on:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # github.workflow is the CALLER's workflow in a reusable run, so a deploy and
+  # a PR check never land in the same group and cancel each other.
+  group: worker-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test + typecheck
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: worker
+    steps:
+      - uses: actions/checkout@v4
+
+      # Node 24: `node --test` runs the .ts test files directly via built-in
+      # type stripping (unflagged since 23.6). There is no test-time bundler.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      # Plain `npm ci` fails on macOS/arm64: miniflare hard-depends on sharp, no
+      # prebuilt binary resolves, and it falls back to a node-gyp source build.
+      # On linux/x64 runners @img/sharp-linux-x64 resolves and this is fine; the
+      # fallback keeps a bad sharp from taking CI down for a package that
+      # neither tsc nor `node --test` actually loads.
+      - name: Install dependencies
+        run: npm ci || npm ci --omit=optional --ignore-scripts
+
+      - name: Tests
+        run: npm test
+
+      - name: Typecheck
+        run: npm run typecheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,10 +79,36 @@ Single source of truth for webcam URL, METAR station (`KSEA`), LoRA hyperparamet
 
 ## Deployment (Cloudflare)
 
-Inference runs as the `mountain-inference` Cloudflare Worker + Container (cron `*/15`), with R2 for storage and Pages for the SPA. There are two deploy paths; **prefer wrangler**:
+Inference runs as the `mountain-inference` Cloudflare Worker + Container (cron `*/15`), with R2 for storage and Pages for the SPA.
 
-- **wrangler (current, preferred):** `scripts/deploy-worker.sh` runs `npx wrangler deploy` from `worker/` and records a GitHub Deployment. This is what the live Worker uses (`last_deployed_from: wrangler`). Secrets are set out-of-band with `wrangler secret put` and only go live on the next `wrangler deploy`.
-- **Terraform (`scripts/deploy-inference.sh` + `terraform/`):** retained as the intended path for reproducibility/IaC later, but the `terraform/` dir is currently absent and the script's TF path is stale — don't rely on it until it's rebuilt. Treat it as aspirational, not the working deploy.
+**The Worker deploys from CI — `.github/workflows/deploy-worker.yml`.** A push to `main` touching `worker/**` (or `gh workflow run deploy-worker.yml`) runs the worker tests + typecheck, then `npx wrangler deploy`, inside the `production` GitHub environment. It creates a GitHub Deployment and sets `in_progress` → `success`/`failure` on it, so the Environments page reflects what is actually live — the same bookkeeping `scripts/deploy-worker.sh` used to do from a laptop. Deploys are serialized (`cancel-in-progress: false`): one in flight is never cancelled. To require human approval, add a required reviewer to the `production` environment — no workflow change needed.
+
+Deploy paths, in order of preference:
+
+- **CI (normal):** the workflow above. Auth is the repo secret `CLOUDFLARE_API_TOKEN`.
+- **`scripts/deploy-worker.sh` (break-glass):** same wrangler deploy + GitHub Deployment, run by a human under their own `wrangler login`. For when Actions is down, the token is expired, or an uncommitted tree must ship. It warns on a dirty tree, because the Deployment it records then points at a ref that does not match what went live.
+- **Terraform (`scripts/deploy-inference.sh` + `terraform/`):** aspirational only — the `terraform/` dir does not exist and the script's TF path is stale. Do not rely on it.
+
+The container image is *not* built or pushed by this workflow. `worker/wrangler.toml` pins an already-pushed tag in Cloudflare's managed registry; `.github/workflows/build-inference-image.yml` builds to GHCR and the `registry.cloudflare.com` push is still manual (`wrangler containers push`).
+
+**CI credential — `CLOUDFLARE_API_TOKEN`.** The workspace rule is "auth via code flow, never mint tokens", but headless CI cannot run `wrangler login`'s browser flow, so a scoped API token is the sanctioned exception. Create it at *My Profile → API Tokens → Create Token*, scoped to account `d7adee58513c1b2f770ccaac90cf114f`, then:
+
+```sh
+gh secret set CLOUDFLARE_API_TOKEN -R robogeosociety/is-the-mountain-out
+```
+
+Required permissions (all **Account**-scoped, restricted to that one account):
+
+| Permission | Why |
+| --- | --- |
+| `Workers Scripts: Edit` | Upload the script, its bindings, the DO migration, and the cron trigger. The one non-negotiable scope. |
+| `Workers R2 Storage: Edit` | `wrangler.toml` declares two `[[r2_buckets]]` bindings, resolved at deploy. Part of Cloudflare's own "Edit Cloudflare Workers" template. |
+| `Account Settings: Read` | Account lookup/validation during deploy. |
+| `Cloudflare Containers: Edit` | `wrangler.toml` has a `[[containers]]` block, so deploy also updates the container application (image ref, `max_instances`, `instance_type`). Without it the script uploads but the container step fails. |
+
+Not needed: `Cloudflare Images: Edit` (only for `wrangler containers push`, which CI does not do) and `Workers KV`/`D1`/`Queues` (no such bindings). If in doubt, Cloudflare's stock **"Edit Cloudflare Workers"** token template is a working superset; prefer the narrower list above. The token is *only* for CI — the operator's laptop keeps using `wrangler login`.
+
+Worker secrets themselves are still set out-of-band with `wrangler secret put` and only go live on the next deploy; CI does not manage them.
 
 Worker secrets (set via `wrangler secret put`):
 - `DISCORD_BOT_TOKEN` / `DISCORD_CHANNEL_ID` — the labeler bot's credentials, so the Worker posts visibility changes *as that bot* and they're reaction-labelable. Same values as `cf.env`. See `NOTIFICATIONS.md`. (Replaced `DISCORD_WEBHOOK_URL`, which made posts unreadable to the bot; delete it with `npx wrangler secret delete DISCORD_WEBHOOK_URL`. The former `NTFY_TOPIC`/`NTFY_TOKEN` ntfy.sh secrets and the gitignored `ntfy.key`/`ntfy-token.key` files are also obsolete.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,9 @@ Single source of truth for webcam URL, METAR station (`KSEA`), LoRA hyperparamet
 
 Inference runs as the `mountain-inference` Cloudflare Worker + Container (cron `*/15`), with R2 for storage and Pages for the SPA.
 
-**The Worker deploys from CI — `.github/workflows/deploy-worker.yml`.** A push to `main` touching `worker/**` (or `gh workflow run deploy-worker.yml`) runs the worker tests + typecheck, then `npx wrangler deploy`, inside the `production` GitHub environment. It creates a GitHub Deployment and sets `in_progress` → `success`/`failure` on it, so the Environments page reflects what is actually live — the same bookkeeping `scripts/deploy-worker.sh` used to do from a laptop. Deploys are serialized (`cancel-in-progress: false`): one in flight is never cancelled. To require human approval, add a required reviewer to the `production` environment — no workflow change needed.
+**The Worker deploys from CI — `.github/workflows/deploy-worker.yml`.** A push to `main` touching `worker/**` (or `gh workflow run deploy-worker.yml`) runs the worker tests + typecheck, then `npx wrangler deploy`, inside the `production` GitHub environment. Deploys are serialized (`cancel-in-progress: false`): one in flight is never cancelled. To require human approval, add a required reviewer to the `production` environment — no workflow change needed.
+
+The GitHub Deployment record comes free with the job's `environment:` key: Actions itself opens a deployment and moves it `in_progress` → `success`/`failure`, with `environment_url` and a `log_url` to the run. That is *exactly* the bookkeeping `scripts/deploy-worker.sh` does by hand, so the workflow makes **no** explicit deployments-API calls — doing both would put two entries on the Environments page per deploy.
 
 Deploy paths, in order of preference:
 
@@ -97,16 +99,21 @@ The container image is *not* built or pushed by this workflow. `worker/wrangler.
 gh secret set CLOUDFLARE_API_TOKEN -R robogeosociety/is-the-mountain-out
 ```
 
-Required permissions (all **Account**-scoped, restricted to that one account):
+Required permissions — **two**, both **Account**-scoped and restricted to that one account:
 
 | Permission | Why |
 | --- | --- |
-| `Workers Scripts: Edit` | Upload the script, its bindings, the DO migration, and the cron trigger. The one non-negotiable scope. |
-| `Workers R2 Storage: Edit` | `wrangler.toml` declares two `[[r2_buckets]]` bindings, resolved at deploy. Part of Cloudflare's own "Edit Cloudflare Workers" template. |
-| `Account Settings: Read` | Account lookup/validation during deploy. |
-| `Cloudflare Containers: Edit` | `wrangler.toml` has a `[[containers]]` block, so deploy also updates the container application (image ref, `max_instances`, `instance_type`). Without it the script uploads but the container step fails. |
+| `Workers Scripts: Edit` | Script upload, and with it the DO + R2 bindings, the `new_sqlite_classes` migration, and the `[triggers] crons` schedule. Non-negotiable. |
+| `Containers: Edit` | `wrangler.toml` has a `[[containers]]` block, so every deploy also PATCHes the container application (`/accounts/{id}/containers/applications`) with the image ref, `max_instances`, `instance_type`. Without it the script uploads and the container step 403s. |
 
-Not needed: `Cloudflare Images: Edit` (only for `wrangler containers push`, which CI does not do) and `Workers KV`/`D1`/`Queues` (no such bindings). If in doubt, Cloudflare's stock **"Edit Cloudflare Workers"** token template is a working superset; prefer the narrower list above. The token is *only* for CI — the operator's laptop keeps using `wrangler login`.
+Deliberately **not** granted, each for a reason:
+
+- `Workers R2 Storage: Edit` — an `[[r2_buckets]]` entry with an explicit `bucket_name` is pure script metadata; wrangler makes no R2 call. It only provisions buckets under the opt-in `--x-provision` flag. Add this only if CI ever runs `wrangler r2 …` itself (e.g. pushing a checkpoint).
+- `Cloudflare Images: Edit` — a different product entirely (imagedelivery.net). Managed-registry auth is brokered through the *containers* API, and CI does not push images anyway.
+- `User Details: Read` / `Memberships: Read` — only needed when wrangler has to discover the account. The workflow sets `CLOUDFLARE_ACCOUNT_ID`, so `/accounts` and `/memberships` are never called. Keep that env var: an account-owned token *cannot* carry User-scoped permissions (`/memberships` returns error 9106), so it is effectively mandatory there.
+- `Workers Routes: Edit` (zone) — the Worker is `workers.dev` + cron only, no zone routes.
+
+Cloudflare's stock **"Edit Cloudflare Workers"** template is *not* sufficient on its own: it omits Containers. If an unexplained 403 appears, that template **plus `Containers: Edit`** is the low-risk superset. (Known upstream wrinkle: [workers-sdk#12483](https://github.com/cloudflare/workers-sdk/issues/12483) — `/containers/applications` 401 despite a valid containers scope.) The token is *only* for CI; the operator's laptop keeps using `wrangler login`.
 
 Worker secrets themselves are still set out-of-band with `wrangler secret put` and only go live on the next deploy; CI does not manage them.
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ inference/            FastAPI server + Dockerfile for the Cloudflare Container
 worker/               Cloudflare Worker source (TypeScript) + wrangler.toml
 web/                  Public SPA (Vite + React), deployed by Cloudflare Pages
 ui/                   Internal classifier UI for bulk labeling (Vite + React)
-terraform/            Cloudflare Worker deploy (R2 buckets managed manually)
-scripts/              deploy-inference.sh — one-command Worker redeploy
+.github/workflows/    CI — ruff, worker tests, and the Worker deploy to Cloudflare
+scripts/              deploy-worker.sh — break-glass manual Worker redeploy
 ```
 
 ## Commands
@@ -176,9 +176,29 @@ uv run --group bot bot post-once    # post one labelable capture, then exit
 # Inference (server-side, used by the Cloudflare Container)
 uv run python tools/predict_state.py --config mountain.toml
 
-# Cloudflare Worker redeploy
-scripts/deploy-inference.sh   # see script header for required env vars
+# Cloudflare Worker tests (also run on every PR by .github/workflows/worker-ci.yml)
+cd worker && npm ci && npm test && npm run typecheck
 ```
+
+## Deploying the Worker
+
+**The Worker deploys from CI.** Pushing to `main` with changes under `worker/**`
+runs `.github/workflows/deploy-worker.yml`: worker tests + typecheck, then
+`wrangler deploy` into the `production` GitHub environment, recording a GitHub
+Deployment so the [Environments page](https://github.com/robogeosociety/is-the-mountain-out/deployments)
+shows what is actually live. Redeploy the current `main` by hand with:
+
+```bash
+gh workflow run deploy-worker.yml
+```
+
+CI authenticates with the repo secret `CLOUDFLARE_API_TOKEN` (see `CLAUDE.md` →
+Deployment (Cloudflare) for the required token scope). Without it the deploy job
+fails at its preflight step with an explicit message and deploys nothing.
+
+`scripts/deploy-worker.sh` is the **break-glass** path — for when Actions is
+down, the token is expired, or an uncommitted tree must ship. It uses your own
+`wrangler login` session and warns before it runs.
 
 ## Configuration
 
@@ -203,8 +223,9 @@ R2 S3 credentials (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`) live in `cf.env` 
 | Storage | Cloudflare R2 | (always) |
 | Public SPA | Cloudflare Pages | (always) |
 | Container image | GHCR | Built by GH Actions on push to main |
+| Worker deploy | GitHub Actions | Push to main touching `worker/**`, or `gh workflow run deploy-worker.yml` |
 
-GitHub's only remaining role is hosting the source repo and the container image registry. Nothing user-facing depends on GitHub Pages, GitHub Actions, or the operator's local machine being available — captures and training are operator-initiated, but the live site keeps serving and predicting on its own.
+GitHub hosts the source repo, the container image registry, and now the Worker's deploy pipeline. Nothing *user-facing* depends on GitHub being available: captures and training are operator-initiated, the live site keeps serving and predicting on its own, and if Actions is down the Worker can still be shipped by hand via `scripts/deploy-worker.sh`.
 
 ## Network access (Mac mini)
 

--- a/scripts/deploy-worker.sh
+++ b/scripts/deploy-worker.sh
@@ -1,12 +1,27 @@
 #!/usr/bin/env bash
-# Deploy the mountain-inference Worker + container via wrangler, and record a
-# GitHub Deployment so the repo's Environments page and the deployed commit show
-# deploy history plus the live URL.
+# BREAK-GLASS deploy path — NOT the normal one.
 #
-# This is the wrangler-direct deploy path (auth via `wrangler login`); it does
-# NOT use Terraform. The container image must already be in the Cloudflare
-# managed registry and referenced by worker/wrangler.toml — build/push it with
-# `wrangler containers push` first (see worker/wrangler.toml and the README).
+# The normal deploy is CI: .github/workflows/deploy-worker.yml runs the worker
+# tests + typecheck and then `wrangler deploy` on every push to main touching
+# worker/**, recording the same GitHub Deployment this script does. Prefer a
+# push to main, or `gh workflow run deploy-worker.yml`, over running this.
+#
+# Use this script only when CI cannot: GitHub Actions is down, the repo's
+# CLOUDFLARE_API_TOKEN is missing/expired, or you need to ship an uncommitted
+# working tree in an emergency. Because it deploys whatever is on YOUR disk, a
+# run from a dirty tree puts code in production that exists in no commit — the
+# GitHub Deployment it records will point at a ref that does not match the live
+# Worker. Commit first if at all possible.
+#
+# Deploys the mountain-inference Worker + container via wrangler and records a
+# GitHub Deployment, so the repo's Environments page and the deployed commit
+# show deploy history plus the live URL.
+#
+# Auth is `wrangler login` (interactive OAuth), unlike CI, which uses the
+# scoped CLOUDFLARE_API_TOKEN secret. It does NOT use Terraform. The container
+# image must already be in the Cloudflare managed registry and referenced by
+# worker/wrangler.toml — build/push it with `wrangler containers push` first
+# (see worker/wrangler.toml and the README).
 #
 # The GitHub Deployment is best-effort: a gh/API hiccup logs a warning but never
 # blocks the actual deploy. A failed `wrangler deploy` marks the deployment
@@ -34,6 +49,13 @@ command -v npx >/dev/null 2>&1 || { echo "npx (Node.js) not found in PATH" >&2; 
 
 REF="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 DEPLOY_ID=""
+
+warn "break-glass path — the normal deploy is CI (.github/workflows/deploy-worker.yml)."
+warn "Prefer: push to main (worker/** changes) or \`gh workflow run deploy-worker.yml\`."
+if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
+  warn "working tree is DIRTY: this deploys code that exists in no commit, and the"
+  warn "GitHub Deployment recorded for ${REF:0:7} will not match what goes live."
+fi
 
 create_deployment() {
   local body


### PR DESCRIPTION
`INFRA` — **DEPLOY DISPATCH**

# The Worker stops depending on one laptop being awake

> _Shipping `mountain-inference` meant a human running a shell script. Now main is the trigger — and the Worker's 13 tests finally sit in front of the merge button._

> [!NOTE]
> **ci/deploy** · feat · risk: low · no issue

`scripts/deploy-worker.sh` ships whatever is on one person's disk, from whatever branch, while that machine is awake. And the Worker's `npm test` (13 cases over the alert-debounce state machine) and `npm run typecheck` have never run in CI — only ruff gates PRs, so a TypeScript regression in `worker/src` merges clean and production notices first.

## Main is the trigger, tests are the gate

- **`worker-ci.yml`** — test + typecheck on **every** PR. Not path-filtered on purpose: a filtered job that never starts reports "pending" forever once it's a required check.
- **`deploy-worker.yml`** — push to `main` touching `worker/**` (or `gh workflow run`) → tests → `npx wrangler deploy`, in the `production` environment. It calls `worker-ci.yml` via `workflow_call`, so deploy gate and PR gate are one file, not two that drift.
- **Deployment bookkeeping comes free.** A job with `environment:` *already* opens a GitHub Deployment and moves it `in_progress` → `success`/`failure` with `environment_url` and a `log_url` — so no hand-rolled API calls, which would double every Environments-page entry.
- **The script becomes break-glass** — relabelled, warning at runtime, loudest on a dirty tree.
- **Approval is a checkbox away** — add a required reviewer to `production`; nothing here changes.

## How it flows

```mermaid
flowchart TD
    PR[Pull request] --> CI[worker-ci.yml<br/>test + typecheck]
    CI -->|green| Merge[Merge to main<br/>touching worker/**]
    Merge --> Deploy[deploy-worker.yml<br/>workflow_call: the same tests]
    Deploy --> Env[environment: production<br/>Deployment opens, in_progress]
    Env --> Pre{CLOUDFLARE_API_TOKEN?}
    Pre -->|missing| Fail[Clear error, nothing deployed]
    Pre -->|set| W[npx wrangler deploy]
    W --> S[Deployment: success / failure]
```

## The credential, and who creates it

Headless CI can't run `wrangler login`, so a scoped API token is the sanctioned exception to "never mint tokens" — **created by a human, not by this PR.** Until it exists the deploy job stops at its first step with an explicit `CLOUDFLARE_API_TOKEN not set` annotation and a job-summary panel containing the fix, never a wrangler stack trace.

Scope is two account permissions, narrowed against wrangler's source rather than guessed: `Workers Scripts: Edit` + `Containers: Edit`. `Workers R2 Storage: Edit` is **not** needed, and Cloudflare's own "Edit Cloudflare Workers" template is *insufficient* — it omits Containers. Reasoning + the `gh secret set` line: `CLAUDE.md` → Deployment (Cloudflare).

## Verification

- [x] PR gate green on Actions — run `30559579936`, alongside ruff.
- [x] Deploy path exercised on a throwaway branch (run `30559836026`, deleted since): tests green, deploy failed **at preflight** with the intended annotation, later steps skipped, exactly **one** Deployment record, `in_progress` → `failure`.
- [x] `actionlint` 1.7.12 clean across **all** repo workflows; `ruff@0.16.0` still clean.
- [ ] **A real deploy is unproven.** Without the secret, `wrangler deploy` itself has never run in CI. First real deploy: the first `worker/**` push to main after the token is set.

## Risk & rollout

Low and reversible: no `worker/src/**` or Python source touched, deploys are serialized (`cancel-in-progress: false`), break-glass still works, and container images stay out of scope. Fixed in passing: `README.md`'s dead `deploy-inference.sh`/`terraform/` references, and a `sharp`/node-gyp `npm ci` failure on macOS/arm64.
