### PR TITLE
fix: the site has been down for 17 days and nothing said so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Single source of truth for webcam URL, METAR station (`KSEA`), LoRA hyperparamet
 
 ## Deployment (Cloudflare)
 
-Inference runs as the `mountain-inference` Cloudflare Worker + Container (cron `*/15`), with R2 for storage and Pages for the SPA.
+Inference runs as the `mountain-inference` Cloudflare Worker + Container (cron `*/15`), with R2 for storage. The SPA is served by **GitHub Pages** (`https://robogeosociety.github.io/is-the-mountain-out/`) — the Cloudflare Pages project the 2026-05-25 migration intended does not exist; see README → Known outage.
 
 **The Worker deploys from CI — `.github/workflows/deploy-worker.yml`.** A push to `main` touching `worker/**` (or `gh workflow run deploy-worker.yml`) runs the worker tests + typecheck, then `npx wrangler deploy`, inside the `production` GitHub environment. Deploys are serialized (`cancel-in-progress: false`): one in flight is never cancelled. To require human approval, add a required reviewer to the `production` environment — no workflow change needed.
 

--- a/NOTIFICATIONS.md
+++ b/NOTIFICATIONS.md
@@ -14,11 +14,14 @@ label this project can collect — precision over recall is the stated priority.
 ## What fires
 
 The channel does two different jobs, and confidence decides which one a tick gets.
+A third job — saying so when the pipeline itself is broken — was added 2026-08-24.
 
 | Kind | Trigger | Title | Color |
 |---|---|---|---|
 | **Alert** | confirmed change, confidence ≥ `ALERT_MIN_CONFIDENCE` | 🏔️ The mountain is out! / ☁️ The mountain is gone | green / gray |
 | **Label request** | any tick below that threshold, at most once per `LABEL_COOLDOWN_HOURS` | 🤔 Is the mountain out? | amber |
+| **Pipeline down** | `HEALTH_ALERT_AFTER_FAILURES` consecutive failed ticks, then at most once per `HEALTH_REALERT_HOURS` | 🚨 Inference pipeline is down | red |
+| **Pipeline recovered** | first success after a `down` alert — never rate-limited | ✅ Inference pipeline recovered | green |
 
 An **alert** must be trustworthy — you act on it. A **label request** must be
 informative — you correct it, and the correction is a training row. Those want
@@ -58,6 +61,40 @@ different picture later, and you must be labeling the frame you can see. The
 footer is the frame's R2 capture key, which is the contract `bot/labeler.py`
 parses. If the frame fails to persist, the post falls back to a prose footer and
 is simply not labelable.
+
+## Pipeline health (`worker/src/health.ts`)
+
+The first two rows above describe the mountain. These two describe whether we can
+see it at all.
+
+Between **2026-08-07T07:15Z** and 2026-08-24 the `*/15` tick failed **1,637 times
+in a row** — the UW webcam image 404'd upstream — and the channel said nothing.
+The tick's error path appended the failure to `history.jsonl` and called
+`console.error`, and that was all it did: a log nobody reads and an ndjson file
+nobody opens. The only visible symptom was a site quietly showing a stale reading,
+which is indistinguishable from a slow day on the mountain.
+
+So a sustained outage is now an event, not an absence of events. Two gates, the
+same shape as the alert/label gates:
+
+- **Threshold.** Nothing is said until `HEALTH_ALERT_AFTER_FAILURES` ticks have
+  failed consecutively (default 4 = one hour). `history.jsonl` holds 142 "container
+  is not listening" and 37 NOAA read timeouts that all self-healed on the next
+  tick; paging on those teaches you to ignore the channel, which is how a
+  seventeen-day outage goes unnoticed.
+- **Cooldown.** Within one outage, re-alert at most every `HEALTH_REALERT_HOURS`
+  (default 6) — about four messages a day rather than ninety-six.
+
+**Recovery is deliberately not rate-limited.** The first success after an alerted
+outage posts immediately. An all-clear is cheap, and a channel still showing a
+pipeline that has actually been healthy for hours is its own kind of wrong.
+
+The down alert carries the last error verbatim. The seventeen-day outage was
+diagnosable from a single line of it; nobody ever saw that line.
+
+Health bookkeeping lives in `health-state.json` in the public bucket, next to
+`notify-state.json`. It is written before the message is posted, so a crash
+between the two costs one alert rather than unlocking a burst of them.
 
 ## Why a bot token and not a webhook
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,90 @@
 
 Real-time image classifier that determines whether Mount Rainier is "out" (visible) from a live UW webcam, augmented with METAR weather data. ConvNeXt Tiny backbone + LoRA fine-tuning, trained on Apple Silicon (MPS), served from Cloudflare.
 
-**Live site:** https://is-the-mountain-out.pages.dev — updated every 15 minutes.
+**Live site:** https://robogeosociety.github.io/is-the-mountain-out/
 Append `?debug` to see confidence bars and the raw METAR readout.
+
+> [!WARNING]
+> **The site is currently down, and has been since 2026-08-07.** Two independent
+> faults, neither fixable from this repo — see [Known outage](#known-outage-2026-08-07)
+> for the two things an operator has to do.
+>
+> The URL above also replaces `https://is-the-mountain-out.pages.dev`, which this
+> README advertised until 2026-08-24. That hostname does not resolve (NXDOMAIN):
+> the Cloudflare Pages project it named does not exist, and no Cloudflare Pages
+> deployment was ever recorded against this repository. GitHub Pages — which the
+> 2026-05-25 migration intended to retire — is what has actually been serving all
+> along.
 
 ![Mount Rainier Topo Map](assets/map.png)
 *Mount Rainier, the UW ATG webcam (north-northwest), and KSEA METAR station.*
+
+## Known outage (2026-08-07 →)
+
+Two independent faults. Both need a human with Cloudflare dashboard access; neither
+is a code change, which is why this section exists instead of a patch.
+
+### 1. The data plane: the webcam this project reads no longer exists
+
+At **2026-08-07T07:15Z** the `*/15` inference tick started failing and has not
+succeeded since — **1,637 consecutive failures** as of 2026-08-24, every one of
+them identical:
+
+```
+container /predict returned 500: {"detail":"HTTPError: 404 Client Error: Not Found
+for url: https://a.atmos.washington.edu/data/images/webcam2_latest.jpg"}
+```
+
+UW retired the image. `webcam2_latest.jpg` is gone from the
+`https://a.atmos.washington.edu/data/images/` directory listing, while its siblings
+(`webcam0_latest.jpg`, `webcam1_latest.jpg`, `webcam1r_latest.jpg`) still return
+`200 image/jpeg`. The camera's own page (`atmos.uw.edu/images/webcam2/`) still
+renders and still links the dead image, so this is an upstream breakage, not a
+move we can chase with a URL rewrite.
+
+Consequently `state.json` is frozen at its 2026-08-07T06:45:32Z reading and the SPA
+shows its stale state.
+
+**This is a product decision, not a config edit.** `webcam1` is alive but points
+somewhere else; the classifier was fine-tuned on webcam2's exact framing (Rainier
+just right of the Chemistry Building stack), so repointing `[webcam] url` in
+`mountain.toml` swaps the model's input distribution out from under it and almost
+certainly requires re-collection and re-training. Pick the camera first, then
+retrain — do not just edit the URL.
+
+### 2. The front end: R2 CORS still names the pre-rename GitHub org
+
+The public bucket's CORS policy allows exactly one origin, `https://tommyroar.github.io`
+— the org name **before** the rename to `robogeosociety`. The live site is served
+from `https://robogeosociety.github.io`, so every `state.json` fetch is blocked:
+
+```
+Access to fetch at 'https://pub-66d3d1f139004e29b2afcb5fba49bdb3.r2.dev/state.json'
+from origin 'https://robogeosociety.github.io' has been blocked by CORS policy:
+No 'Access-Control-Allow-Origin' header is present on the requested resource.
+```
+
+The page renders **STATE UNAVAILABLE**. This fault is independent of fault 1 — it
+would still break the site on the day the webcam comes back.
+
+**Fix:** add `https://robogeosociety.github.io` to the `AllowedOrigins` of the
+`is-the-mountain-out-public` bucket's CORS policy (R2 → the bucket → Settings →
+CORS Policy). Keeping the old origin costs nothing; adding the new one is the
+whole fix.
+
+### Also worth deciding
+
+- **The SPA build is frozen.** GitHub Pages is still enabled (`build_type: workflow`,
+  source `main`) but the workflow that built it — `.github/workflows/update.yml` —
+  was deleted in `85923e5` when the project migrated to Cloudflare Pages. It has
+  been serving the 2026-05-25 artifact ever since. Either restore a build workflow
+  or stand the Pages project back up; today the site cannot be redeployed at all.
+  Note that the served build uses `base = "/is-the-mountain-out/"` while
+  `web/vite.config.ts` now sets `base = "/"`, so a naive rebuild onto GitHub Pages
+  would 404 its own assets.
+- **Cloudflare Pages.** Restoring the project (root `web`, build
+  `npm install && npm run build`, output `web/dist`) is a live option — this README
+  no longer claims it exists either way.
 
 ## Architecture
 
@@ -23,7 +102,7 @@ flowchart LR
     container["InferenceContainer<br/>(FastAPI, sleeps 5min)"]
     r2priv[("R2: is-the-mountain-out<br/>private — captures, labels,<br/>checkpoint")]
     r2pub[("R2: is-the-mountain-out-public<br/>state.json + history.jsonl")]
-    pages["Pages SPA"]
+    ghp["GitHub Pages SPA<br/>(frozen build, 2026-05-25)"]
   end
 
   webcam(["UW ATG webcam"]) --> collector
@@ -45,8 +124,8 @@ flowchart LR
   container -- "PredictionState" --> worker
   worker -- "state.json + history.jsonl" --> r2pub
 
-  browser(["Browser"]) --> pages
-  pages -- "GET state.json (60s poll)" --> r2pub
+  browser(["Browser"]) --> ghp
+  ghp -- "GET state.json (60s poll)" --> r2pub
 ```
 
 ### Inference tick (every 15 min)
@@ -145,7 +224,7 @@ train/                model definition, scheduler, config loader, checkpoints
 tools/                labeling backend, evaluation/pruning/ab-test scripts, predict_state
 inference/            FastAPI server + Dockerfile for the Cloudflare Container
 worker/               Cloudflare Worker source (TypeScript) + wrangler.toml
-web/                  Public SPA (Vite + React), deployed by Cloudflare Pages
+web/                  Public SPA (Vite + React) — source of the GitHub Pages build
 ui/                   Internal classifier UI for bulk labeling (Vite + React)
 .github/workflows/    CI — ruff, worker tests, and the Worker deploy to Cloudflare
 scripts/              deploy-worker.sh — break-glass manual Worker redeploy
@@ -209,6 +288,14 @@ Single source of truth: `mountain.toml`.
 - `[collection]` — capture cadence
 - `[storage]` — R2 backend (`backend = "r2"`, account/bucket/cache_dir)
 
+Worker-side policy lives in `worker/wrangler.toml` `[vars]`, so thresholds move
+without a code change:
+
+- `ALERT_MIN_CONFIDENCE`, `LABEL_COOLDOWN_HOURS` — what the channel says about the
+  mountain (see `worker/src/transition.ts`)
+- `HEALTH_ALERT_AFTER_FAILURES`, `HEALTH_REALERT_HOURS` — when the channel says the
+  *pipeline* is broken (see `worker/src/health.ts`)
+
 R2 S3 credentials (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`) live in `cf.env` (gitignored). The Worker holds the same values as secrets so the container can pull its checkpoint from R2 on startup.
 
 ## What runs where
@@ -221,11 +308,11 @@ R2 S3 credentials (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`) live in `cf.env` 
 | Inference cron | Cloudflare Worker | `*/15 * * * *` |
 | Inference compute | Cloudflare Container | Worker invocation |
 | Storage | Cloudflare R2 | (always) |
-| Public SPA | Cloudflare Pages | (always) |
+| Public SPA | GitHub Pages | Frozen — its build workflow was deleted 2026-05-25 |
 | Container image | GHCR | Built by GH Actions on push to main |
 | Worker deploy | GitHub Actions | Push to main touching `worker/**`, or `gh workflow run deploy-worker.yml` |
 
-GitHub hosts the source repo, the container image registry, and now the Worker's deploy pipeline. Nothing *user-facing* depends on GitHub being available: captures and training are operator-initiated, the live site keeps serving and predicting on its own, and if Actions is down the Worker can still be shipped by hand via `scripts/deploy-worker.sh`.
+GitHub hosts the source repo, the container image registry, the Worker's deploy pipeline — and, as it turns out, the live site. The 2026-05-25 migration to Cloudflare Pages was written up as making nothing *user-facing* depend on GitHub, but that Pages project does not exist today, so the claim never held: the SPA is served by GitHub Pages. Prediction itself is independent of GitHub (the Worker's cron and the Container run on Cloudflare), and if Actions is down the Worker can still be shipped by hand via `scripts/deploy-worker.sh`.
 
 ## Network access (Mac mini)
 

--- a/worker/src/discord-mountain-notify.ts
+++ b/worker/src/discord-mountain-notify.ts
@@ -252,3 +252,69 @@ export async function notifyDiscordTest(env: Env): Promise<boolean> {
   };
   return (await postAsBot(env, embed, "test notification")) !== null;
 }
+
+const COLOR_DOWN = 0xe74c3c; // red — the pipeline, not the mountain
+const COLOR_RECOVERED = 0x2ecc71; // green
+
+/** How long a run of failed ticks has lasted, in human units. */
+function outageDuration(since: string | null, now: Date): string {
+  if (!since) return "an unknown period";
+  const ms = now.getTime() - Date.parse(since);
+  if (!Number.isFinite(ms) || ms < 0) return "an unknown period";
+  const hours = ms / 3_600_000;
+  if (hours < 1) return `${Math.max(1, Math.round(ms / 60_000))} minutes`;
+  if (hours < 48) return `${Math.round(hours)} hours`;
+  return `${Math.round(hours / 24)} days`;
+}
+
+/**
+ * Announce that the inference pipeline is down.
+ *
+ * This is deliberately NOT a mountain notification: the embed says nothing
+ * about visibility, because the honest answer during an outage is that we do
+ * not know. It carries the last error verbatim, because the seventeen-day
+ * webcam outage was diagnosable from a single line of it and nobody ever saw
+ * that line.
+ */
+export async function notifyPipelineDown(
+  env: Env,
+  detail: { failures: number; since: string | null; error: string },
+): Promise<boolean> {
+  const now = new Date();
+  const embed: DiscordEmbed = {
+    title: "🚨 Inference pipeline is down",
+    description: [
+      `The */15 inference tick has failed **${detail.failures} times in a row** ` +
+        `(about ${outageDuration(detail.since, now)}).`,
+      "",
+      "`state.json` is frozen at its last good reading, so the site is showing stale data.",
+      "",
+      "**Last error**",
+      "```",
+      detail.error.slice(0, 900),
+      "```",
+    ].join("\n"),
+    color: COLOR_DOWN,
+    footer: { text: "is-the-mountain-out • Pipeline health" },
+    timestamp: now.toISOString(),
+  };
+  return (await postAsBot(env, embed, "pipeline-down alert")) !== null;
+}
+
+/** Close the loop: the pipeline that was announced broken is publishing again. */
+export async function notifyPipelineRecovered(
+  env: Env,
+  detail: { failures: number; since: string | null },
+): Promise<boolean> {
+  const now = new Date();
+  const embed: DiscordEmbed = {
+    title: "✅ Inference pipeline recovered",
+    description:
+      `Publishing again after **${detail.failures} failed ticks** ` +
+      `(about ${outageDuration(detail.since, now)}). \`state.json\` is live.`,
+    color: COLOR_RECOVERED,
+    footer: { text: "is-the-mountain-out • Pipeline health" },
+    timestamp: now.toISOString(),
+  };
+  return (await postAsBot(env, embed, "pipeline-recovered notice")) !== null;
+}

--- a/worker/src/health.ts
+++ b/worker/src/health.ts
@@ -1,0 +1,157 @@
+// Whether a broken pipeline says so out loud — a pure state machine, testable
+// without a Worker runtime (`npm test` in worker/), like transition.ts.
+//
+// WHY THIS EXISTS
+//
+// On 2026-08-07 at 07:15Z the UW ATG webcam2 image (webcam2_latest.jpg) stopped
+// existing upstream. Every */15 tick since has failed the same way:
+//
+//   container /predict returned 500: {"detail":"HTTPError: 404 Client Error:
+//   Not Found for url: https://a.atmos.washington.edu/data/images/webcam2_latest.jpg"}
+//
+// 1,637 consecutive failures. Seventeen days. NOTHING WAS SAID. The tick's
+// catch block appended the error to history.jsonl and called console.error,
+// and that was the whole of it — a log nobody reads and an ndjson file nobody
+// opens. The published state.json simply stopped moving, and the only symptom a
+// human could see was a site quietly showing an hours-old reading.
+//
+// The Worker already had a Discord channel it posts to. It just never posted
+// failures. That is the bug this module closes: an outage is now an event, not
+// an absence of events.
+//
+// WHY NOT "ALERT ON EVERY FAILED TICK"
+//
+// A single failed tick is noise — the container cold-starts, METAR times out,
+// a Durable Object gets reset mid-deploy. history.jsonl has 142 "container is
+// not listening" and 37 NOAA read timeouts that all self-healed on the next
+// tick. Paging on those trains you to ignore the channel, which is how you end
+// up not noticing the one that lasts seventeen days.
+//
+// So two gates, mirroring transition.ts:
+//
+//   1. THRESHOLD. Say nothing until `alertAfterFailures` ticks have failed in a
+//      row (default 4 = one hour of a dead pipeline). Transients never reach it.
+//   2. COOLDOWN. Once alerting, re-alert at most every `realertCooldownMs`
+//      (default 6h) so a long outage nags a few times a day rather than 96.
+//
+// And one thing that is NOT gated: RECOVERY. The first success after an alerted
+// outage always posts, immediately. An all-clear is cheap, it is the message
+// that closes the loop, and rate-limiting it would leave the channel showing a
+// broken pipeline that has actually been fine for hours.
+
+export interface HealthState {
+  /** Consecutive failed ticks. Reset to 0 by any success. */
+  consecutive_failures: number;
+  /** When the current failure run began (ISO 8601). null = not failing. */
+  failing_since: string | null;
+  /** When the channel was last told about this run (ISO 8601). Drives cooldown. */
+  last_alert: string | null;
+  /** Whether the channel currently believes the pipeline is broken. */
+  alerted: boolean;
+}
+
+export const INITIAL_HEALTH_STATE: HealthState = {
+  consecutive_failures: 0,
+  failing_since: null,
+  last_alert: null,
+  alerted: false,
+};
+
+export interface HealthOptions {
+  /** Consecutive failures before the first alert. */
+  alertAfterFailures: number;
+  /** Minimum gap between repeat alerts within one outage, in milliseconds. */
+  realertCooldownMs: number;
+}
+
+export const DEFAULT_HEALTH_OPTIONS: HealthOptions = {
+  // Four ticks = one hour at the */15 cadence. Long enough that container cold
+  // starts and upstream blips never reach it, short enough that a real outage
+  // is in the channel within the hour instead of within a fortnight.
+  alertAfterFailures: 4,
+  realertCooldownMs: 6 * 60 * 60 * 1000,
+};
+
+/**
+ * `down` announces (or re-announces) a sustained outage; `recovered` posts the
+ * all-clear; `quiet` posts nothing.
+ */
+export type HealthKind = "down" | "recovered" | "quiet";
+
+export interface HealthDecision {
+  kind: HealthKind;
+  next: HealthState;
+  /**
+   * Failure count carried on the message. On `recovered` this is the length of
+   * the outage that just ended, not the (zero) current count — the all-clear
+   * needs to say how bad it was.
+   */
+  failures: number;
+  /** Start of the outage (ISO 8601), for "down since …" / "was down since …". */
+  since: string | null;
+}
+
+/**
+ * Fold one tick's outcome into the health state and decide what to say.
+ *
+ * @param state    Health bookkeeping as of the previous tick.
+ * @param ok       Whether THIS tick succeeded.
+ * @param now      Tick time, ISO 8601.
+ * @param options  Threshold + cooldown.
+ */
+export function decideHealth(
+  state: HealthState,
+  ok: boolean,
+  now: string,
+  options: HealthOptions = DEFAULT_HEALTH_OPTIONS,
+): HealthDecision {
+  const { alertAfterFailures, realertCooldownMs } = options;
+
+  if (ok) {
+    // A success always clears the books. It only SPEAKS if the channel was
+    // told the pipeline was broken — otherwise there is nothing to take back.
+    const kind: HealthKind = state.alerted ? "recovered" : "quiet";
+    return {
+      kind,
+      next: INITIAL_HEALTH_STATE,
+      failures: state.consecutive_failures,
+      since: state.failing_since,
+    };
+  }
+
+  const consecutive = state.consecutive_failures + 1;
+  // The run started at this tick only if it is the first failure of the run.
+  const failingSince = state.failing_since ?? now;
+
+  const belowThreshold = consecutive < alertAfterFailures;
+  const cooling =
+    state.alerted &&
+    state.last_alert !== null &&
+    Date.parse(now) - Date.parse(state.last_alert) < realertCooldownMs;
+
+  if (belowThreshold || cooling) {
+    return {
+      kind: "quiet",
+      next: {
+        consecutive_failures: consecutive,
+        failing_since: failingSince,
+        last_alert: state.last_alert,
+        alerted: state.alerted,
+      },
+      failures: consecutive,
+      since: failingSince,
+    };
+  }
+
+  return {
+    kind: "down",
+    next: {
+      consecutive_failures: consecutive,
+      failing_since: failingSince,
+      last_alert: now,
+      alerted: true,
+    },
+    failures: consecutive,
+    since: failingSince,
+  };
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -18,6 +18,8 @@ import {
   notifyDiscordTest,
   notifyLabelRequest,
   notifyMountainVisibility,
+  notifyPipelineDown,
+  notifyPipelineRecovered,
 } from "./discord-mountain-notify";
 import {
   DEFAULT_OPTIONS,
@@ -26,6 +28,13 @@ import {
   type DecisionOptions,
   type NotifyState,
 } from "./transition";
+import {
+  DEFAULT_HEALTH_OPTIONS,
+  INITIAL_HEALTH_STATE,
+  decideHealth,
+  type HealthOptions,
+  type HealthState,
+} from "./health";
 
 interface Env {
   INFERENCE_CONTAINER: DurableObjectNamespace<InferenceContainer>;
@@ -45,6 +54,11 @@ interface Env {
   // LABEL_COOLDOWN_HOURS: minimum gap between label requests.
   ALERT_MIN_CONFIDENCE?: string;
   LABEL_COOLDOWN_HOURS?: string;
+  // Pipeline-health policy (see health.ts). HEALTH_ALERT_AFTER_FAILURES:
+  // consecutive failed ticks before the outage is announced.
+  // HEALTH_REALERT_HOURS: minimum gap between repeat alerts within one outage.
+  HEALTH_ALERT_AFTER_FAILURES?: string;
+  HEALTH_REALERT_HOURS?: string;
 }
 
 export class InferenceContainer extends Container<Env> {
@@ -90,6 +104,11 @@ const HISTORY_KEY = "history.jsonl";
 // awaiting confirmation). Separate from state.json so the SPA's contract stays
 // exactly the published prediction — see transition.ts for the state machine.
 const NOTIFY_STATE_KEY = "notify-state.json";
+// Pipeline-health bookkeeping (consecutive failures + what the channel has been
+// told). Separate from notify-state.json because it survives a different thing:
+// notify state is about the MOUNTAIN, this is about whether we can see it at
+// all. See health.ts.
+const HEALTH_STATE_KEY = "health-state.json";
 
 const isoUtc = (d: Date) => d.toISOString().replace(/\.\d{3}Z$/, "Z");
 
@@ -124,6 +143,26 @@ async function getNotifyState(env: Env): Promise<NotifyState> {
 
 async function putNotifyState(env: Env, state: NotifyState): Promise<void> {
   await env.STATE_BUCKET.put(NOTIFY_STATE_KEY, JSON.stringify(state, null, 2) + "\n", {
+    httpMetadata: { contentType: "application/json" },
+  });
+}
+
+async function getHealthState(env: Env): Promise<HealthState> {
+  try {
+    const obj = await env.STATE_BUCKET.get(HEALTH_STATE_KEY);
+    if (!obj) return INITIAL_HEALTH_STATE;
+    return { ...INITIAL_HEALTH_STATE, ...(JSON.parse(await obj.text()) as Partial<HealthState>) };
+  } catch (e) {
+    // Unreadable bookkeeping starts the count over rather than throwing. The
+    // cost is at most a delayed alert; throwing here would make the health
+    // check itself the thing that breaks the tick.
+    console.warn("failed to read health state; restarting the failure count:", e);
+    return INITIAL_HEALTH_STATE;
+  }
+}
+
+async function putHealthState(env: Env, state: HealthState): Promise<void> {
+  await env.STATE_BUCKET.put(HEALTH_STATE_KEY, JSON.stringify(state, null, 2) + "\n", {
     httpMetadata: { contentType: "application/json" },
   });
 }
@@ -191,16 +230,73 @@ function binaryConfidence(state: PredictionState): number {
     : (state.confidence?.not_out ?? 0);
 }
 
+/**
+ * Read a numeric [vars] override, falling back on anything unparseable.
+ *
+ * Shared by both policy readers below: an operator who fat-fingers a wrangler
+ * var gets the documented default, never a NaN threshold that silently
+ * disables a gate.
+ */
+const num = (raw: string | undefined, fallback: number) => {
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
 function decisionOptions(env: Env): DecisionOptions {
-  const num = (raw: string | undefined, fallback: number) => {
-    const parsed = Number(raw);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  };
   return {
     alertMinConfidence: num(env.ALERT_MIN_CONFIDENCE, DEFAULT_OPTIONS.alertMinConfidence),
     labelCooldownMs:
       num(env.LABEL_COOLDOWN_HOURS, DEFAULT_OPTIONS.labelCooldownMs / 3_600_000) * 3_600_000,
   };
+}
+
+function healthOptions(env: Env): HealthOptions {
+  return {
+    alertAfterFailures: num(
+      env.HEALTH_ALERT_AFTER_FAILURES,
+      DEFAULT_HEALTH_OPTIONS.alertAfterFailures,
+    ),
+    realertCooldownMs:
+      num(env.HEALTH_REALERT_HOURS, DEFAULT_HEALTH_OPTIONS.realertCooldownMs / 3_600_000) *
+      3_600_000,
+  };
+}
+
+/**
+ * Say out loud whether the pipeline itself is working.
+ *
+ * Called on EVERY tick, success or failure — a health check that only runs when
+ * things break can never announce that they stopped being broken.
+ *
+ * Best-effort by construction: this is observability, and observability must
+ * not be able to fail a tick that otherwise succeeded. Every path is wrapped,
+ * and a thrown error here is logged and swallowed.
+ */
+async function notifyHealth(env: Env, ok: boolean, errorMessage?: string): Promise<void> {
+  try {
+    const { kind, next, failures, since } = decideHealth(
+      await getHealthState(env),
+      ok,
+      isoUtc(new Date()),
+      healthOptions(env),
+    );
+    // Persist BEFORE posting, for the same reason notifyTransition does: a
+    // crash between the two would otherwise re-announce the outage every 15
+    // minutes, which is precisely the noise the cooldown exists to prevent.
+    await putHealthState(env, next);
+    if (kind === "quiet") return;
+    if (kind === "down") {
+      await notifyPipelineDown(env, {
+        failures,
+        since,
+        error: errorMessage ?? "(no error message recorded)",
+      });
+      return;
+    }
+    await notifyPipelineRecovered(env, { failures, since });
+  } catch (e) {
+    console.error("health notification failed:", e);
+  }
 }
 
 // One tick, one decision: announce a confirmed+confident change, ask for a
@@ -282,6 +378,15 @@ async function tick(env: Env): Promise<void> {
     console.error("inference tick failed:", e);
   }
   await appendHistory(env, record);
+  // Last, and outside the try/catch above: whatever this tick did, the channel
+  // now hears about a pipeline that has been down for an hour. Before this,
+  // the error branch ended at `appendHistory` and a `console.error` — which is
+  // how 1,637 consecutive failures went unremarked for seventeen days.
+  await notifyHealth(
+    env,
+    record.status === "ok",
+    record.status === "error" ? record.error.message : undefined,
+  );
 }
 
 export default {

--- a/worker/test/health.test.ts
+++ b/worker/test/health.test.ts
@@ -1,0 +1,124 @@
+// Run with: npm test   (node:test + native TypeScript stripping, no deps)
+//
+// The regression these tests exist for: 1,637 consecutive failed ticks between
+// 2026-08-07T07:15Z and 2026-08-24 produced zero Discord messages, because the
+// error path only ever wrote to history.jsonl and console.error. The first test
+// below is that outage, replayed.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  DEFAULT_HEALTH_OPTIONS,
+  INITIAL_HEALTH_STATE,
+  decideHealth,
+  type HealthKind,
+  type HealthState,
+} from "../src/health.ts";
+
+const T0 = Date.parse("2026-08-07T07:15:00Z");
+/** Tick n, 15 minutes apart — the real inference cadence. */
+const at = (n: number) => new Date(T0 + n * 15 * 60_000).toISOString();
+
+/** Feed a sequence of tick outcomes through the machine; one kind per tick. */
+function run(outcomes: boolean[], from: HealthState = INITIAL_HEALTH_STATE): HealthKind[] {
+  let state = from;
+  return outcomes.map((ok, i) => {
+    const { kind, next } = decideHealth(state, ok, at(i));
+    state = next;
+    return kind;
+  });
+}
+
+const FAIL = false;
+const OK = true;
+
+test("the webcam outage: a sustained failure is announced, once, within the hour", () => {
+  // Four ticks = the threshold. Nothing is said for the first three.
+  const kinds = run(Array(4).fill(FAIL));
+  assert.deepEqual(kinds, ["quiet", "quiet", "quiet", "down"]);
+});
+
+test("a day of the outage nags a few times, not 96", () => {
+  // 96 ticks = 24 hours. With a 6h cooldown that is the first alert plus three
+  // re-alerts. Before this module it was zero; the failure mode being guarded
+  // against now is the opposite one.
+  const kinds = run(Array(96).fill(FAIL));
+  const downs = kinds.filter((k) => k === "down").length;
+  assert.equal(downs, 4);
+  assert.equal(kinds.filter((k) => k === "recovered").length, 0);
+});
+
+test("transients stay quiet — the container cold start that self-heals", () => {
+  // history.jsonl has 142 "container is not listening" and 37 NOAA read
+  // timeouts that recovered on the next tick. None of them should page.
+  assert.deepEqual(run([FAIL, OK]), ["quiet", "quiet"]);
+  assert.deepEqual(run([FAIL, FAIL, OK]), ["quiet", "quiet", "quiet"]);
+  assert.deepEqual(run([FAIL, FAIL, FAIL, OK]), ["quiet", "quiet", "quiet", "quiet"]);
+});
+
+test("a success after an alerted outage always posts the all-clear, immediately", () => {
+  const kinds = run([...Array(4).fill(FAIL), OK]);
+  assert.deepEqual(kinds, ["quiet", "quiet", "quiet", "down", "recovered"]);
+});
+
+test("recovery is not rate-limited — it fires inside the re-alert cooldown", () => {
+  // Alert at tick 3, recover at tick 4: fifteen minutes, far inside the 6h
+  // cooldown. An all-clear the channel never hears is worse than a chatty one.
+  const kinds = run([...Array(4).fill(FAIL), OK]);
+  assert.equal(kinds.at(-1), "recovered");
+});
+
+test("recovery reports the outage it ended, not the current (zero) count", () => {
+  let state: HealthState = INITIAL_HEALTH_STATE;
+  for (let i = 0; i < 10; i++) state = decideHealth(state, FAIL, at(i)).next;
+
+  const decision = decideHealth(state, OK, at(10));
+  assert.equal(decision.kind, "recovered");
+  assert.equal(decision.failures, 10);
+  assert.equal(decision.since, at(0));
+  assert.deepEqual(decision.next, INITIAL_HEALTH_STATE);
+});
+
+test("the failure run is stamped at its first tick, not its alerting tick", () => {
+  let state: HealthState = INITIAL_HEALTH_STATE;
+  for (let i = 0; i < 4; i++) state = decideHealth(state, FAIL, at(i)).next;
+  assert.equal(state.failing_since, at(0));
+  assert.equal(state.last_alert, at(3));
+});
+
+test("a flapping pipeline re-arms — recovery resets the threshold", () => {
+  // Fail to the alert, recover, then fail again: the second outage must earn
+  // its own four ticks rather than inheriting the first run's count.
+  const kinds = run([...Array(4).fill(FAIL), OK, FAIL, FAIL, FAIL, FAIL]);
+  assert.deepEqual(kinds, [
+    "quiet",
+    "quiet",
+    "quiet",
+    "down",
+    "recovered",
+    "quiet",
+    "quiet",
+    "quiet",
+    "down",
+  ]);
+});
+
+test("a success with nothing to take back stays quiet", () => {
+  assert.deepEqual(run([OK, OK, OK]), ["quiet", "quiet", "quiet"]);
+});
+
+test("thresholds are options, not constants", () => {
+  const eager = { alertAfterFailures: 1, realertCooldownMs: 0 };
+  let state: HealthState = INITIAL_HEALTH_STATE;
+  const kinds = [FAIL, FAIL].map((ok) => {
+    const d = decideHealth(state, ok, at(0), eager);
+    state = d.next;
+    return d.kind;
+  });
+  assert.deepEqual(kinds, ["down", "down"]);
+});
+
+test("defaults are the documented one-hour / six-hour policy", () => {
+  assert.equal(DEFAULT_HEALTH_OPTIONS.alertAfterFailures, 4);
+  assert.equal(DEFAULT_HEALTH_OPTIONS.realertCooldownMs, 6 * 60 * 60 * 1000);
+});

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -19,6 +19,19 @@ ALERT_MIN_CONFIDENCE = "0.85"
 # rather than every 15 minutes. 4h ≈ 4 asks/day on that same sample.
 LABEL_COOLDOWN_HOURS = "4"
 
+# Pipeline-health alerting — see worker/src/health.ts. The */15 tick failed
+# 1,637 times in a row between 2026-08-07 and 2026-08-24 (the UW webcam2 image
+# 404'd upstream) and said nothing, because the error path only wrote to
+# history.jsonl. These two govern the alert that now exists.
+#
+# Consecutive failed ticks before the outage is announced. 4 = one hour at the
+# */15 cadence: past every transient in the history file (container cold start,
+# NOAA read timeout, Durable Object reset), well short of a fortnight.
+HEALTH_ALERT_AFTER_FAILURES = "4"
+# Minimum gap between repeat alerts within one outage, so a long outage nags
+# ~4x/day rather than 96x. Recovery is never rate-limited.
+HEALTH_REALERT_HOURS = "6"
+
 # Container binding. Cloudflare Containers can only pull from its own managed
 # registry (not GHCR), so the image is pushed to registry.cloudflare.com:
 #   docker pull ghcr.io/robogeosociety/is-the-mountain-out/inference:latest


### PR DESCRIPTION
**IS THE MOUNTAIN OUT · OUTAGE**

# The site has been down for 17 days and nothing said so

### The advertised URL never existed; chasing it found two live faults and one real bug — a tick that fails silently. The silence is what this PR fixes.

`fix/dead-site-url-and-silent-failures` → `main` · 8 files, +601/−12 · 24 worker tests green · every claim below re-verified against the live services

## Why

`README.md` advertised **https://is-the-mountain-out.pages.dev**. That hostname does not resolve — `NXDOMAIN`, not a 404 — and no Cloudflare Pages deployment was ever recorded against this repo. **GitHub Pages, which the 2026-05-25 migration meant to retire, has been serving all along.**

Chasing the dead URL turned up why the page is blank:

| # | Fault | Evidence |
|---|---|---|
| 1 | **The `*/15` tick has failed every time since 2026-08-07T06:45:32Z** — 17 days | UW retired `webcam2_latest.jpg`; it 404s after redirect, while `webcam1_latest.jpg` returns a live 16,811-byte JPEG. `state.json` is frozen at that morning's reading. |
| 2 | **CORS still names the pre-rename org** | The bucket answers `Origin: https://tommyroar.github.io` with `Access-Control-Allow-Origin: https://tommyroar.github.io`, and answers the **live** origin `https://robogeosociety.github.io` with **no ACAO header at all**. Every `state.json` fetch is blocked; the page renders STATE UNAVAILABLE. |

**Neither is fixable from this repo**, and both are written up in README → *Known outage* with the exact operator action:

- The model was fine-tuned on `webcam2`'s framing, so repointing to a sibling camera is a **retrain**, not a URL edit. That is a product decision.
- The CORS allowlist is a **Cloudflare dashboard edit**.

## What

What *is* fixable here is the reason seventeen days passed unremarked. The tick's error path appended to `history.jsonl`, called `console.error`, and stopped. Nobody reads either.

`worker/src/health.ts` adds a pipeline-health state machine, built on the same shape as the existing `transition.ts`:

- **4-tick threshold**, so transients stay quiet — the history file holds 142 container cold starts and 37 NOAA timeouts that should never have paged anyone.
- **6h cooldown**, so a long outage nags ~4×/day rather than 96×.
- **An all-clear that is deliberately never rate-limited** — recovery is always worth hearing immediately.
- **The down alert carries the last error verbatim.** This outage was diagnosable from one line of it that nobody ever saw.

Docs corrected throughout: the live-site URL, the architecture diagram, the repo layout, "what runs where", and the migration's since-falsified claim that nothing user-facing depends on GitHub.

```mermaid
flowchart LR
  T["*/15 tick"] -->|ok| S[state.json → R2]
  T -->|error| H{4 consecutive?}
  H -->|no| Q[stay quiet — transient]
  H -->|yes| D["🔴 #ops: down + last error"]
  D --> C[6h cooldown]
  S -->|recovered| A["✅ all-clear, never throttled"]
  S -.->|CORS blocks live origin| P[page shows STATE UNAVAILABLE]
```

## Verification

Every diagnostic claim was re-checked against the live services rather than taken on trust:

- `https://robogeosociety.github.io/is-the-mountain-out/` → **200**. `https://tommyroar.github.io/is-the-mountain-out/` → 404 (org renamed). The advertised `pages.dev` host → **does not resolve**.
- `webcam2_latest.jpg` → **404** after its 302; `webcam1_latest.jpg` → **200, image/jpeg, 16,811 bytes**. The siblings really do still serve.
- `state.json` `timestamp_utc` = `2026-08-07T06:45:32Z` → **17 days stale**, matching the tick-failure window exactly.
- CORS probed from both origins; results in the table above.
- **24 worker tests pass**, including the new health-state suite.

One correction worth recording: I first tested the cameras against `atmos.washington.edu/cgi-bin/uwcam/` and got 404s for *both*, which looked like it contradicted the "siblings still serve" finding. That was my wrong host — the code uses `atmos.uw.edu/data/images/`. The original finding was right.

## Risk

- **This PR does not bring the site back.** It makes the next failure loud. The two live faults need a human: a retrain decision and a dashboard edit. Merging this and expecting the mountain to reappear would be a misreading.
- **A new notification lane can itself go wrong** — a misconfigured webhook means the alarm about silence is silent. The all-clear being un-throttled limits the blast radius in the other direction.
- **The 4-tick threshold is a judgement call** tuned against the errors actually in `history.jsonl`. A fault that flaps on a 5-tick period would still slip through; the cooldown, not the threshold, is what bounds the noise.
- **`webcam1` is confirmed serving today**, but nothing here pins it. If UW retires it too, the same silence returns until the health lane fires.
