### PR TITLE
feat(train): 99.8% was a fog detector's score

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,12 @@ Checkpoints saved to `train/checkpoints/`: `adapter_config.json`, `adapter_model
 
 `WebcamStream` fetches JPEG from the webcam URL and converts directly to a `(1, 3, 224, 224)` tensor (no intermediate disk writes). `WeatherFetcher` queries METAR for KSEA and returns `[visibility_sm, ceiling_ft]`. The scheduler accumulates gradients over `N` captures before stepping (configurable in `mountain.toml`).
 
+The `batch` command splits train/val **stratified per class, on unique labels, before oversampling, and seeded** (`--seed`, default 1337) — `stratified_split()`. That order is load-bearing: minority frames are oversampled ~5-7x, so splitting afterwards (as it did until 2026-07-30) put copies of the same image on both sides and inflated val accuracy. Val numbers from before that change are not comparable.
+
+### Evaluation metrics (`train/metrics.py`)
+
+**Accuracy is not the metric here.** The label set is 86.3% Not Out, so always answering "Not Out" scores 86.3%. Every validation pass builds a 3x3 confusion matrix and derives per-class precision/recall/F1/support, **macro-F1**, **balanced accuracy**, and a **Full+Partial "visible" binary view** — the last being the product question and what the Worker's alerts key on. Pure torch/stdlib arithmetic; scikit-learn stays a `dev`-group dependency. Results flow to `--json-summary` (`best_val_metrics`), each `per_epoch` record (`val_metrics`), `--progress-jsonl`, and the Discord embeds, which lead with macro-F1. All consumers tolerate the fields being absent (older runs). Details + the small-sample caveat: `TRAINING.md`.
+
 ### Data Collection (`collect/collector.py`)
 
 Writes timestamped directories: `data/YYYYMMDD/HHMMSS_us_UTC/{images/,metar/}`. Labels stored in `data/labels.yaml` as `{relative_path: label}`.
@@ -128,7 +134,7 @@ Confidence routes each tick to one of two posts (`worker/src/transition.ts`, boo
 - **Zero-disk training:** Live frames go directly to tensors — never written to disk during live loops.
 - **Dynamic port:** The classifier server picks a free port and writes it to `data/classifier_server.port`; the React UI fetches `config.json` at a relative path to discover it.
 - **MPS device:** Apple Silicon (MPS) is the primary target; falls back to CPU.
-- **Precision over recall:** The system is tuned to minimize false positives (announcing the mountain is out when it isn't).
+- **Precision over recall:** The system is tuned to minimize false positives (announcing the mountain is out when it isn't). Measured as `visible.precision` in `train/metrics.py` — before 2026-07-30 this constraint was stated but never measured.
 ## Pull requests — the "newspaper" framework
 
 PR descriptions follow the **newspaper / information-pyramid** format: one self-contained

--- a/TRAINING.md
+++ b/TRAINING.md
@@ -54,18 +54,76 @@ the mountain-specific instance.
    run and let the committed copy drift stale; R2 `checkpoints/` is the single
    source of truth and `load_checkpoint` falls back to it.
 
+## What "good" means — read macro-F1, not accuracy
+
+**Accuracy is not evidence on this label set.** Measured 2026-07-30 over 2010
+labels: 1735 Not Out (86.3%) / 164 Partial (8.2%) / 111 Full (5.5%). A model that
+answers "Not Out" to every frame scores **86.3% accuracy** while detecting the
+mountain exactly never. A 99% headline is therefore mostly a report on how well
+the model detects fog.
+
+`train/metrics.py` computes, every validation pass, from one confusion matrix:
+
+| Number | Why |
+| --- | --- |
+| **macro-F1** | Averaged over classes, so the majority class can't carry it. The all-"Not Out" predictor scores **0.31** here against 0.86 accuracy. This is the headline. |
+| **balanced accuracy** | Mean per-class recall. Chance is 33.3%; the degenerate predictor scores exactly that. |
+| per-class precision / recall / F1 / support | Where the errors actually are. `support` is printed everywhere on purpose — see the caveat below. |
+| **visible (Full+Partial vs Not Out)** | The product question, and what the Worker's alerts key on. Precision leads: the repo's constraint is *precision over recall* — a false positive is an alert claiming the mountain is out when it isn't. |
+| 3x3 confusion matrix | Rows = truth, columns = prediction. |
+
+These land in `--json-summary` (`best_val_metrics`), in every `per_epoch` record
+(`val_metrics`), and therefore in `--progress-jsonl`. Consumers must tolerate
+their absence — summaries written before this existed have neither.
+
+> **Caveat that matters more than any of the numbers.** With ~17 Full frames in
+> val, **one flipped frame moves Full recall by ~6 percentage points.** Treat
+> per-class recall on Full/Partial as a coarse signal with a ±1-frame error bar,
+> not a precise measurement; a 3pt week-over-week "improvement" is noise. The
+> fix is more Full/Partial labels, not more decimal places. The trainer prints a
+> warning when any val class drops below 20 frames.
+
+## Train/val split
+
+Stratified per class, **on unique labels, before oversampling**, seeded
+(`--seed`, default 1337). Each of those three properties fixes a real defect:
+
+- **Before oversampling.** Minority frames are duplicated ~5-7x for class
+  balance. The split previously ran on the *oversampled* list, so copies of the
+  same image landed on both sides and validation scored the model on frames it
+  had memorised. Historical val numbers — including the 99.8% that read as a
+  success — are inflated by this and **are not comparable to numbers from this
+  version**. Expect the first honest run to look worse. It isn't.
+- **Stratified.** With 111 Full labels, a naive random split can leave single
+  digits in val.
+- **Seeded.** An unseeded split redrew the val set every week, so week-over-week
+  deltas measured the dice as much as the model.
+
+A class with a single example keeps it in train — spending it on val would make
+the class untrainable *and* its recall a coin flip. Per-class val counts are
+reported in the summary (`val_class_counts`) and in the Discord embed.
+
 ## Run telemetry
 
 An unattended run reports to #mountain as it goes (`train/scheduled.py`), not
 just at the end:
 
 - **One start message**, edited in place with the final metrics when the run
-  finishes — best val loss and accuracy vs the previous run, dataset counts,
-  duration breakdown, and **peak memory**.
+  finishes — **macro-F1 (with a delta vs the previous run), balanced accuracy,
+  per-class recall/precision, the visible-vs-not-out collapse, and the confusion
+  matrix**, then best val loss, accuracy, dataset + val-split counts, duration
+  breakdown, and **peak memory**. Accuracy is still there; it is no longer the
+  headline, and its field name carries the 86.3% majority baseline next to it.
 - **One message per saved checkpoint**, posted live. Only an *improvement*
   saves a checkpoint, so a 5-epoch run posts ~3: epoch, val loss with the delta
-  over the previous best, val accuracy, epoch time, memory, and how many of the
-  3 checkpoint files reached R2.
+  over the previous best, macro-F1 / balanced accuracy, per-class recall, val
+  accuracy, epoch time, memory, and how many of the 3 checkpoint files reached
+  R2. Per-class recall is here because an improving val loss with a collapsing
+  Full recall is a regression wearing a green badge.
+
+The run-over-run macro-F1 delta comes from `best_macro_f1` on the R2 watermark
+(`labels/train-watermark.json`), written alongside `best_val_loss`. The first run
+after this landed has no previous value and says so.
 
 The mechanism is `training batch --progress-jsonl PATH`: the trainer appends one
 fsync'd JSON line per epoch (metrics + `memory_snapshot()` + whether a checkpoint

--- a/train/metrics.py
+++ b/train/metrics.py
@@ -1,0 +1,195 @@
+"""Per-class evaluation metrics — the numbers accuracy hides.
+
+The label set is severely imbalanced (measured 2026-07-30 over 2010 R2 labels:
+1735 Not Out / 164 Partial / 111 Full). A model that answers "Not Out" to every
+frame scores **86.3% accuracy**, so a headline accuracy near 99% says almost
+nothing about the only question this project actually asks — *is the mountain
+out?* Worse, the repo's stated constraint is "precision over recall: minimize
+false positives (announcing the mountain is out when it isn't)", and raw
+accuracy cannot express that at all.
+
+So this module computes, from a confusion matrix:
+
+* per-class precision / recall / F1 / support,
+* **macro-F1** and **balanced accuracy** — averages over classes, which the
+  all-majority predictor cannot game (it scores 0.31 / 0.33 where accuracy
+  scores 0.86),
+* a derived **"visible" binary view** (Full+Partial vs Not Out), because that
+  collapse is the product question and exactly what the Worker's alerts key on.
+
+Implemented with plain torch/numpy-free arithmetic on purpose: scikit-learn is a
+`dev`-group dependency only, and the trainer must not grow a main dependency for
+four divisions.
+
+Conventions: class indices follow `bot/labeler.py` — 0=Not Out, 1=Full,
+2=Partial. Confusion matrix rows are TRUE classes, columns are PREDICTED.
+Every rate is guarded against a zero denominator and reports 0.0 rather than
+NaN, so a class the model never predicts renders as "0% precision", not a crash.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+# Mirrors bot/labeler.py CLASS_NAMES / CLASS_LABELS — kept as a local constant so
+# train/ never has to import the bot (discord.py is a separate dependency group).
+CLASS_NAMES = ["not_out", "full", "partial"]
+CLASS_LABELS = ["Not Out", "Full", "Partial"]
+NUM_CLASSES = 3
+
+# The classes that mean "you can see the mountain". The Worker alerts on this
+# collapse, so it gets first-class precision/recall of its own.
+VISIBLE_CLASSES = (1, 2)
+
+
+def _to_int_list(values: Any) -> list[int]:
+    """Accept a torch tensor, numpy array, or any sequence of ints."""
+    if hasattr(values, "tolist"):
+        values = values.tolist()
+    if isinstance(values, int):
+        return [values]
+    return [int(v) for v in values]
+
+
+def confusion_matrix(
+    targets: Any, preds: Any, num_classes: int = NUM_CLASSES
+) -> list[list[int]]:
+    """Rows = true class, columns = predicted class.
+
+    Out-of-range indices are dropped rather than raising: a metrics probe must
+    never be the thing that kills an hour-long training run.
+    """
+    matrix = [[0] * num_classes for _ in range(num_classes)]
+    target_list = _to_int_list(targets)
+    pred_list = _to_int_list(preds)
+    for true_c, pred_c in zip(target_list, pred_list, strict=True):
+        if 0 <= true_c < num_classes and 0 <= pred_c < num_classes:
+            matrix[true_c][pred_c] += 1
+    return matrix
+
+
+def _safe_div(numerator: float, denominator: float) -> float:
+    return numerator / denominator if denominator else 0.0
+
+
+def _prf(tp: int, fp: int, fn: int) -> dict[str, float]:
+    precision = _safe_div(tp, tp + fp)
+    recall = _safe_div(tp, tp + fn)
+    f1 = _safe_div(2 * precision * recall, precision + recall)
+    return {
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "f1": round(f1, 4),
+    }
+
+
+def metrics_from_confusion(matrix: Sequence[Sequence[int]]) -> dict[str, Any]:
+    """Every headline number this project should be judged on, from one matrix.
+
+    Macro-F1 and balanced accuracy average over the classes **present in the
+    val set** (support > 0). Averaging over an absent class would drag both
+    numbers toward zero for a reason that has nothing to do with the model, and
+    a val split that lost a class entirely is a split bug to fix, not a score to
+    report. `macro_classes` names what was averaged, so the number is never
+    silently computed over a different denominator than the reader assumes.
+    """
+    num_classes = len(matrix)
+    total = sum(sum(row) for row in matrix)
+    correct = sum(matrix[c][c] for c in range(num_classes))
+
+    per_class: dict[str, dict[str, float]] = {}
+    recalls: list[float] = []
+    f1s: list[float] = []
+    macro_classes: list[str] = []
+
+    for c in range(num_classes):
+        tp = matrix[c][c]
+        fn = sum(matrix[c]) - tp
+        fp = sum(matrix[r][c] for r in range(num_classes)) - tp
+        support = tp + fn
+        stats = _prf(tp, fp, fn)
+        stats["support"] = support
+        stats["predicted"] = tp + fp
+        name = CLASS_NAMES[c] if c < len(CLASS_NAMES) else f"class_{c}"
+        per_class[name] = stats
+        if support > 0:
+            recalls.append(stats["recall"])
+            f1s.append(stats["f1"])
+            macro_classes.append(name)
+
+    # Binary collapse: positive = "visible" (Full or Partial).
+    vis_tp = sum(
+        matrix[t][p]
+        for t in VISIBLE_CLASSES
+        for p in VISIBLE_CLASSES
+        if t < num_classes
+    )
+    vis_fn = sum(sum(matrix[t]) for t in VISIBLE_CLASSES if t < num_classes) - vis_tp
+    vis_fp = sum(
+        matrix[t][p]
+        for t in range(num_classes)
+        for p in VISIBLE_CLASSES
+        if t not in VISIBLE_CLASSES
+    )
+    visible = _prf(vis_tp, vis_fp, vis_fn)
+    visible["support"] = vis_tp + vis_fn
+    visible["predicted"] = vis_tp + vis_fp
+
+    return {
+        "accuracy": round(_safe_div(correct, total), 4),
+        "macro_f1": round(_safe_div(sum(f1s), len(f1s)), 4),
+        "balanced_accuracy": round(_safe_div(sum(recalls), len(recalls)), 4),
+        "macro_classes": macro_classes,
+        "per_class": per_class,
+        "visible": visible,
+        "confusion": [list(row) for row in matrix],
+        "n": total,
+    }
+
+
+def compute_metrics(
+    targets: Any, preds: Any, num_classes: int = NUM_CLASSES
+) -> dict[str, Any]:
+    """Convenience wrapper: predictions + truth in, the full metric block out."""
+    return metrics_from_confusion(confusion_matrix(targets, preds, num_classes))
+
+
+def format_confusion(metrics: dict[str, Any] | None) -> str:
+    """A 3x3 matrix as fixed-width text.
+
+    Nine Discord embed fields would blow the embed budget and read worse than
+    the table does; callers wrap this in a code block.
+    """
+    matrix = (metrics or {}).get("confusion")
+    if not matrix:
+        return "n/a"
+    header = "true\\pred  " + "".join(f"{label:>9}" for label in CLASS_LABELS)
+    lines = [header]
+    for c, row in enumerate(matrix):
+        label = CLASS_LABELS[c] if c < len(CLASS_LABELS) else f"class_{c}"
+        lines.append(f"{label:<10}" + "".join(f"{value:>9}" for value in row))
+    return "\n".join(lines)
+
+
+def summary_line(metrics: dict[str, Any] | None) -> str:
+    """One-line console rendering for the epoch log."""
+    if not metrics:
+        return "no metrics"
+    per_class = metrics.get("per_class", {})
+    parts = [
+        f"macro_f1={metrics.get('macro_f1', 0.0):.3f}",
+        f"bal_acc={metrics.get('balanced_accuracy', 0.0):.1%}",
+    ]
+    for name, label in zip(CLASS_NAMES, CLASS_LABELS, strict=True):
+        stats = per_class.get(name)
+        if not stats:
+            continue
+        parts.append(
+            f"{label}: P{stats['precision']:.2f}/R{stats['recall']:.2f}"
+            f"(n={stats['support']})"
+        )
+    visible = metrics.get("visible")
+    if visible:
+        parts.append(f"visible: P{visible['precision']:.2f}/R{visible['recall']:.2f}")
+    return "  ".join(parts)

--- a/train/scheduled.py
+++ b/train/scheduled.py
@@ -39,6 +39,7 @@ import requests
 
 from bot.labeler import EVENTS_KEY, uncached_storage
 from train.config_loader import ConfigLoader
+from train.metrics import CLASS_LABELS, CLASS_NAMES, format_confusion
 
 WATERMARK_KEY = "labels/train-watermark.json"
 
@@ -143,6 +144,94 @@ def _acc_delta_text(acc: float | None, previous: float | None) -> str:
     return f"{acc:.1%} — {arrow} {abs(delta_pt):.1f}pt vs last ({previous:.1%})"
 
 
+def _f1_delta_text(macro_f1: float | None, previous: float | None) -> str:
+    """Macro-F1 with a run-over-run delta.
+
+    Macro-F1 is the headline because accuracy is not one: on this label set
+    (86% Not Out) a model that never says "out" scores 86% accuracy and 0.31
+    macro-F1. Higher is better, so arrows match `_acc_delta_text`, not the loss
+    delta. Reported to 3 decimals — 2 hides the movement small val classes make.
+    """
+    if macro_f1 is None:
+        return "n/a — run predates per-class metrics"
+    if previous is None:
+        return f"{macro_f1:.3f} — no previous run to compare"
+    delta = macro_f1 - previous
+    if abs(delta) < 0.0005:
+        return f"{macro_f1:.3f} — unchanged vs last"
+    arrow = "▲ improved" if delta > 0 else "▼ regressed"
+    return f"{macro_f1:.3f} — {arrow} {abs(delta):.3f} vs last ({previous:.3f})"
+
+
+def _recall_text(metrics: Mapping[str, Any] | None) -> str:
+    """Per-class recall + precision for the two classes anyone cares about.
+
+    Not Out is included last for completeness, but Full and Partial lead: they
+    are 5.5% and 8.2% of the data, and they are the entire product. `n=` is the
+    val support, printed on purpose — at n≈17 one flipped frame is ~6pt of
+    recall, and a reader who cannot see the denominator will over-read the move.
+    """
+    if not metrics:
+        return "n/a — run predates per-class metrics"
+    per_class = metrics.get("per_class") or {}
+    lines = []
+    for name, label in zip(CLASS_NAMES, CLASS_LABELS, strict=True):
+        stats = per_class.get(name)
+        if not stats:
+            continue
+        if not stats.get("support"):
+            lines.append(f"**{label}** — absent from val set")
+            continue
+        lines.append(
+            f"**{label}** recall {float(stats['recall']):.0%} · "
+            f"precision {float(stats['precision']):.0%} (n={stats['support']})"
+        )
+    return "\n".join(lines) or "n/a"
+
+
+def _visible_text(metrics: Mapping[str, Any] | None) -> str:
+    """The product question: Full+Partial collapsed against Not Out.
+
+    Precision leads because the repo's stated constraint is precision over
+    recall — a false positive is an alert claiming the mountain is out when it
+    is not, which is the failure users actually notice.
+    """
+    if not metrics:
+        return "n/a — run predates per-class metrics"
+    visible = metrics.get("visible")
+    if not visible:
+        return "n/a"
+    return (
+        f"precision {float(visible['precision']):.0%} · "
+        f"recall {float(visible['recall']):.0%} "
+        f"(n={visible.get('support', '?')} visible frames in val)"
+    )
+
+
+def _confusion_text(metrics: Mapping[str, Any] | None) -> str:
+    """A code block, not nine embed fields — 9 fields would eat the embed."""
+    if not metrics or not metrics.get("confusion"):
+        return "n/a — run predates per-class metrics"
+    return f"```\n{format_confusion(dict(metrics))}\n```"
+
+
+def _best_metrics(summary: Mapping[str, Any]) -> dict | None:
+    """The metric block from the epoch that saved the model.
+
+    Older summaries have neither `best_val_metrics` nor per-epoch `val_metrics`
+    — they predate this feature — so every caller must tolerate None, the same
+    way `result_embed` already falls back for `best_val_acc`.
+    """
+    best = summary.get("best_val_metrics")
+    if best:
+        return dict(best)
+    best_epoch = summary.get("best_epoch")
+    for epoch in summary.get("per_epoch") or []:
+        if epoch.get("epoch") == best_epoch and epoch.get("val_metrics"):
+            return dict(epoch["val_metrics"])
+    return None
+
+
 def _gb(mb: float) -> str:
     return f"{mb / 1024:.2f} GB"
 
@@ -188,11 +277,23 @@ def checkpoint_embed(record: Mapping[str, Any]) -> dict:
         else f"▼ {float(previous) - val_loss:.4f} better than {float(previous):.4f}"
     )
     keys = record.get("checkpoint_keys") or []
-    return {
-        "title": f"💾 Checkpoint saved — epoch {record.get('epoch', '?')}/{record.get('total_epochs', '?')}",
-        "color": COLOR_OK if len(keys) == 3 else COLOR_FAILED,
-        "fields": [
-            {"name": "Val loss", "value": f"{val_loss:.4f} — {delta}", "inline": False},
+    metrics = record.get("val_metrics")
+    fields = [
+        {"name": "Val loss", "value": f"{val_loss:.4f} — {delta}", "inline": False},
+    ]
+    if metrics:
+        fields.append(
+            {
+                "name": "Macro-F1 / balanced acc",
+                "value": (
+                    f"{float(metrics.get('macro_f1', 0.0)):.3f} / "
+                    f"{float(metrics.get('balanced_accuracy', 0.0)):.1%}"
+                ),
+                "inline": True,
+            }
+        )
+    fields.extend(
+        [
             {
                 "name": "Val accuracy",
                 "value": f"{float(record.get('val_acc', 0.0)):.1%}",
@@ -203,13 +304,29 @@ def checkpoint_embed(record: Mapping[str, Any]) -> dict:
                 "value": f"{float(record.get('duration_s', 0.0)) / 60:.1f} min",
                 "inline": True,
             },
+        ]
+    )
+    if metrics:
+        # Per-class recall on the checkpoint post too: an improving val loss
+        # with a collapsing Full recall is a regression wearing a green badge,
+        # and this is the message that gets read while the run is still going.
+        fields.append(
+            {"name": "Per class", "value": _recall_text(metrics), "inline": False}
+        )
+    fields.extend(
+        [
             {
                 "name": "Memory",
                 "value": _memory_text(record.get("memory")),
                 "inline": False,
             },
             {"name": "Uploaded", "value": f"{len(keys)}/3 files → R2", "inline": True},
-        ],
+        ]
+    )
+    return {
+        "title": f"💾 Checkpoint saved — epoch {record.get('epoch', '?')}/{record.get('total_epochs', '?')}",
+        "color": COLOR_OK if len(keys) == 3 else COLOR_FAILED,
+        "fields": fields,
         "footer": {"text": "is-the-mountain-out • scheduled training"},
         "timestamp": datetime.now(UTC).isoformat(),
     }
@@ -235,6 +352,7 @@ def result_embed(
     previous_best: float | None,
     duration_s: float,
     previous_best_acc: float | None = None,
+    previous_macro_f1: float | None = None,
 ) -> dict:
     counts = summary.get("class_counts", {})
     dataset = (
@@ -242,6 +360,15 @@ def result_embed(
         f"({counts.get('not_out', '?')}/{counts.get('full', '?')}/{counts.get('partial', '?')} "
         "Not Out/Full/Partial)"
     )
+    val_counts = summary.get("val_class_counts")
+    if val_counts:
+        # The denominator behind every per-class rate below. Without it the
+        # recall numbers look far more precise than 16 val frames can support.
+        dataset += (
+            f"\nval split: {val_counts.get('not_out', '?')}/"
+            f"{val_counts.get('full', '?')}/{val_counts.get('partial', '?')}"
+            f" (seed {summary.get('split_seed', '?')})"
+        )
     best = summary.get("best_val_loss")
     best_epoch = summary.get("best_epoch")
     per_epoch = summary.get("per_epoch") or [{}]
@@ -257,9 +384,16 @@ def result_embed(
         if len(uploaded) == 3
         else f"⚠️ only {len(uploaded)}/3 files uploaded — check logs"
     )
+    metrics = _best_metrics(summary)
+    macro_f1 = metrics.get("macro_f1") if metrics else None
+    balanced = metrics.get("balanced_accuracy") if metrics else None
     return {
         "title": "🧠 Weekly training run",
         "color": COLOR_OK if len(uploaded) == 3 else COLOR_FAILED,
+        # Order is the message. Macro-F1 and per-class recall come FIRST because
+        # raw accuracy on an 86%-majority label set is not evidence the model
+        # works — 86.3% of it is available by always answering "Not Out".
+        # Accuracy stays, demoted, so run-over-run history remains readable.
         "fields": [
             {
                 "name": "Trigger",
@@ -268,12 +402,37 @@ def result_embed(
             },
             {"name": "Dataset", "value": dataset, "inline": False},
             {
+                "name": "Macro-F1 (headline)",
+                "value": _f1_delta_text(macro_f1, previous_macro_f1),
+                "inline": False,
+            },
+            {
+                "name": "Balanced accuracy",
+                "value": (
+                    f"{balanced:.1%} (chance = 33.3%)"
+                    if balanced is not None
+                    else "n/a — run predates per-class metrics"
+                ),
+                "inline": True,
+            },
+            {
+                "name": "Mountain visible (Full+Partial)",
+                "value": _visible_text(metrics),
+                "inline": False,
+            },
+            {"name": "Per class", "value": _recall_text(metrics), "inline": False},
+            {
+                "name": "Confusion (rows = truth)",
+                "value": _confusion_text(metrics),
+                "inline": False,
+            },
+            {
                 "name": "Best val loss",
                 "value": f"{best:.4f} (epoch {best_epoch}) — {_delta_text(best, previous_best)}",
                 "inline": False,
             },
             {
-                "name": "Val accuracy",
+                "name": "Val accuracy (majority baseline 86.3%)",
                 "value": _acc_delta_text(best_val_acc, previous_best_acc),
                 "inline": False,
             },
@@ -528,6 +687,7 @@ def main(config: str, data_root: str, check: bool) -> None:
         telemetry.update(failure_embed(len(pending), reason))
         sys.exit(1)
 
+    best_metrics = _best_metrics(summary) or {}
     save_watermark(
         storage,
         {
@@ -536,6 +696,10 @@ def main(config: str, data_root: str, check: bool) -> None:
             "labels_total": summary.get("labels_loaded"),
             "best_val_loss": summary.get("best_val_loss"),
             "best_val_acc": summary.get("best_val_acc"),
+            # Carried so NEXT week's embed can show a macro-F1 delta. Absent on
+            # watermarks written before this landed — every reader defaults it.
+            "best_macro_f1": best_metrics.get("macro_f1"),
+            "best_balanced_accuracy": best_metrics.get("balanced_accuracy"),
             "epochs": epochs,
         },
     )
@@ -546,6 +710,7 @@ def main(config: str, data_root: str, check: bool) -> None:
             watermark.get("best_val_loss"),
             duration_s,
             previous_best_acc=watermark.get("best_val_acc"),
+            previous_macro_f1=watermark.get("best_macro_f1"),
         )
     )
     print(

--- a/train/scheduler.py
+++ b/train/scheduler.py
@@ -9,6 +9,7 @@ import typer
 from torch import optim
 
 from train.config_loader import ConfigLoader
+from train.metrics import compute_metrics, summary_line
 from train.model import ConvNextLoRAModel
 from train.utils import WeatherFetcher, WebcamStream
 
@@ -54,6 +55,39 @@ def memory_snapshot() -> dict:
     except Exception:  # noqa: BLE001 — probe only
         pass
     return snapshot
+
+
+def stratified_split(
+    by_class: dict[int, list[str]], val_fraction: float, rng
+) -> tuple[dict[int, list[str]], dict[int, list[str]]]:
+    """Split UNIQUE items per class into (train, val), deterministically.
+
+    Two properties this function exists to guarantee, both of which the previous
+    inline split lacked:
+
+    1. **It runs on unique items, before oversampling.** Oversampling duplicates
+       each minority frame ~8x. Splitting the oversampled list put copies of the
+       same image on both sides, so validation scored the model on frames it had
+       memorised — the mechanism behind a 99.8% val accuracy on a class holding
+       5.5% of the data.
+    2. **It is seeded.** An unseeded split redraws the val set on every run, so
+       week-over-week metric deltas measured the dice, not the model.
+
+    A class with a single example keeps it in train: spending it on val would
+    make the class untrainable *and* its recall a coin flip.
+    """
+    train: dict[int, list[str]] = {}
+    val: dict[int, list[str]] = {}
+    for cls, items in by_class.items():
+        # sorted() first so the result depends on the seed, not on dict or
+        # filesystem ordering.
+        shuffled = sorted(items)
+        rng.shuffle(shuffled)
+        n = len(shuffled)
+        n_val = 0 if n < 2 else min(max(1, round(n * val_fraction)), n - 1)
+        val[cls] = shuffled[:n_val]
+        train[cls] = shuffled[n_val:]
+    return train, val
 
 
 class Trainer:
@@ -191,6 +225,14 @@ def batch(
         "checkpoint was saved) as the run proceeds, so a supervisor can report "
         "progress live instead of waiting for --json-summary at the end.",
     ),
+    seed: int = typer.Option(
+        1337,
+        "--seed",
+        help="Seed for the train/val split, oversampling and epoch shuffles. "
+        "Fixed by default so two runs' val metrics are comparable — an unseeded "
+        "split redraws the val set every week and turns run-over-run deltas "
+        "into noise.",
+    ),
 ):
     """Runs training using a labels index. Pass --labels path/to/labels.yaml or a folder containing labels.yaml."""
     from datetime import UTC, datetime
@@ -200,6 +242,7 @@ def batch(
     uploaded_keys: list[str] = []
     best_epoch: int | None = None
     best_val_acc: float | None = None
+    best_val_metrics: dict | None = None
 
     def _write_summary(status: str, **extra) -> None:
         """Atomic (tmp+rename) summary write; a scheduled wrapper parses this
@@ -272,7 +315,6 @@ def batch(
             labels_map = yaml.safe_load(f) or {}
         print(f"Loaded {len(labels_map)} labels from {labels_file}")
 
-    # Strategy: Oversample minority classes (Full = 1, Partial = 2)
     labels_full = {path: label for path, label in labels_map.items() if label == 1}
     labels_partial = {path: label for path, label in labels_map.items() if label == 2}
     labels_not_out = {path: label for path, label in labels_map.items() if label == 0}
@@ -281,34 +323,45 @@ def batch(
         f"Dataset stats: {len(labels_not_out)} Not Out, {len(labels_full)} Full, {len(labels_partial)} Partial"
     )
 
-    # We want a reasonable representation of all visible mountain frames
-    # Target: 1:2:2 ratio (NotOut : Full : Partial) or similar
-    max_not_out = len(labels_not_out)
-
-    final_training_list = []
-    # Add all 'Not Out' once
-    for p, label in labels_not_out.items():
-        final_training_list.append((p, label))
-
-    # Oversample 'Full'
-    if labels_full:
-        full_factor = max(1, max_not_out // (len(labels_full) * 2))
-        for p, label in labels_full.items():
-            for _ in range(full_factor):
-                final_training_list.append((p, label))
-        print(f"  Oversampling 'Full' by {full_factor}x")
-
-    # Oversample 'Partial'
-    if labels_partial:
-        partial_factor = max(1, max_not_out // (len(labels_partial) * 2))
-        for p, label in labels_partial.items():
-            for _ in range(partial_factor):
-                final_training_list.append((p, label))
-        print(f"  Oversampling 'Partial' by {partial_factor}x")
-
     import random
 
-    random.shuffle(final_training_list)
+    rng = random.Random(seed)
+
+    # SPLIT FIRST, THEN OVERSAMPLE.
+    #
+    # This order is the whole point. Oversampling duplicates each minority frame
+    # ~8x; splitting the oversampled list afterwards puts copies of the SAME
+    # image in both train and val, so the model is scored on frames it memorised
+    # — which is how a 5.5%-of-the-data class produced a 99.8% val accuracy.
+    # Splitting the unique labels first keeps val honest, and oversampling only
+    # the train side keeps the class-balance benefit it was added for.
+    train_by_class, val_by_class = stratified_split(
+        {
+            0: list(labels_not_out),
+            1: list(labels_full),
+            2: list(labels_partial),
+        },
+        val_fraction=0.15,
+        rng=rng,
+    )
+
+    val_list = [(p, cls) for cls, paths in val_by_class.items() for p in paths]
+    rng.shuffle(val_list)
+
+    # Oversample the minority classes — TRAIN SIDE ONLY.
+    # Target: roughly 1:2:2 (NotOut : Full : Partial) representation.
+    max_not_out = len(train_by_class[0])
+    final_training_list = [(p, 0) for p in train_by_class[0]]
+    for cls, name in ((1, "Full"), (2, "Partial")):
+        paths = train_by_class[cls]
+        if not paths:
+            continue
+        factor = max(1, max_not_out // (len(paths) * 2))
+        for p in paths:
+            final_training_list.extend([(p, cls)] * factor)
+        print(f"  Oversampling '{name}' by {factor}x")
+
+    rng.shuffle(final_training_list)
 
     print(f"Final training set size: {len(final_training_list)} samples.")
 
@@ -332,7 +385,10 @@ def batch(
 
     if isinstance(storage, CachedR2Storage):
         prefetch_keys = []
-        for rel_path, _ in final_training_list:
+        # Val frames are no longer duplicated inside the training list, so they
+        # have to be prefetched explicitly or every validation pass would fall
+        # back to per-image R2 GETs.
+        for rel_path, _ in final_training_list + val_list:
             prefetch_keys.append(rel_path)
             # Also add METAR file keys (try all fallback patterns)
             img_p = Path(rel_path)
@@ -349,21 +405,27 @@ def batch(
 
     batch_size = 16
 
-    # Stratified train/val split (85/15)
-    from collections import defaultdict
-
-    by_class = defaultdict(list)
-    for item in final_training_list:
-        by_class[item[1]].append(item)
-    train_list, val_list = [], []
-    for cls, items in by_class.items():
-        random.shuffle(items)
-        split = max(1, int(len(items) * 0.15))
-        val_list.extend(items[:split])
-        train_list.extend(items[split:])
-    random.shuffle(train_list)
-    random.shuffle(val_list)
-    print(f"Train/Val split: {len(train_list)} train, {len(val_list)} val")
+    train_list = final_training_list
+    val_class_counts = {
+        name: len(val_by_class[cls])
+        for cls, name in ((0, "not_out"), (1, "full"), (2, "partial"))
+    }
+    train_class_counts_unique = {
+        name: len(train_by_class[cls])
+        for cls, name in ((0, "not_out"), (1, "full"), (2, "partial"))
+    }
+    print(
+        f"Train/Val split (seed {seed}): {len(train_list)} train samples "
+        f"({sum(train_class_counts_unique.values())} unique), {len(val_list)} val"
+    )
+    print(f"  Val per class: {val_class_counts}")
+    if min(val_class_counts.values()) < 20:
+        # Say it out loud: at these counts one flipped frame moves that class's
+        # recall by several points, so small deltas are noise, not progress.
+        print(
+            "  ⚠️ small val classes — per-class recall moves by "
+            f"~{100 / max(1, min(val_class_counts.values())):.0f}pt per frame"
+        )
 
     total_batches = (len(train_list) + batch_size - 1) // batch_size
 
@@ -460,10 +522,18 @@ def batch(
         )
 
     def _run_validation():
-        """Run validation pass batch-by-batch, return average loss and accuracy."""
+        """Validation pass, batch by batch → (loss, accuracy, per-class metrics).
+
+        Predictions and truth are accumulated as plain ints (on CPU, one small
+        list) so the confusion matrix — and everything derived from it — comes
+        out of the same forward passes accuracy already needed. No second pass,
+        no extra memory of consequence.
+        """
         trainer.model_wrapper.model_dict.eval()
         cw = class_weights.to(trainer.device)
         total_loss, correct, total = 0.0, 0, 0
+        all_preds: list[int] = []
+        all_targets: list[int] = []
         buf_img, buf_w, buf_l = [], [], []
 
         def _flush():
@@ -477,9 +547,12 @@ def batch(
             total_loss += torch.nn.functional.cross_entropy(
                 outputs, lb, weight=cw
             ).item() * lb.size(0)
-            correct += (outputs.argmax(1) == lb).sum().item()
+            predicted = outputs.argmax(1)
+            correct += (predicted == lb).sum().item()
             total += lb.size(0)
-            del ib, wb, lb, outputs
+            all_preds.extend(predicted.detach().cpu().tolist())
+            all_targets.extend(lb.detach().cpu().tolist())
+            del ib, wb, lb, outputs, predicted
             if trainer.device == "mps":
                 torch.mps.empty_cache()
 
@@ -495,9 +568,10 @@ def batch(
                     _flush()
                     buf_img, buf_w, buf_l = [], [], []
             _flush()
+        metrics = compute_metrics(all_targets, all_preds)
         if total == 0:
-            return float("nan"), 0.0
-        return total_loss / total, correct / total
+            return float("nan"), 0.0, metrics
+        return total_loss / total, correct / total, metrics
 
     best_val_loss = float("inf")
 
@@ -511,7 +585,7 @@ def batch(
 
         for epoch in range(epochs):
             epoch_started = time.monotonic()
-            random.shuffle(train_list)
+            rng.shuffle(train_list)
             batch_task = progress.add_task(
                 f"[cyan]Epoch {epoch + 1}/{epochs}...", total=total_batches
             )
@@ -623,22 +697,28 @@ def batch(
             )
 
             # Validation
-            val_loss, val_acc = _run_validation()
+            val_loss, val_acc, val_metrics = _run_validation()
+            macro_f1 = val_metrics.get("macro_f1", 0.0)
             progress.remove_task(batch_task)
             progress.update(
                 epoch_task,
                 advance=1,
-                description=f"[green]Epoch {epoch + 1}: train={avg_loss:.4f} val={val_loss:.4f} acc={val_acc:.1%}",
+                description=f"[green]Epoch {epoch + 1}: train={avg_loss:.4f} val={val_loss:.4f} macroF1={macro_f1:.3f}",
             )
             print(
                 f"  Epoch {epoch + 1}: train_loss={avg_loss:.4f}  val_loss={val_loss:.4f}  val_acc={val_acc:.1%}"
             )
+            print(f"    {summary_line(val_metrics)}")
             record = {
                 "epoch": epoch + 1,
                 "total_epochs": epochs,
                 "train_loss": avg_loss,
                 "val_loss": val_loss,
                 "val_acc": val_acc,
+                # Per-class precision/recall/F1, the confusion matrix, macro-F1,
+                # balanced accuracy and the Full+Partial "visible" collapse.
+                # Flows to --json-summary and --progress-jsonl via this dict.
+                "val_metrics": val_metrics,
                 "duration_s": round(time.monotonic() - epoch_started, 1),
                 "memory": memory_snapshot(),
                 "checkpoint_saved": False,
@@ -652,6 +732,7 @@ def batch(
                 best_val_loss = val_loss
                 best_epoch = epoch + 1
                 best_val_acc = val_acc
+                best_val_metrics = val_metrics
                 uploaded_keys = trainer.model_wrapper.save_checkpoint(
                     trainer.config_loader.checkpoint_dir, storage=storage
                 )
@@ -705,8 +786,14 @@ def batch(
         },
         train_n=len(train_list),
         val_n=len(val_list),
+        train_class_counts=train_class_counts_unique,
+        val_class_counts=val_class_counts,
+        split_seed=seed,
         best_val_loss=best_val_loss,
         best_val_acc=best_val_acc,
+        # The headline block: macro-F1 / balanced accuracy / per-class P-R-F1 /
+        # confusion / visible-vs-not-out, from the epoch that saved the model.
+        best_val_metrics=best_val_metrics,
         prefetch_s=prefetch_s,
     )
 

--- a/train/tests/test_metrics.py
+++ b/train/tests/test_metrics.py
@@ -1,0 +1,205 @@
+"""Tests for train.metrics — the numbers that accuracy was hiding.
+
+The motivating case has its own test (`test_all_majority_predictor_*`): on this
+project's real class balance, answering "Not Out" every time scores 86%
+accuracy. If macro-F1 does not collapse there, the metric is worthless and the
+whole change is theatre.
+"""
+
+import torch
+
+from train.metrics import (
+    compute_metrics,
+    confusion_matrix,
+    format_confusion,
+    metrics_from_confusion,
+    summary_line,
+)
+
+# The real label balance, measured over 2010 R2 labels on 2026-07-30, scaled to
+# a 100-frame val set: 86 Not Out / 6 Full / 8 Partial.
+REAL_BALANCE = [0] * 86 + [1] * 6 + [2] * 8
+
+
+class TestConfusionMatrix:
+    def test_rows_are_truth_columns_are_predictions(self):
+        # One true-Full frame predicted Not Out => row 1, column 0.
+        matrix = confusion_matrix([1], [0])
+        assert matrix[1][0] == 1
+        assert sum(sum(row) for row in matrix) == 1
+
+    def test_accepts_torch_tensors(self):
+        targets = torch.tensor([0, 1, 2, 1])
+        preds = torch.tensor([0, 1, 2, 0])
+        assert confusion_matrix(targets, preds) == [
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 0, 1],
+        ]
+
+    def test_out_of_range_indices_are_dropped_not_fatal(self):
+        # A telemetry probe must never be what kills an hour-long run.
+        assert sum(sum(r) for r in confusion_matrix([0, 7], [0, 0])) == 1
+
+    def test_empty_input_is_all_zeros(self):
+        assert confusion_matrix([], []) == [[0] * 3 for _ in range(3)]
+
+
+class TestPerfectPredictor:
+    def test_everything_is_one(self):
+        metrics = compute_metrics(REAL_BALANCE, REAL_BALANCE)
+        assert metrics["accuracy"] == 1.0
+        assert metrics["macro_f1"] == 1.0
+        assert metrics["balanced_accuracy"] == 1.0
+        for stats in metrics["per_class"].values():
+            assert stats["precision"] == 1.0
+            assert stats["recall"] == 1.0
+            assert stats["f1"] == 1.0
+        assert metrics["visible"]["precision"] == 1.0
+        assert metrics["visible"]["recall"] == 1.0
+        # Support adds up to the frames that went in.
+        assert metrics["n"] == len(REAL_BALANCE)
+        assert metrics["visible"]["support"] == 14
+
+
+class TestAllMajorityPredictor:
+    """THE case this whole change exists for."""
+
+    METRICS = compute_metrics(REAL_BALANCE, [0] * len(REAL_BALANCE))
+
+    def test_accuracy_looks_great_and_means_nothing(self):
+        assert self.METRICS["accuracy"] == 0.86
+
+    def test_macro_f1_is_far_below_accuracy(self):
+        # 0.86 accuracy, 0.31 macro-F1: the gap IS the finding.
+        assert self.METRICS["macro_f1"] < 0.35
+        assert self.METRICS["accuracy"] - self.METRICS["macro_f1"] > 0.5
+
+    def test_balanced_accuracy_is_chance(self):
+        # One class right, two at zero recall => 1/3.
+        assert abs(self.METRICS["balanced_accuracy"] - 1 / 3) < 0.001
+
+    def test_the_mountain_is_never_detected(self):
+        for name in ("full", "partial"):
+            assert self.METRICS["per_class"][name]["recall"] == 0.0
+            assert self.METRICS["per_class"][name]["f1"] == 0.0
+        visible = self.METRICS["visible"]
+        assert visible["recall"] == 0.0
+        assert visible["predicted"] == 0
+        # Zero predicted positives must not raise; precision is 0.0, not NaN.
+        assert visible["precision"] == 0.0
+
+    def test_not_out_recall_is_perfect_which_is_the_trap(self):
+        assert self.METRICS["per_class"]["not_out"]["recall"] == 1.0
+        assert self.METRICS["per_class"]["not_out"]["precision"] == 0.86
+
+
+class TestPrecisionRecallMath:
+    def test_matches_hand_computed_values(self):
+        # true:  0 0 0 1 1 2
+        # pred:  0 0 1 1 2 2
+        targets = [0, 0, 0, 1, 1, 2]
+        preds = [0, 0, 1, 1, 2, 2]
+        metrics = compute_metrics(targets, preds)
+        not_out = metrics["per_class"]["not_out"]
+        assert not_out["precision"] == 1.0  # 2 predicted, 2 right
+        assert round(not_out["recall"], 4) == round(2 / 3, 4)
+        full = metrics["per_class"]["full"]
+        assert full["precision"] == 0.5  # 2 predicted (one was a true Not Out)
+        assert full["recall"] == 0.5
+        partial = metrics["per_class"]["partial"]
+        assert partial["precision"] == 0.5
+        assert partial["recall"] == 1.0
+        assert metrics["accuracy"] == round(4 / 6, 4)
+
+    def test_f1_is_the_harmonic_mean(self):
+        metrics = compute_metrics([1, 1, 0, 0], [1, 0, 0, 0])
+        full = metrics["per_class"]["full"]
+        expected = (
+            2
+            * full["precision"]
+            * full["recall"]
+            / (full["precision"] + full["recall"])
+        )
+        assert abs(full["f1"] - expected) < 1e-4
+
+
+class TestVisibleBinaryView:
+    def test_full_and_partial_confusion_is_not_a_visible_error(self):
+        # Calling a Full frame Partial still means "the mountain is out", which
+        # is the question the Worker's alert answers. Per-class F1 punishes it;
+        # the binary view must not.
+        metrics = compute_metrics([1, 2], [2, 1])
+        assert metrics["accuracy"] == 0.0
+        assert metrics["visible"]["precision"] == 1.0
+        assert metrics["visible"]["recall"] == 1.0
+
+    def test_false_positive_is_the_failure_the_project_cares_about(self):
+        # Two Not Out frames announced as visible: 2 false positives.
+        metrics = compute_metrics([0, 0, 0, 1], [1, 2, 0, 1])
+        visible = metrics["visible"]
+        assert visible["predicted"] == 3
+        assert visible["support"] == 1
+        assert round(visible["precision"], 4) == round(1 / 3, 4)
+        assert visible["recall"] == 1.0
+
+
+class TestDegenerateInputs:
+    def test_class_absent_from_val_is_excluded_from_the_macro_average(self):
+        # No Partial frames at all. Averaging a 0.0 for a class that was never
+        # in the val set would report a model failure that did not happen.
+        metrics = compute_metrics([0, 0, 1, 1], [0, 0, 1, 1])
+        assert metrics["per_class"]["partial"]["support"] == 0
+        assert metrics["macro_classes"] == ["not_out", "full"]
+        assert metrics["macro_f1"] == 1.0
+        assert metrics["balanced_accuracy"] == 1.0
+
+    def test_absent_class_that_gets_predicted_still_costs_precision(self):
+        # Partial is not in truth but the model emits it: it must not vanish
+        # silently — the frame it stole shows up as lost recall elsewhere.
+        metrics = compute_metrics([0, 0, 1, 1], [0, 2, 1, 1])
+        assert metrics["per_class"]["partial"]["support"] == 0
+        assert metrics["per_class"]["partial"]["predicted"] == 1
+        assert metrics["per_class"]["not_out"]["recall"] == 0.5
+        assert metrics["macro_f1"] < 1.0
+
+    def test_zero_predicted_positives_does_not_divide_by_zero(self):
+        metrics = compute_metrics([1, 1], [0, 0])
+        assert metrics["per_class"]["full"]["precision"] == 0.0
+        assert metrics["per_class"]["not_out"]["precision"] == 0.0
+        assert metrics["per_class"]["not_out"]["support"] == 0
+
+    def test_empty_val_set_yields_zeros_not_nan(self):
+        metrics = compute_metrics([], [])
+        assert metrics["n"] == 0
+        assert metrics["accuracy"] == 0.0
+        assert metrics["macro_f1"] == 0.0
+        assert metrics["balanced_accuracy"] == 0.0
+        assert metrics["macro_classes"] == []
+
+    def test_metrics_are_json_serialisable(self):
+        # They travel through --json-summary and --progress-jsonl.
+        import json
+
+        assert json.loads(json.dumps(compute_metrics(REAL_BALANCE, REAL_BALANCE)))
+
+
+class TestRendering:
+    def test_confusion_is_a_readable_grid(self):
+        text = format_confusion(
+            metrics_from_confusion([[3, 1, 0], [0, 2, 1], [1, 0, 4]])
+        )
+        lines = text.splitlines()
+        assert len(lines) == 4  # header + 3 truth rows
+        assert "Not Out" in lines[1] and "3" in lines[1]
+        assert lines[0].strip().startswith("true\\pred")
+
+    def test_missing_metrics_degrade_not_crash(self):
+        assert format_confusion(None) == "n/a"
+        assert format_confusion({}) == "n/a"
+        assert summary_line(None) == "no metrics"
+
+    def test_summary_line_leads_with_the_ungameable_numbers(self):
+        line = summary_line(compute_metrics(REAL_BALANCE, [0] * len(REAL_BALANCE)))
+        assert line.startswith("macro_f1=0.308")
+        assert "Full: P0.00/R0.00(n=6)" in line

--- a/train/tests/test_scheduled.py
+++ b/train/tests/test_scheduled.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 
 from collect.storage import LocalStorage
 from train import scheduled
+from train.metrics import metrics_from_confusion
 
 
 def _event(ts: str, capture: str = "20260726/x/images/a.jpg") -> dict:
@@ -60,13 +61,21 @@ class TestWatermark:
         assert scheduled.load_watermark(store) == {}
 
 
+# A plausible good-but-not-perfect run: Not Out nearly clean, the two minority
+# classes leaky in both directions — exactly what the accuracy-only embed could
+# not show. 260/16/25 val frames, matching val_class_counts below.
+BEST_METRICS = metrics_from_confusion([[258, 1, 1], [1, 13, 2], [2, 3, 20]])
+
 SUMMARY = {
     "status": "ok",
     "labels_loaded": 2004,
     "class_counts": {"not_out": 1729, "full": 109, "partial": 166},
+    "val_class_counts": {"not_out": 260, "full": 16, "partial": 25},
+    "split_seed": 1337,
     "best_val_loss": 0.0765,
     "best_epoch": 2,
     "best_val_acc": 0.979,
+    "best_val_metrics": BEST_METRICS,
     "prefetch_s": 372.0,
     "per_epoch": [
         {
@@ -81,6 +90,7 @@ SUMMARY = {
             "train_loss": 0.22,
             "val_loss": 0.0765,
             "val_acc": 0.979,
+            "val_metrics": BEST_METRICS,
             "duration_s": 192.0,
         },
     ],
@@ -110,7 +120,12 @@ class TestEmbeds:
         # Time telemetry: total · prefetch · avg per-epoch.
         assert values["Duration"] == "15 min total · prefetch 6.2 min · ~3.1 min/epoch"
         # Accuracy improvement in percentage points, arrows flipped vs loss.
-        assert values["Val accuracy"] == "97.9% — ▲ improved 0.3pt vs last (97.6%)"
+        # The field is labelled with the majority baseline now: 97.9% next to
+        # "86.3% is free" reads very differently from 97.9% on its own.
+        assert (
+            values["Val accuracy (majority baseline 86.3%)"]
+            == "97.9% — ▲ improved 0.3pt vs last (97.6%)"
+        )
 
     def test_acc_regression_and_first_run_text(self):
         assert "▼ regressed 1.9pt" in scheduled._acc_delta_text(0.957, 0.976)
@@ -122,7 +137,7 @@ class TestEmbeds:
         legacy = {k: v for k, v in SUMMARY.items() if k != "best_val_acc"}
         embed = scheduled.result_embed(legacy, 1, previous_best=None, duration_s=600)
         values = {f["name"]: f["value"] for f in embed["fields"]}
-        assert values["Val accuracy"].startswith("97.9%")
+        assert values["Val accuracy (majority baseline 86.3%)"].startswith("97.9%")
 
     def test_duration_text_without_breakdown(self):
         assert scheduled._duration_text(600, {}) == "10 min total"
@@ -385,3 +400,128 @@ class TestEmitterConsumerContract:
         from train import scheduler
 
         assert "progress_jsonl" in inspect.signature(scheduler.batch).parameters
+
+    def test_batch_exposes_a_seed_option(self):
+        """An unseeded split redraws val every week and makes deltas noise."""
+        import inspect
+
+        from train import scheduler
+
+        assert "seed" in inspect.signature(scheduler.batch).parameters
+
+
+class TestPerClassTelemetry:
+    """Macro-F1, per-class recall and the visible collapse in the embeds.
+
+    Raw accuracy is not evidence on this label set: 86.3% of it is available by
+    always answering "Not Out". These assertions pin the demotion.
+    """
+
+    def test_macro_f1_is_the_headline_field(self):
+        embed = scheduled.result_embed(
+            SUMMARY, 4, previous_best=0.0782, duration_s=900, previous_best_acc=0.976
+        )
+        names = [f["name"] for f in embed["fields"]]
+        assert names[2] == "Macro-F1 (headline)"
+        # Accuracy still present, but after the per-class block.
+        assert names.index("Macro-F1 (headline)") < names.index("Per class")
+        assert names.index("Per class") < names.index(
+            "Val accuracy (majority baseline 86.3%)"
+        )
+
+    def test_per_class_recall_names_full_and_partial_with_their_support(self):
+        embed = scheduled.result_embed(SUMMARY, 1, previous_best=None, duration_s=60)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        per_class = values["Per class"]
+        assert "**Full** recall 81% · precision 76% (n=16)" in per_class
+        assert "**Partial** recall 80% · precision 87% (n=25)" in per_class
+        assert "**Not Out**" in per_class
+
+    def test_visible_collapse_leads_with_precision(self):
+        embed = scheduled.result_embed(SUMMARY, 1, previous_best=None, duration_s=60)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        # 38 correct visible, 2 Not Out frames announced visible => 95% precision.
+        assert values["Mountain visible (Full+Partial)"].startswith("precision 95%")
+        assert "n=41 visible frames in val" in values["Mountain visible (Full+Partial)"]
+
+    def test_confusion_is_one_code_block_not_nine_fields(self):
+        embed = scheduled.result_embed(SUMMARY, 1, previous_best=None, duration_s=60)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        block = values["Confusion (rows = truth)"]
+        assert block.startswith("```\n") and block.endswith("\n```")
+        assert len(embed["fields"]) < 15, "Discord caps embeds at 25 fields"
+
+    def test_val_split_counts_are_shown_next_to_the_dataset(self):
+        embed = scheduled.result_embed(SUMMARY, 1, previous_best=None, duration_s=60)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        assert "val split: 260/16/25 (seed 1337)" in values["Dataset"]
+
+    def test_macro_f1_delta_arrows_match_higher_is_better(self):
+        assert "▲ improved 0.040" in scheduled._f1_delta_text(0.840, 0.800)
+        assert "▼ regressed 0.040" in scheduled._f1_delta_text(0.760, 0.800)
+        assert "unchanged" in scheduled._f1_delta_text(0.800, 0.8001)
+        assert "no previous run" in scheduled._f1_delta_text(0.800, None)
+
+    def test_a_class_absent_from_val_says_so(self):
+        metrics = metrics_from_confusion([[10, 0, 0], [0, 0, 0], [1, 0, 4]])
+        assert "**Full** — absent from val set" in scheduled._recall_text(metrics)
+
+    def test_checkpoint_embed_carries_per_class_recall(self):
+        record = dict(TestCheckpointEmbed.RECORD, val_metrics=BEST_METRICS)
+        values = {
+            f["name"]: f["value"] for f in scheduled.checkpoint_embed(record)["fields"]
+        }
+        assert "**Full** recall 81%" in values["Per class"]
+        assert values["Macro-F1 / balanced acc"].startswith("0.8")
+
+
+class TestBackwardCompatibility:
+    """`--json-summary` consumers must tolerate summaries written before this
+    landed — the same fallback contract `best_val_acc` already had."""
+
+    LEGACY = {
+        k: v
+        for k, v in SUMMARY.items()
+        if k not in ("best_val_metrics", "val_class_counts", "split_seed")
+    }
+
+    def test_legacy_summary_still_renders(self):
+        legacy = dict(
+            self.LEGACY,
+            per_epoch=[
+                {k: v for k, v in e.items() if k != "val_metrics"}
+                for e in self.LEGACY["per_epoch"]
+            ],
+        )
+        embed = scheduled.result_embed(legacy, 1, previous_best=None, duration_s=60)
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        assert "predates per-class metrics" in values["Macro-F1 (headline)"]
+        assert "predates per-class metrics" in values["Per class"]
+        # Everything that DID exist still renders normally.
+        assert values["Val accuracy (majority baseline 86.3%)"].startswith("97.9%")
+        assert "val split" not in values["Dataset"]
+
+    def test_metrics_recovered_from_the_best_epoch_when_top_level_is_missing(self):
+        # A run whose summary predates `best_val_metrics` but whose per-epoch
+        # records carry `val_metrics` — the same recovery path `best_val_acc`
+        # already uses.
+        embed = scheduled.result_embed(
+            self.LEGACY, 1, previous_best=None, duration_s=60
+        )
+        values = {f["name"]: f["value"] for f in embed["fields"]}
+        assert "**Full** recall 81%" in values["Per class"]
+
+    def test_checkpoint_embed_without_metrics_is_unchanged(self):
+        embed = scheduled.checkpoint_embed(TestCheckpointEmbed.RECORD)
+        names = [f["name"] for f in embed["fields"]]
+        assert "Per class" not in names
+        assert names == [
+            "Val loss",
+            "Val accuracy",
+            "Epoch time",
+            "Memory",
+            "Uploaded",
+        ]
+
+    def test_watermark_without_macro_f1_does_not_crash_the_delta(self):
+        assert scheduled._f1_delta_text(0.84, None).startswith("0.840")

--- a/train/tests/test_scheduler.py
+++ b/train/tests/test_scheduler.py
@@ -112,3 +112,74 @@ def test_live_training_loop_cycle(mock_sleep, mock_weather_cls, mock_webcam):
                 trainer.live_training_loop(label=1)
 
             assert mock_stream.capture_to_tensor.call_count == 1
+
+
+class TestStratifiedSplit:
+    """The split is the reason the old val numbers were not trustworthy.
+
+    It was already stratified — but it ran AFTER oversampling, so the same
+    minority frame landed in both train and val ~8 times over, and it was
+    unseeded, so no two runs' val metrics described the same val set.
+    """
+
+    # The measured real balance (2010 R2 labels, 2026-07-30).
+    REAL = {
+        0: [f"n{i}" for i in range(1735)],
+        1: [f"f{i}" for i in range(111)],
+        2: [f"p{i}" for i in range(164)],
+    }
+
+    def _split(self, by_class=None, seed=1337, fraction=0.15):
+        import random
+
+        from train.scheduler import stratified_split
+
+        return stratified_split(
+            by_class if by_class is not None else self.REAL,
+            val_fraction=fraction,
+            rng=random.Random(seed),
+        )
+
+    def test_no_item_is_in_both_sides(self):
+        """The leak test. This is the whole point."""
+        train, val = self._split()
+        for cls in train:
+            assert not (set(train[cls]) & set(val[cls]))
+
+    def test_every_class_is_represented_in_val(self):
+        _, val = self._split()
+        assert len(val[0]) == 260
+        assert len(val[1]) == 17  # Full — the class that motivated stratifying
+        assert len(val[2]) == 25
+
+    def test_split_is_deterministic_for_a_given_seed(self):
+        assert self._split(seed=1337) == self._split(seed=1337)
+
+    def test_a_different_seed_draws_a_different_val_set(self):
+        _, a = self._split(seed=1337)
+        _, b = self._split(seed=7)
+        assert a[1] != b[1]
+
+    def test_split_ignores_input_ordering(self):
+        shuffled = {cls: list(reversed(items)) for cls, items in self.REAL.items()}
+        assert self._split(shuffled) == self._split()
+
+    def test_nothing_is_lost_or_duplicated(self):
+        train, val = self._split()
+        for cls, items in self.REAL.items():
+            assert sorted(train[cls] + val[cls]) == sorted(items)
+
+    def test_a_singleton_class_stays_in_train(self):
+        # Spending the only example on val makes the class untrainable AND its
+        # recall a coin flip — worst of both.
+        train, val = self._split({0: ["a", "b", "c", "d"], 1: ["only"]})
+        assert train[1] == ["only"]
+        assert val[1] == []
+
+    def test_an_empty_class_is_survivable(self):
+        train, val = self._split({0: ["a", "b"], 1: []})
+        assert train[1] == [] and val[1] == []
+
+    def test_a_two_item_class_gives_one_to_each_side(self):
+        train, val = self._split({1: ["a", "b"]})
+        assert len(train[1]) == 1 and len(val[1]) == 1


### PR DESCRIPTION
`TRAINING` — **MEASUREMENT DISPATCH**

# 99.8% was a fog detector's score

> _The label set is 86.3% "Not Out." A model that never sees the mountain scores 86.3% by saying nothing. We were reporting accuracy and calling it success — and the val split was leaking the answers._

> [!NOTE]
> **train** · feat · risk: low (telemetry + split; no model or serving change) · no `worker/**`

Last week's scheduled run posted **99.8% val accuracy** and everyone moved on. Here is what that number could not tell you: whether the model has ever correctly identified Mount Rainier.

Measured today over 2010 R2 labels the classes are **1735 Not Out (86.3%) / 164 Partial (8.2%) / 111 Full (5.5%)** — answer "Not Out" to every frame and you score 86.3% while detecting the mountain exactly never. No per-class precision or recall was reported anywhere. Meanwhile `CLAUDE.md` has said *"precision over recall: minimize false positives"* this whole time, and nothing measured that either.

Then, chasing the metric, the split turned out to be worse than the metric.

## The bug under the bug: val was scoring memorised frames

The split was already stratified — but it ran **after** oversampling. Minority frames are duplicated 5-7x for class balance, so copies of the *same image* landed in both train and val. Validation was grading the model on pictures it had already trained on. That is where a 5.5%-of-the-data class produces a 99.8%.

> _"Historical val numbers are not comparable to numbers from this version. The first honest run will look worse. It isn't."_

Fixed by splitting unique labels first, oversampling **only** the train side, and seeding it (`--seed`, default `1337`) — an unseeded split redrew the val set every week, so run-over-run deltas were partly measuring the dice.

## What now gets measured

`train/metrics.py` builds one confusion matrix per validation pass and derives:

- **macro-F1** — the new headline. Averaged over classes, so the majority can't carry it. The all-"Not Out" predictor scores **0.31** against its 0.86 accuracy; that gap is the point, and it has its own test.
- **balanced accuracy** — mean per-class recall. Chance is 33.3%.
- **per-class precision / recall / F1 / support** for Not Out, Full, Partial.
- **the "visible" binary view** — Full+Partial vs Not Out, the actual product question and what the Worker's alerts key on. Its *precision* is the first real measurement of the precision-over-recall constraint.
- a 3x3 confusion matrix (rows = truth).

Pure stdlib arithmetic on purpose — scikit-learn stays a `dev`-group dependency and the trainer grows no main dependency for four divisions. Every rate is guarded against a zero denominator, so a class the model never predicts renders `0% precision`, not `NaN` and not a crash an hour into a run.

## How it flows

```mermaid
flowchart TD
  L[labels.yaml · 1735/111/164] --> S[stratified_split<br/>UNIQUE labels · seeded]
  S -->|85%| T[train side]
  S -->|15%| V[val side · 260/17/25<br/>no duplicates]
  T --> O[oversample 7x Full · 5x Partial]
  O --> E[epoch]
  V --> R[_run_validation]
  E --> R
  R --> M[compute_metrics<br/>confusion → macro-F1 · per-class · visible]
  M --> P[per_epoch record]
  P --> J[--json-summary]
  P --> G[--progress-jsonl]
  G --> C[checkpoint embed · live per save]
  J --> D[result embed · macro-F1 headline]
  D --> W[(R2 watermark<br/>best_macro_f1)]
  W -.next week's delta.-> D
```

## The embed, rendered from a simulated run

Same model, told honestly. Accuracy stays — demoted, and labelled with the baseline it has to beat:

```
Macro-F1 (headline)   0.740 — ▼ regressed 0.050 vs last (0.790)
Balanced accuracy     84.5% (chance = 33.3%)
Mountain visible      precision 54% · recall 90% (n=42 visible in val)
Per class             Not Out  recall 87% · precision 98% (n=260)
                      Full     recall 82% · precision 30% (n=17)
                      Partial  recall 84% · precision 88% (n=25)
Confusion             true\pred   Not Out    Full  Partial
 (rows = truth)       Not Out         227      33        0
                      Full              0      14        3
                      Partial           4       0       21
Val accuracy (majority baseline 86.3%)    86.8%
```

`Full precision 30%` is a sentence the old embed had no way to say. Per-class recall also rides the **checkpoint** posts that arrive live mid-run — an improving val loss with a collapsing Full recall is a regression wearing a green badge.

## The honest caveat

**With ~17 Full frames in val, one flipped frame moves Full recall by ~6 percentage points.** These are coarse signals with a ±1-frame error bar, not measurements; a 3pt week-over-week "improvement" on Full is noise. So: the trainer warns when any val class drops below 20 frames, `n=` prints next to every rate so nobody over-reads a rounded percentage, and `TRAINING.md` says this out loud instead of burying it. The real fix is more Full/Partial labels — this change makes that need visible instead of hiding it under a 99.8%.

## Verification

- `uv run pytest --ignore=collect/tests/test_notebook_helpers.py` → **191 passed, 2 skipped** (that file has a pre-existing unrelated import error being fixed elsewhere).
- `uvx ruff@0.16.0 check .` clean · `format --check .` → 63 files already formatted. Rule set unchanged (`E4,E7,E9,F`).
- **No training run was executed.** Metric math is tested on synthetic tensors: perfect predictor; the degenerate all-majority predictor (asserts macro-F1 lands >0.5 *below* accuracy — the case motivating the change); a class absent from val; a class predicted but absent from truth; zero predicted positives; empty val set.
- Split tested directly on the real 1735/111/164 balance: **no item on both sides**, every class present in val, deterministic per seed, order-independent, nothing lost or duplicated, singleton and empty classes survivable.
- Embed rendering exercised offline end to end: 13 fields (Discord caps at 25), 968 chars, confusion matrix as one code block rather than 9 fields.

## Risk & rollout

- **Backward compatible on read.** `best_val_metrics`, `val_metrics`, `val_class_counts`, `split_seed` and the watermark's `best_macro_f1` are optional; older summaries render `n/a — run predates per-class metrics`, the same fallback `best_val_acc` already had. Tested.
- **Expect next week's numbers to drop.** That is the leak closing, not a regression. The macro-F1 delta reads "no previous run to compare" once, then becomes meaningful. One cosmetic embed rename (accuracy now carries its baseline); nothing parses embeds.
- Untouched: `worker/**`, the model, serving, checkpoint format. Nothing deployed, nothing merged. Follow-up for its own PR: `tools/evaluate.py` still builds a parallel report via scikit-learn and could share `train/metrics.py`.
